### PR TITLE
feat(proxy): static upstream request headers (upstream.headers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ dashboard:
   api_secret: '${HELIO_DASHBOARD_SECRET}'
 ```
 
+If your upstream requires a static credential (for example `Authorization: Bearer …` on a hosted MCP server), set [`upstream.headers`](docs/configuration.md#static-request-headers) — values support `${VAR}` interpolation so secrets stay out of the file.
+
 About `dashboard.api_secret`:
 
 - **If you ran `npx @gethelio/proxy init`**, your `helio.yaml` already contains a generated `api_secret` (a literal 32-byte hex value, also printed when you ran `init`). It's set — skip this step.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,15 +100,16 @@ Connection to the MCP server that Helio proxies.
 > object, not a list — multiple/named upstreams and routing are not yet
 > supported.
 
-| Field             | Type     | Required    | Default           | Description                                                                |
-| ----------------- | -------- | ----------- | ----------------- | -------------------------------------------------------------------------- |
-| `url`             | string   | Yes         | —                 | URL of the upstream MCP server (e.g. `http://localhost:8080/mcp`).         |
-| `transport`       | string   | No          | `streamable-http` | Transport protocol: `streamable-http`, `sse`, or `stdio`.                  |
-| `command`         | string   | Conditional | —                 | Command to spawn the MCP server. **Required** when `transport` is `stdio`. |
-| `args`            | string[] | No          | —                 | Arguments passed to the `command` (stdio only).                            |
-| `connect_timeout` | duration | No          | `10s`             | Timeout for establishing SSE upstream connections.                         |
-| `request_timeout` | duration | No          | `30s`             | Timeout for upstream HTTP/SSE POST requests.                               |
-| `forward_headers` | string[] | No          | `[]`              | Explicit allowlist of caller `x-*` headers to forward upstream.            |
+| Field             | Type     | Required    | Default           | Description                                                                                                                                      |
+| ----------------- | -------- | ----------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `url`             | string   | Yes         | —                 | URL of the upstream MCP server (e.g. `http://localhost:8080/mcp`).                                                                               |
+| `transport`       | string   | No          | `streamable-http` | Transport protocol: `streamable-http`, `sse`, or `stdio`.                                                                                        |
+| `command`         | string   | Conditional | —                 | Command to spawn the MCP server. **Required** when `transport` is `stdio`.                                                                       |
+| `args`            | string[] | No          | —                 | Arguments passed to the `command` (stdio only).                                                                                                  |
+| `connect_timeout` | duration | No          | `10s`             | Timeout for establishing SSE upstream connections.                                                                                               |
+| `request_timeout` | duration | No          | `30s`             | Timeout for upstream HTTP/SSE POST requests.                                                                                                     |
+| `forward_headers` | string[] | No          | `[]`              | Explicit allowlist of caller `x-*` headers to forward upstream.                                                                                  |
+| `headers`         | object   | No          | `{}`              | Static headers sent on every upstream request (HTTP transports). Values support `${VAR}` interpolation. Reserved transport headers are rejected. |
 
 **Transport options:**
 
@@ -128,6 +129,20 @@ upstream:
 ```
 
 > **Note:** The `url` field is required by the schema but ignored when `transport` is `stdio`. Any value (e.g. `stdio://`) works as a placeholder.
+
+#### Static request headers
+
+Attach static headers to every upstream request with `upstream.headers` — for example an operator-provided API credential. Values support `${VAR}` interpolation, so secrets stay out of the file:
+
+```yaml
+upstream:
+  url: 'https://api.example.com/mcp'
+  transport: streamable-http
+  headers:
+    Authorization: 'Bearer ${UPSTREAM_TOKEN}'
+```
+
+Applies to the HTTP transports (`streamable-http`, `sse`); `stdio` has no request headers, so the field is ignored there. The reserved transport/protocol headers `mcp-session-id`, `mcp-protocol-version`, `content-type`, `content-length`, and `host` are rejected — Helio owns those.
 
 #### Startup annotation cache priming
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,8 @@ upstream:
   connect_timeout: '10s' # SSE connect timeout
   request_timeout: '30s' # Upstream request timeout
   forward_headers: [] # Caller x-* headers allowed upstream (default: none)
+  # headers:
+  #   Authorization: 'Bearer ${UPSTREAM_TOKEN}' # Static upstream auth (HTTP transports)
 
 listen:
   port: 3000 # Proxy listening port

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,6 +144,8 @@ upstream:
 
 Applies to the HTTP transports (`streamable-http`, `sse`); `stdio` has no request headers, so the field is ignored there. The reserved transport/protocol headers `mcp-session-id`, `mcp-protocol-version`, `content-type`, `content-length`, and `host` are rejected — Helio owns those.
 
+On a name conflict, static `upstream.headers` take precedence over caller-forwarded headers (`forward_headers`), matched case-insensitively. This is deliberate: a downstream caller cannot override an operator-provided credential such as `Authorization`.
+
 #### Startup annotation cache priming
 
 At startup, Helio sends a synthetic upstream `tools/list` request to warm the tool-annotation cache before serving traffic. This avoids first-request false denials in flows that call `tools/call` before any client-issued `tools/list`.

--- a/packages/proxy/src/__tests__/integration-http.test.ts
+++ b/packages/proxy/src/__tests__/integration-http.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest'
 import { Hono } from 'hono'
 import { createApp } from '../server.js'
+import { createForwarderFromConfig } from '../cli-forwarder.js'
 import { UpstreamForwarder } from '../upstream/forwarder.js'
 import { GovernedForwarder } from '../policy/governed-forwarder.js'
 import { compilePolicies } from '../policy/parser.js'
@@ -651,5 +652,45 @@ describe('Audit response capture (Streamable HTTP)', () => {
     } finally {
       await proxy.close()
     }
+  })
+})
+
+describe('Static upstream headers', () => {
+  let upstreamServer: ManagedServer
+  let proxy: ManagedServer
+  let proxyUrl: string
+  let capturedAuth: string | undefined
+
+  beforeAll(async () => {
+    const upstreamApp = new Hono()
+    upstreamApp.post('/mcp', (c) => {
+      capturedAuth = c.req.header('authorization')
+      return c.json({ jsonrpc: '2.0', id: 1, result: { tools: [] } })
+    })
+    upstreamServer = startOnDynamicPort(upstreamApp)
+
+    const config = makeConfig({
+      upstream: {
+        url: `http://127.0.0.1:${String(upstreamServer.port)}/mcp`,
+        transport: 'streamable-http',
+        request_timeout: '30s',
+        headers: { Authorization: 'Bearer integration-token' },
+      },
+    })
+
+    const { forwarder } = await createForwarderFromConfig(config)
+    const app = createApp(config, forwarder)
+    proxy = startOnDynamicPort(app)
+    proxyUrl = `http://127.0.0.1:${String(proxy.port)}/mcp`
+  })
+
+  afterAll(async () => {
+    await proxy.close()
+    await upstreamServer.close()
+  })
+
+  it('forwards the configured static Authorization header to upstream', async () => {
+    await sendMcpRequest(proxyUrl, 'tools/list')
+    expect(capturedAuth).toBe('Bearer integration-token')
   })
 })

