### PR TITLE
docs: add changelog entries for v0.1.1 and v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,34 @@ Maintainer notes:
 
 _Nothing yet._
 
+## [0.2.0] - 2026-06-09
+
+### Added
+
+- **Static upstream headers.** A new `upstream.headers` map attaches
+  operator-defined static headers (e.g.
+  `Authorization: Bearer ${UPSTREAM_TOKEN}`) to every upstream request, so Helio
+  can front an authenticated MCP server without the caller supplying
+  credentials. Values support `${VAR}` interpolation, keeping secrets out of
+  `helio.yaml`. Applies to the HTTP transports (`streamable-http`, `sse`);
+  `stdio` has no request headers. Header names are matched case-insensitively.
+
+### Security
+
+- Configured `upstream.headers` take precedence over any caller-supplied header
+  on a name conflict, so a downstream caller cannot override an operator-provided
+  credential such as `Authorization`. Reserved transport/protocol headers (`mcp-session-id`, `mcp-protocol-version`,
+  `content-type`, `content-length`, `host`) are rejected by config validation.
+
+## [0.1.1] - 2026-06-04
+
+### Changed
+
+- **Clearer upstream-unreachable errors.** When the upstream MCP server cannot
+  be reached (connection refused, DNS failure, or timeout), Helio now returns a
+  diagnostic message naming the likely cause and remediation instead of an
+  opaque fetch error.
+
 ## [0.1.0] - 2026-05-19
 
 Helio's first public release.
@@ -109,5 +137,7 @@ Helio's first public release.
 - Secret scanning is now part of the default quality gate (pre-commit + CI),
   designed to prevent accidental credential commits before merge.
 
-[Unreleased]: https://github.com/gethelio/helio/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/gethelio/helio/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/gethelio/helio/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/gethelio/helio/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/gethelio/helio/releases/tag/v0.1.0


### PR DESCRIPTION
## Description

 Release prep for v0.2.0. Adds the `[0.2.0]` changelog section for the static upstream headers feature (`upstream.headers`, shipped in #54) and backfills the `[0.1.1]` section, which was tagged without a changelog entry. Updates the compare links. No code changes.

Closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [ ] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

<!-- Steps a reviewer can follow to verify the change. -->

1. Render `CHANGELOG.md` and confirm the `[0.2.0]` and `[0.1.1]` sections read correctly.
2. Confirm the compare links resolve (`[0.2.0]` will work once the `v0.2.0` tag is pushed).

## Additional Context

This PR precedes the `v0.2.0` tag — once merged, the tag is pushed against `main` to trigger the publish workflow. No `Closes` lines: the feature itself already merged in #54.

The one judgment call is Packages Affected — CHANGELOG.md is repo-root, so none of the options fit perfectly; I marked "Root config / monorepo tooling" as least-wrong with a clarifying comment. If you'd rather, leave all unchecked and note "repo-root CHANGELOG.md" in the description. Either reads fine.
