### PR TITLE
docs: add changelog entry for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Maintainer notes:
 - Keep entries user-visible and operator-relevant (new behavior, defaults,
   security posture, and breaking changes).
 
-## [Unreleased]
+## [0.4.0] - 2026-06-11
 
 ### Added
 


### PR DESCRIPTION
## Description

Cuts the changelog for the **v0.4.0** release: moves the `Unreleased` entries (tool definition drift detection, shipped in #59 for #25) into a `## [0.4.0] - 2026-06-11` section, per the maintainer notes at the top of CHANGELOG.md. Same pattern as the v0.3.0 cut (#57).

This PR is docs-only and closes no issues. Once it merges, the `v0.4.0` tag will be pushed on the merge commit, which triggers the release workflow (npm, PyPI, Docker/GHCR + cosign, SBOM, GitHub Release).

References: #25, #59, #60 (deferred follow-up shipping with this release's known-limitation note).


## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

<!-- Steps a reviewer can follow to verify the change. -->

1. Review the CHANGELOG diff: the only change is the `## [Unreleased]` heading becoming `## [0.4.0] - 2026-06-11` — no entries added, removed, or reworded.
2. Cross-check the section's claims against what actually shipped in #59 (`policies.on_tool_drift`, `block` default, baseline-annotation evaluation, aggregate exclusions).
3. Confirm no `Unreleased` content remains above the new section, matching the post-cut state of previous releases (v0.3.0 and earlier).

## Additional Context

This is the release-cut PR for v0.4.0 — a minor bump because the release adds a new config surface and a **conservative behavior change** (`on_tool_drift` defaults to `block`; drifted tools are denied until restart or upstream revert).
The version number itself lives nowhere in the repo; it is injected from the git tag by `scripts/set-release-version.sh` during the release workflow.