--- a/packages/proxy/src/cli-forwarder.test.ts
+++ b/packages/proxy/src/cli-forwarder.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const upstreamCtor = vi.fn()
+const sseCtor = vi.fn()
+
+vi.mock('./upstream/index.js', () => ({
+  UpstreamForwarder: upstreamCtor,
+  SseUpstreamForwarder: class {
+    connect = vi.fn().mockResolvedValue(undefined)
+    close = vi.fn().mockResolvedValue(undefined)
+    constructor(opts: unknown) {
+      sseCtor(opts)
+    }
+  },
+}))
+
+const { createForwarderFromConfig } = await import('./cli-forwarder.js')
+const { makeConfig } = await import('./__tests__/helpers/test-utils.js')
+
+describe('createForwarderFromConfig', () => {
+  beforeEach(() => {
+    upstreamCtor.mockClear()
+    sseCtor.mockClear()
+  })
+
+  it('passes upstream.headers to the streamable-http forwarder', async () => {
+    const config = makeConfig({
+      upstream: {
+        url: 'http://upstream/mcp',
+        transport: 'streamable-http',
+        request_timeout: '30s',
+        headers: { Authorization: 'Bearer t' },
+      },
+    })
+
+    await createForwarderFromConfig(config)
+
+    expect(upstreamCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ headers: { Authorization: 'Bearer t' } }),
+    )
+  })
+
+  it('passes upstream.headers to the sse forwarder', async () => {
+    const config = makeConfig({
+      upstream: {
+        url: 'http://upstream/mcp',
+        transport: 'sse',
+        connect_timeout: '10s',
+        request_timeout: '30s',
+        headers: { Authorization: 'Bearer t' },
+      },
+    })
+
+    await createForwarderFromConfig(config)
+
+    expect(sseCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ headers: { Authorization: 'Bearer t' } }),
+    )
+  })
+})

