### PR TITLE
docs: add changelog entry for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Maintainer notes:
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.3.0] - 2026-06-10
+
 ### Deprecated
 
 - **`UpstreamForwarder` is deprecated.** It is now a compatibility alias of


### PR DESCRIPTION
## Description

Roll the `Unreleased` changelog entries into a new `[0.3.0] - 2026-06-10` section ahead of tagging the v0.3.0 release, and reset `Unreleased` to `_Nothing yet._`.

The entries cover what shipped in #56: the session-aware `streamable-http` upstream client (handshake validation, negotiated protocol version, SSE response parsing with guardrails, classified annotation-prime diagnostics) under **Fixed**, and the `UpstreamForwarder` → `StreamableHttpForwarder` compatibility alias under **Deprecated**.

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/` (root `CHANGELOG.md`)
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [ ] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

<!-- Steps a reviewer can follow to verify the change. -->

1. Confirm the diff touches only `CHANGELOG.md`.
2. Check the `[0.3.0] - 2026-06-10` section matches the scope of #56 (one `### Deprecated` entry, four `### Fixed` entries) — content is moved verbatim from `Unreleased`, with no edits.
3. Confirm `## [Unreleased]` is reset to `_Nothing yet._` and the section order follows Keep a Changelog (Deprecated before Fixed).
4. CI green (the docs/lint/format gates are the meaningful ones here).

## Additional Context

Release-prep for tagging `v0.3.0`, following the v0.2.0 flow: this PR merges to `main` first, then the merged commit is tagged (`git tag -s v0.3.0 -m "Helio v0.3.0"`) and the tag push triggers the release workflow that publishes `@gethelio/proxy` (npm), `helio` (PyPI), and the GHCR Docker image together. Minor bump per SemVer: #56 added new public API (`StreamableHttpForwarder`) and introduced a deprecation, both of which require at least a minor release.
