### PR TITLE
Docs/quickstart init consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ This single package includes the built-in dashboard UI bundle.
 
 ### 2. Configure
 
-Create a `helio.yaml` in your project root:
+`npx @gethelio/proxy init` already created a `helio.yaml` in your project root. Open it and point `upstream.url` at your existing MCP server. A fuller example with policies, audit, and a dashboard secret:
 
 ```yaml
 version: '1'
 
 upstream:
-  url: 'http://localhost:3001/mcp' # Your existing MCP server
+  url: 'http://localhost:8080/mcp' # Your existing MCP server
+  transport: streamable-http # streamable-http (default), sse, or stdio
 
 listen:
   port: 3000 # Helio listens here

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This single package includes the built-in dashboard UI bundle.
 
 ### 2. Configure
 
-`npx @gethelio/proxy init` already created a `helio.yaml` in your project root. Open it and point `upstream.url` at your existing MCP server. A fuller example with policies, audit, and a dashboard secret:
+`npx @gethelio/proxy init` already created a `helio.yaml` in your project root. Open it and point `upstream.url` at your existing MCP server. Helio v0.1 proxies a single upstream MCP server. A fuller example with policies, audit, and a dashboard secret:
 
 ```yaml
 version: '1'

--- a/README.md
+++ b/README.md
@@ -108,11 +108,14 @@ dashboard:
   api_secret: '${HELIO_DASHBOARD_SECRET}'
 ```
 
-If you use the `${HELIO_DASHBOARD_SECRET}` placeholder above, set it before `start`:
+About `dashboard.api_secret`:
 
-```bash
-export HELIO_DASHBOARD_SECRET="$(openssl rand -hex 32)"
-```
+- **If you ran `npx @gethelio/proxy init`**, your `helio.yaml` already contains a generated `api_secret` (a literal 32-byte hex value, also printed when you ran `init`). It's set — skip this step.
+- **If you authored `helio.yaml` by hand** using the `${HELIO_DASHBOARD_SECRET}` placeholder shown above, set the variable before `start`:
+
+  ```bash
+  export HELIO_DASHBOARD_SECRET="$(openssl rand -hex 32)"
+  ```
 
 ### 3. Start Helio
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,6 +96,10 @@ sdk:
 
 Connection to the MCP server that Helio proxies.
 
+> **v0.1 proxies exactly one upstream MCP server.** `upstream` is a single
+> object, not a list — multiple/named upstreams and routing are not yet
+> supported.
+
 | Field             | Type     | Required    | Default           | Description                                                                |
 | ----------------- | -------- | ----------- | ----------------- | -------------------------------------------------------------------------- |
 | `url`             | string   | Yes         | —                 | URL of the upstream MCP server (e.g. `http://localhost:8080/mcp`).         |


### PR DESCRIPTION
## Description

Fixes three onboarding-docs inconsistencies during install from Windows beta testing.

- Quick Start said "Create a `helio.yaml`" though Step 1 (`npx @gethelio/proxy init`) already writes one. Reworded Step 2 to "open and edit," and reconciled the example's `upstream.url` (`3001` → `8080`) and added `transport: streamable-http` so the README matches the generated template.
- Quick Start unconditionally told the reader to `export HELIO_DASHBOARD_SECRET`, but `init` writes a literal `api_secret` into the file. Split the instruction into init-user (skip) vs hand-authored (export) cases.
- Added a note that v0.1 proxies exactly one upstream MCP server, in both the Quick Start and the `### upstream` configuration reference.

Docs-only; no code or schema changes.

Closes #32
Closes #33
Refs #35

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [ ] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `npx @gethelio/proxy init` and observe it writes a complete `helio.yaml` with `upstream.url: http://localhost:8080/mcp`, `transport: streamable-http`, and a literal `dashboard.api_secret`.
2. Open the README Quick Start and confirm Step 2 says to open/edit the generated file (not create one), the example matches the generated `upstream.url`/`transport`, and the secret step branches by init vs hand-authored config.
3. Open `docs/configuration.md` → `### upstream` and confirm the "v0.1 proxies exactly one upstream" note renders above the field table; confirm the same single-upstream line appears in the README Quick Start.

## Additional Context

Findings come from a Windows 11 / WSL2 beta install report. The single-upstream note is the short-term docs mitigation for #35 — the multi-upstream feature itself (named upstreams + routing) remains open there and is tracked by RFCs #49–#51, so this PR uses `Refs #35`, not a closing keyword.