--- a/packages/proxy/src/cli-forwarder.ts
+++ b/packages/proxy/src/cli-forwarder.ts
@@ -1,0 +1,48 @@
+import { parseDuration } from './config/schema.js'
+import { UpstreamForwarder, SseUpstreamForwarder } from './upstream/index.js'
+import { StdioForwarder } from './transport/stdio-wrapper.js'
+import type { HelioConfig } from './config/index.js'
+import type { McpForwarder } from './mcp/types.js'
+
+export interface BuiltForwarder {
+  readonly forwarder: McpForwarder
+  readonly close?: () => Promise<void>
+}
+
+/**
+ * Construct the upstream forwarder for the configured transport. Static
+ * `upstream.headers` are passed to the HTTP transports (`streamable-http`,
+ * `sse`); `stdio` is a child process with no request headers.
+ */
+export async function createForwarderFromConfig(config: HelioConfig): Promise<BuiltForwarder> {
+  switch (config.upstream.transport) {
+    case 'streamable-http': {
+      return {
+        forwarder: new UpstreamForwarder({
+          url: config.upstream.url,
+          headers: config.upstream.headers,
+          requestTimeoutMs: parseDuration(config.upstream.request_timeout),
+        }),
+      }
+    }
+    case 'sse': {
+      const sse = new SseUpstreamForwarder({
+        url: config.upstream.url,
+        headers: config.upstream.headers,
+        connectTimeoutMs: parseDuration(config.upstream.connect_timeout),
+        requestTimeoutMs: parseDuration(config.upstream.request_timeout),
+      })
+      await sse.connect()
+      return { forwarder: sse, close: () => sse.close() }
+    }
+    case 'stdio': {
+      const stdio = new StdioForwarder({
+        command: config.upstream.command as string,
+        args: config.upstream.args,
+        requestTimeoutMs: parseDuration(config.upstream.request_timeout),
+      })
+      await stdio.start()
+      return { forwarder: stdio, close: () => stdio.close() }
+    }
+  }
+}

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -108,6 +108,8 @@ upstream:
   url: "http://localhost:8080/mcp"
   # Transport: streamable-http (default), sse, or stdio
   transport: streamable-http
+#   headers:
+#     Authorization: "Bearer \${UPSTREAM_TOKEN}"
 
 # Operator dashboard + approval REST API. Bound to 127.0.0.1 by default — do
 # not change to 0.0.0.0 without putting an authenticating reverse proxy in

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -8,8 +8,7 @@ import { fileURLToPath } from 'node:url'
 import { VERSION } from './version.js'
 import { loadConfig, ConfigError, ConfigWatcher } from './config/index.js'
 import { createApp, startServer, startSidebandServer } from './server.js'
-import { UpstreamForwarder, SseUpstreamForwarder } from './upstream/index.js'
-import { StdioForwarder } from './transport/stdio-wrapper.js'
+import { createForwarderFromConfig } from './cli-forwarder.js'
 import { compilePolicies, PolicyParseError } from './policy/index.js'
 import { GovernedForwarder } from './policy/governed-forwarder.js'
 import type { AnnotationCachePrimeResult } from './policy/governed-forwarder.js'
@@ -27,7 +26,6 @@ import { parseDuration } from './config/schema.js'
 import { createDashboardAppWithLifecycle, DashboardEventBus } from './dashboard/index.js'
 import type { AuditRecord } from './audit/index.js'
 import { CSV_HEADERS, csvEscape } from './audit/csv.js'
-import type { McpForwarder } from './mcp/types.js'
 import type { ServerHandle } from './server.js'
 import {
   warnIfWebhookChannelUnreachable,
@@ -302,44 +300,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   }
 
   // Create the right forwarder based on upstream transport
-  let forwarder: McpForwarder
-  let closeForwarder: (() => Promise<void>) | undefined
-
-  switch (config.upstream.transport) {
-    case 'streamable-http': {
-      forwarder = new UpstreamForwarder({
-        url: config.upstream.url,
-        requestTimeoutMs: parseDuration(config.upstream.request_timeout),
-      })
-      break
-    }
-    case 'stdio': {
-      if (!config.upstream.command) {
-        console.error('Error: "command" is required for stdio transport')
-        process.exit(1)
-      }
-      const stdio = new StdioForwarder({
-        command: config.upstream.command,
-        args: config.upstream.args,
-        requestTimeoutMs: parseDuration(config.upstream.request_timeout),
-      })
-      await stdio.start()
-      forwarder = stdio
-      closeForwarder = () => stdio.close()
-      break
-    }
-    case 'sse': {
-      const sse = new SseUpstreamForwarder({
-        url: config.upstream.url,
-        connectTimeoutMs: parseDuration(config.upstream.connect_timeout),
-        requestTimeoutMs: parseDuration(config.upstream.request_timeout),
-      })
-      await sse.connect()
-      forwarder = sse
-      closeForwarder = () => sse.close()
-      break
-    }
-  }
+  const { forwarder, close: closeForwarder } = await createForwarderFromConfig(config)
 
   // Compile policies and wrap the forwarder with governance
   const { policy, warnings } = compilePolicies(config.policies)

--- a/packages/proxy/src/config/loader.test.ts
+++ b/packages/proxy/src/config/loader.test.ts
@@ -115,6 +115,22 @@ approval:
     })
   })
 
+  it('interpolates ${VAR} inside upstream.headers', async () => {
+    const yaml = `
+version: "1"
+upstream:
+  url: "http://localhost:8080"
+  headers:
+    Authorization: "Bearer \${UPSTREAM_TOKEN}"
+dashboard:
+  enabled: false
+`
+    const filePath = await writeTempYaml('helio.yaml', yaml)
+    const config = await loadConfig(filePath, { UPSTREAM_TOKEN: 'tok-123' })
+
+    expect(config.upstream.headers).toEqual({ Authorization: 'Bearer tok-123' })
+  })
+
   it('throws ConfigError for non-existent file', async () => {
     await expect(loadConfig('/tmp/nonexistent-helio.yaml')).rejects.toThrow(ConfigError)
     await expect(loadConfig('/tmp/nonexistent-helio.yaml')).rejects.toThrow(

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -74,6 +74,7 @@ describe('helioConfigSchema', () => {
       expect(result.data.upstream.connect_timeout).toBe('10s')
       expect(result.data.upstream.request_timeout).toBe('30s')
       expect(result.data.upstream.forward_headers).toEqual([])
+      expect(result.data.upstream.headers).toEqual({})
       expect(result.data.listen.port).toBe(3000)
       expect(result.data.listen.host).toBe('127.0.0.1')
       expect(result.data.dashboard.enabled).toBe(false)
@@ -164,6 +165,44 @@ describe('helioConfigSchema', () => {
           upstream: {
             url: 'http://localhost:8080',
             forward_headers: ['authorization'],
+          },
+        }),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts a string-to-string headers map', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          upstream: {
+            url: 'http://localhost:8080',
+            headers: { Authorization: 'Bearer abc' },
+          },
+        }),
+      )
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(result.data.upstream.headers).toEqual({ Authorization: 'Bearer abc' })
+    })
+
+    it('rejects non-string header values', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          upstream: {
+            url: 'http://localhost:8080',
+            headers: { 'X-Count': 3 },
+          },
+        }),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects reserved protocol headers (case-insensitive)', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          upstream: {
+            url: 'http://localhost:8080',
+            headers: { 'Mcp-Session-Id': 'bad', 'content-type': 'text/plain' },
           },
         }),
       )

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -48,6 +48,7 @@ const upstreamSchema = z
     connect_timeout: durationSchema.default('10s'),
     request_timeout: durationSchema.default('30s'),
     forward_headers: z.array(z.string().min(1)).default([]),
+    headers: z.record(z.string(), z.string()).default({}),
   })
   .refine((data) => data.transport !== 'stdio' || data.command !== undefined, {
     message: '"command" is required when transport is "stdio"',
@@ -60,6 +61,25 @@ const upstreamSchema = z
           code: 'custom',
           path: ['forward_headers', index],
           message: 'Forwarded caller headers must start with "x-"',
+        })
+      }
+    }
+
+    // Reserved transport/protocol headers must not be operator-overridden via
+    // upstream.headers — the forwarders own these.
+    const reserved = new Set([
+      'mcp-session-id',
+      'mcp-protocol-version',
+      'content-type',
+      'content-length',
+      'host',
+    ])
+    for (const name of Object.keys(data.headers)) {
+      if (reserved.has(name.toLowerCase())) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['headers', name],
+          message: `upstream.headers must not set reserved header "${name}"`,
         })
       }
     }

--- a/packages/proxy/src/server.test.ts
+++ b/packages/proxy/src/server.test.ts
@@ -27,6 +27,7 @@ const minimalConfig = {
     connect_timeout: '10s',
     request_timeout: '30s',
     forward_headers: [],
+    headers: {},
   },
   listen: { port: 3000, host: '127.0.0.1' },
   dashboard: {

--- a/packages/proxy/src/upstream/e2e.test.ts
+++ b/packages/proxy/src/upstream/e2e.test.ts
@@ -42,6 +42,7 @@ function makeConfig(upstreamUrl: string): HelioConfig {
       connect_timeout: '10s',
       request_timeout: '30s',
       forward_headers: [],
+      headers: {},
     },
     listen: { port: 0, host: '127.0.0.1' },
     dashboard: {

--- a/packages/proxy/src/upstream/forwarder.test.ts
+++ b/packages/proxy/src/upstream/forwarder.test.ts
@@ -136,6 +136,18 @@ describe('UpstreamForwarder', () => {
     expect(calls[0]?.headers['authorization']).toBe('Bearer tok123')
   })
 
+  it('static config headers override caller-forwarded headers', async () => {
+    const forwarder = new UpstreamForwarder({
+      url: 'http://upstream/mcp',
+      headers: { Authorization: 'Bearer static-token' },
+    })
+
+    await forwarder.forward(makeRequest({ headers: { authorization: 'Bearer caller-token' } }))
+
+    expect(calls[0]?.headers['authorization']).toBe('Bearer static-token')
+    expect(calls[0]?.headers).not.toHaveProperty('Authorization')
+  })
+
   it('omits sessionId and headers from the JSON-RPC body', async () => {
     const forwarder = new UpstreamForwarder({ url: 'http://upstream/mcp' })
 

--- a/packages/proxy/src/upstream/forwarder.ts
+++ b/packages/proxy/src/upstream/forwarder.ts
@@ -1,6 +1,7 @@
 import type { McpForwarder, McpRequest, ForwardResult } from '../mcp/types.js'
 import { parseUpstreamResponse } from './response.js'
 import { describeUnreachableUpstream } from './connection-error.js'
+import { mergeUpstreamHeaders } from './merge-headers.js'
 
 /** Options for constructing an UpstreamForwarder. */
 export interface UpstreamForwarderOptions {
@@ -30,13 +31,14 @@ export class UpstreamForwarder implements McpForwarder {
   }
 
   async forward(request: McpRequest): Promise<ForwardResult> {
-    const requestHeaders = request.headers ?? {}
-    const headers: Record<string, string> = {
-      'content-type': 'application/json',
-      accept: 'application/json, text/event-stream',
-      ...this.staticHeaders,
-      ...requestHeaders,
-    }
+    const headers = mergeUpstreamHeaders(
+      {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      request.headers ?? {},
+      this.staticHeaders,
+    )
 
     if (request.sessionId) {
       headers['mcp-session-id'] = request.sessionId

--- a/packages/proxy/src/upstream/merge-headers.test.ts
+++ b/packages/proxy/src/upstream/merge-headers.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { mergeUpstreamHeaders } from './merge-headers.js'
+
+describe('mergeUpstreamHeaders', () => {
+  it('lowercases all header names', () => {
+    const merged = mergeUpstreamHeaders({ 'Content-Type': 'application/json' }, {}, {})
+    expect(merged).toEqual({ 'content-type': 'application/json' })
+  })
+
+  it('forwarded headers override base defaults', () => {
+    const merged = mergeUpstreamHeaders(
+      { accept: 'application/json' },
+      { accept: 'text/plain' },
+      {},
+    )
+    expect(merged['accept']).toBe('text/plain')
+  })
+
+  it('static headers win over caller-forwarded headers (case-insensitive)', () => {
+    const merged = mergeUpstreamHeaders(
+      {},
+      { authorization: 'Bearer caller' },
+      { Authorization: 'Bearer static' },
+    )
+    expect(merged['authorization']).toBe('Bearer static')
+    expect(merged).not.toHaveProperty('Authorization')
+  })
+
+  it('merges disjoint headers from all three sources', () => {
+    const merged = mergeUpstreamHeaders(
+      { 'content-type': 'application/json' },
+      { 'x-trace': 't1' },
+      { authorization: 'Bearer s' },
+    )
+    expect(merged).toEqual({
+      'content-type': 'application/json',
+      'x-trace': 't1',
+      authorization: 'Bearer s',
+    })
+  })
+})

--- a/packages/proxy/src/upstream/merge-headers.ts
+++ b/packages/proxy/src/upstream/merge-headers.ts
@@ -1,0 +1,28 @@
+/**
+ * Merge the three header sources that feed an upstream request, normalising
+ * every name to lower-case so case-only duplicates collapse to one header.
+ *
+ * Precedence (later wins): base defaults → caller-forwarded → static config.
+ * Static `upstream.headers` deliberately override caller-forwarded headers so
+ * a downstream client cannot clobber an operator-provided credential such as
+ * `Authorization`.
+ *
+ * Note: `Mcp-Session-Id` is applied by the forwarder after this merge and is
+ * not passed through here.
+ */
+export function mergeUpstreamHeaders(
+  base: Record<string, string>,
+  forwarded: Record<string, string>,
+  staticHeaders: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  const apply = (headers: Record<string, string>) => {
+    for (const [name, value] of Object.entries(headers)) {
+      out[name.toLowerCase()] = value
+    }
+  }
+  apply(base)
+  apply(forwarded)
+  apply(staticHeaders)
+  return out
+}

--- a/packages/proxy/src/upstream/sse-forwarder.ts
+++ b/packages/proxy/src/upstream/sse-forwarder.ts
@@ -1,5 +1,6 @@
 import { PendingRequests } from '../mcp/pending-requests.js'
 import { describeUnreachableUpstream } from './connection-error.js'
+import { mergeUpstreamHeaders } from './merge-headers.js'
 import type {
   McpForwarder,
   McpRequest,
@@ -168,12 +169,11 @@ export class SseUpstreamForwarder implements McpForwarder {
     if (request.id !== undefined) body['id'] = request.id
     if (request.params !== undefined) body['params'] = request.params
 
-    const requestHeaders = request.headers ?? {}
-    const headers: Record<string, string> = {
-      'content-type': 'application/json',
-      ...this.staticHeaders,
-      ...requestHeaders,
-    }
+    const headers = mergeUpstreamHeaders(
+      { 'content-type': 'application/json' },
+      request.headers ?? {},
+      this.staticHeaders,
+    )
 
     if (request.sessionId) {
       headers['mcp-session-id'] = request.sessionId


### PR DESCRIPTION
## Description

Implements Finding 5 from the Windows beta-tester report: operators can now attach static request headers (e.g. `Authorization: Bearer …`) to every upstream MCP request via `upstream.headers` in `helio.yaml`.
  
- Add an `upstream.headers` map to the config schema, with `${VAR}` interpolation (secrets stay out of the file) and schema-level rejection of reserved transport headers (`mcp-session-id`, `mcp-protocol-version`, `content-type`, `content-length`, `host`). 
- Add a shared, case-insensitive header-merge helper and route both HTTP forwarders (`streamable-http`, `sse`) through it, so static config headers deterministically win over caller-forwarded headers — a downstream caller cannot override an operator-provided credential. `stdio` takes no headers.
- Extract forwarder construction into `createForwarderFromConfig` so the configured headers actually reach the forwarders, covered by a unit test and an end-to-end integration test that observes the header arriving at a real upstream.
- Document the feature: `configuration.md` reference + annotated example, a README Quick Start note, and a commented hint in the `helio init` template.

Closes #36
Closes #44
Closes #45
Closes #46
Closes #47
Closes #48

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

<!-- Steps a reviewer can follow to verify the change. -->

1. Point `upstream.url` at any HTTP MCP server, add `headers: { Authorization: 'Bearer ${UPSTREAM_TOKEN}' }`, export `UPSTREAM_TOKEN`, run `npx @gethelio/proxy  start`, and confirm the upstream receives the `Authorization` header.
2. Put a reserved header (e.g. `content-type`) under `upstream.headers` and confirm `helio validate` rejects it with a clear schema error.
3. Send a request carrying its own `Authorization` while `upstream.headers.Authorization` is set, and confirm the static value reaches upstream (caller cannot override).
4. `pnpm --filter @gethelio/proxy test` — full suite (1339 tests) passes, including `merge-headers`, `cli-forwarder`, and the static-header integration test.

## Additional Context

<!-- Screenshots, config snippets, performance benchmarks, or anything else that helps reviewers. -->
