### PR TITLE
feat(proxy): context-aware policy primitives (#13)

### DIFF
--- a/docs/adapter-api.md
+++ b/docs/adapter-api.md
@@ -76,7 +76,9 @@ If you embed `GovernanceService` directly (instead of running `helio start`), wi
 
 The `decision` is an **outcome**, not Helio's internal rule action: a `rate_limit` rule that still has headroom returns `"allow"` with a `limits.rate` block; only when the bucket is exhausted does it return `"rate_limited"`. There is no `modify` decision — argument rewriting has no engine support today.
 
-**Errors:** `400` validation / invalid JSON, `401` wrong-or-missing adapter token, `403` Origin header, `413` oversized `metadata`/`tool_input`/body, `400 origin_limit_exceeded` / `400 tool_baseline_limit` / `503 evaluation_backlog_full` (memory budgets), `503 governance_unavailable` (sideband running without the service).
+**Errors:** `400` validation / invalid JSON, `401` wrong-or-missing adapter token, `403` Origin header, `413` oversized `metadata`/`tool_input`/body, `400 reserved_metadata_key` (a reserved column key — currently `agent_id` — was passed inside `metadata`; use the top-level field), `400 origin_limit_exceeded` / `400 tool_baseline_limit` / `503 evaluation_backlog_full` / `503 limit_capacity_exhausted` (memory/cardinality budgets — see below), `503 governance_unavailable` (sideband running without the service).
+
+`match.metadata.*` rules and `sender_id`-scoped limits read the `metadata` object you supply here (well-known keys `channel_id`, `sender_id`, `sender_name`, `conversation_id`; the virtual `agent_id` comes from the top-level field). See the [Policy Guide](./policies.md#metadata).
 
 ## `POST /audit`
 
@@ -108,16 +110,35 @@ Counters are consumed here (not at `/evaluate`), and only when the call actually
 - An evaluation that is never audited expires after `sdk.evaluation_ttl` (default `10m`) into an audit record with `record_kind: "evaluation_expired"`. This is a **bypass/tamper signal**, not a normal block — surface it in monitoring.
 - Because decision and execution are separate calls, two concurrent `/evaluate`s can both peek the last limit slot and both execute. Counters stay truthful after the fact (both `/audit`s record), but the host-enforced tier cannot close this window from the proxy side.
 
+### Memory and cardinality budgets
+
+A token-bearing adapter is in the threat model, so several caller-controlled growth vectors are bounded. Breaches fail closed (the call is refused, never silently dropped):
+
+| Budget                          | Limit           | On breach                                                                 |
+| ------------------------------- | --------------- | ------------------------------------------------------------------------- |
+| Distinct origins                | 32              | `400 origin_limit_exceeded`                                               |
+| Baselined tools per origin      | 1,024           | `400 tool_baseline_limit` (first-seen only; existing tools keep updating) |
+| `tool_input` (serialized)       | 64 KiB          | `413`                                                                     |
+| `metadata` (serialized)         | 4 KiB           | `413`                                                                     |
+| Pending evaluations             | 10,000 / 64 MiB | `503 evaluation_backlog_full`                                             |
+| Distinct `sender_id` limit keys | 50,000          | `503 limit_capacity_exhausted`                                            |
+
+The `sender_id` budget is a **reservation registry**: because `sender_id` is caller-minted, a new sender key is reserved at `/evaluate` (pre-execution, so it can fail closed) and released once its limiter bucket empties. It is scoped to `sender:*` keys only, so a flood of sender ids can never starve the structural MCP path's `tool`/`session` limits — the two doors share one limiter, but only the untrusted key family is capped.
+
 ## `POST /install-scan`
 
-Observational until install-time policy ships: always returns `decision: "allow"` with `reason: "no install-time rules defined"`, and writes an audit record with `record_kind: "install_scan"`. The request/response shape is final now so adapters and the dashboard build against a stable contract.
+Evaluates a package/skill install against the operator's `policies.install` rules (see the [Policy Guide](./policies.md#install-time-policy-deny_install)). When **no** `policies.install` block is configured it stays observational — always `decision: "allow"` with `reason: "no install-time rules defined"`. With rules, a matching `deny_install` returns `decision: "deny"` and writes an audit record with `record_kind: "install_scan"` and `block_reason: "install_denied"`. Either way the call is terminal — no `/audit` follow-up is expected.
 
 ```jsonc
 // Request
-{ "origin": "openclaw", "package": { "name": "left-pad", "version": "1.3.0", "source": "npm" } }
-// Response 200
+{ "origin": "openclaw", "package": { "name": "left-pad", "version": "1.3.0", "source": "npm" }, "metadata": { "sender_id": "U7" } }
+// Response 200 (allowed)
 { "evaluation_id": "…", "decision": "allow", "reason": "no install-time rules defined", "matched_rule": null }
+// Response 200 (denied by a deny_install rule)
+{ "evaluation_id": "…", "decision": "deny", "reason": "Matched \"block-evil\" → deny_install", "matched_rule": "block-evil", "feedback": { "message": "…" } }
 ```
+
+Install rules can match on the package `name` (glob), `source`, and `metadata.*` context (the same reserved keys). `metadata.agent_id` is rejected here too (see `/evaluate`).
 
 ## Approvals
 
@@ -140,7 +161,9 @@ Sideband activity shares the audit schema with the MCP path, plus three columns 
 
 - `record_kind` — `tool_call` | `drift_event` | `install_scan` | `evaluation_expired`.
 - `origin` — `mcp` for the proxy path, or the adapter origin string.
-- `metadata` — the adapter-supplied context object (reserved keys `channel_id`, `sender_id`, `sender_name`, `conversation_id`).
+- `metadata` — the adapter-supplied context object (reserved keys `channel_id`, `sender_id`, `sender_name`, `conversation_id`). `agent_id` is **not** carried here — it has its own column and is rejected if placed in `metadata`.
+
+An install denied by a `deny_install` rule is recorded with `record_kind: install_scan`, `policy_decision: deny`, and `block_reason: install_denied`.
 
 See [Audit Trail](./audit.md) for the full record reference.
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -6,35 +6,35 @@ Every `tools/call` request that passes through Helio is recorded in an audit tra
 
 Each audit record contains the following fields:
 
-| Field                  | Type           | Description                                                                                                                                         |
-| ---------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                   | string         | Unique record identifier (UUID v4).                                                                                                                 |
-| `timestamp`            | string         | ISO 8601 timestamp of when the proxy received the tool call.                                                                                        |
-| `session_id`           | string \| null | MCP session ID from the `Mcp-Session-Id` header.                                                                                                    |
-| `agent_id`             | string \| null | Agent identifier, if available.                                                                                                                     |
-| `environment`          | string \| null | Runtime environment label configured at proxy startup.                                                                                              |
-| `tool_name`            | string         | The name of the tool that was called.                                                                                                               |
-| `tool_input`           | object         | The full arguments passed to the tool call.                                                                                                         |
-| `policy_decision`      | string         | The policy engine's decision: `allow`, `deny`, `require_approval`, `rate_limit`, `spend_limit`, or `dry_run`.                                       |
-| `block_reason`         | string \| null | Structured deny/block reason (`evidence_missing`, `approval_timeout`, `client_disconnected`, `shutdown_cancelled`, etc.). Null when not blocked.    |
-| `matched_rule`         | string \| null | Name of the policy rule that matched, or null if the default action applied.                                                                        |
-| `matched_rule_index`   | number \| null | Rule index in config order that matched, or null when no rule matched.                                                                              |
-| `evidence_chain`       | object \| null | Evidence and dependency state from the evidence grounding system.                                                                                   |
-| `approval_status`      | string \| null | Approval outcome: `approved`, `denied`, `timeout`, `break_glass`, `client_disconnected`, or `shutdown_cancelled`. Null if no approval was required. |
-| `approved_by`          | string \| null | Identity of the human who resolved approval (`approved`, `denied`, or `break_glass`), when applicable.                                              |
-| `upstream_response`    | any \| null    | The upstream MCP server's response. Null for denied calls (no upstream request was made).                                                           |
-| `upstream_error`       | string \| null | Error message from the upstream server, if the call failed.                                                                                         |
-| `upstream_http_status` | number \| null | Upstream HTTP status code when an upstream response was received. Null on denied or connection-level forwarding failures.                           |
-| `upstream_latency_ms`  | number \| null | Time in milliseconds the upstream request took. Null for denied calls.                                                                              |
-| `total_duration_ms`    | number         | End-to-end duration from request receipt to final response.                                                                                         |
-| `approval_wait_ms`     | number         | Time spent waiting in the approval queue/timer. Zero when no approval hold occurred.                                                                |
-| `proxy_compute_ms`     | number         | Proxy compute time excluding approval wait and upstream processing.                                                                                 |
-| `flagged_destructive`  | boolean        | Whether the tool was flagged as potentially destructive (`destructiveHint: true`).                                                                  |
-| `dry_run`              | boolean        | Whether this record was produced in dry-run mode.                                                                                                   |
-| `record_kind`          | string         | Record category: `tool_call` (default), `drift_event`, `install_scan`, or `evaluation_expired` (a sideband decision that was never audited).        |
-| `origin`               | string         | Enforcement origin: `mcp` for the proxy path, or an adapter origin string (e.g. `openclaw`) for [sideband-governed](./adapter-api.md) calls.        |
-| `metadata`             | object \| null | Adapter-supplied context (reserved keys `channel_id`, `sender_id`, `sender_name`, `conversation_id`). Null for MCP-origin records.                  |
-| `created_at`           | string         | ISO 8601 timestamp of when the record was persisted to the database.                                                                                |
+| Field                  | Type           | Description                                                                                                                                                                                          |
+| ---------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | string         | Unique record identifier (UUID v4).                                                                                                                                                                  |
+| `timestamp`            | string         | ISO 8601 timestamp of when the proxy received the tool call.                                                                                                                                         |
+| `session_id`           | string \| null | MCP session ID from the `Mcp-Session-Id` header.                                                                                                                                                     |
+| `agent_id`             | string \| null | Agent identifier, if available.                                                                                                                                                                      |
+| `environment`          | string \| null | Runtime environment label configured at proxy startup.                                                                                                                                               |
+| `tool_name`            | string         | The name of the tool that was called.                                                                                                                                                                |
+| `tool_input`           | object         | The full arguments passed to the tool call.                                                                                                                                                          |
+| `policy_decision`      | string         | The policy engine's decision: `allow`, `deny`, `require_approval`, `rate_limit`, `spend_limit`, or `dry_run`.                                                                                        |
+| `block_reason`         | string \| null | Structured deny/block reason (`evidence_missing`, `approval_timeout`, `client_disconnected`, `shutdown_cancelled`, `install_denied` for a `deny_install` install scan, etc.). Null when not blocked. |
+| `matched_rule`         | string \| null | Name of the policy rule that matched, or null if the default action applied.                                                                                                                         |
+| `matched_rule_index`   | number \| null | Rule index in config order that matched, or null when no rule matched.                                                                                                                               |
+| `evidence_chain`       | object \| null | Evidence and dependency state from the evidence grounding system.                                                                                                                                    |
+| `approval_status`      | string \| null | Approval outcome: `approved`, `denied`, `timeout`, `break_glass`, `client_disconnected`, or `shutdown_cancelled`. Null if no approval was required.                                                  |
+| `approved_by`          | string \| null | Identity of the human who resolved approval (`approved`, `denied`, or `break_glass`), when applicable.                                                                                               |
+| `upstream_response`    | any \| null    | The upstream MCP server's response. Null for denied calls (no upstream request was made).                                                                                                            |
+| `upstream_error`       | string \| null | Error message from the upstream server, if the call failed.                                                                                                                                          |
+| `upstream_http_status` | number \| null | Upstream HTTP status code when an upstream response was received. Null on denied or connection-level forwarding failures.                                                                            |
+| `upstream_latency_ms`  | number \| null | Time in milliseconds the upstream request took. Null for denied calls.                                                                                                                               |
+| `total_duration_ms`    | number         | End-to-end duration from request receipt to final response.                                                                                                                                          |
+| `approval_wait_ms`     | number         | Time spent waiting in the approval queue/timer. Zero when no approval hold occurred.                                                                                                                 |
+| `proxy_compute_ms`     | number         | Proxy compute time excluding approval wait and upstream processing.                                                                                                                                  |
+| `flagged_destructive`  | boolean        | Whether the tool was flagged as potentially destructive (`destructiveHint: true`).                                                                                                                   |
+| `dry_run`              | boolean        | Whether this record was produced in dry-run mode.                                                                                                                                                    |
+| `record_kind`          | string         | Record category: `tool_call` (default), `drift_event`, `install_scan`, or `evaluation_expired` (a sideband decision that was never audited).                                                         |
+| `origin`               | string         | Enforcement origin: `mcp` for the proxy path, or an adapter origin string (e.g. `openclaw`) for [sideband-governed](./adapter-api.md) calls.                                                         |
+| `metadata`             | object \| null | Adapter-supplied context (reserved keys `channel_id`, `sender_id`, `sender_name`, `conversation_id`). Null for MCP-origin records.                                                                   |
+| `created_at`           | string         | ISO 8601 timestamp of when the record was persisted to the database.                                                                                                                                 |
 
 ## Tool Definition Drift Records
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -163,6 +163,37 @@ policies:
 
 Changing top-level `environment` on a running process is restart-required. Hot-reload keeps the startup environment label and logs a restart warning.
 
+### metadata
+
+Match against the adapter-supplied **context** of a call — who sent it, in which channel, and so on. This is populated only on the **host-enforced (sideband) path** (see the [Adapter Governance API](./adapter-api.md)); MCP requests carry no metadata, so a rule with `match.metadata` is **inert on the MCP path** (it never matches there, and is skipped — not denied).
+
+Well-known keys: `channel_id`, `sender_id`, `sender_name`, `conversation_id`, and the virtual `agent_id` (read from the request's `agent_id` field, not the metadata object). Any other adapter-supplied key can be matched too.
+
+Each key takes either a bare string (exact match) or an operator object using the string operators `eq`, `neq`, `contains`, `regex`:
+
+```yaml
+policies:
+  rules:
+    # Block one Slack channel outright
+    - name: no-prod-channel
+      match:
+        metadata:
+          channel_id: 'C_PROD'
+      action: deny
+
+    # Require approval for a specific sender pattern, agent-scoped
+    - name: external-senders
+      match:
+        metadata:
+          sender_id: { regex: '^EXT-' }
+          agent_id: 'support-bot'
+      action: require_approval
+      approval:
+        channel: slack
+```
+
+All metadata conditions are AND-combined with each other and with the rest of the `match` block. A `regex` is validated for catastrophic backtracking at load time, exactly like `match.input` regexes. Because metadata is absent on the MCP path, prefer pairing a metadata `deny` rule with a separate MCP-path control if you need both doors covered.
+
 ## Actions
 
 | Action             | Description                                                                                          |
@@ -282,20 +313,49 @@ Returns a synthetic response showing what would have happened:
 }
 ```
 
+## Install-Time Policy (`deny_install`)
+
+Hook-based adapters can scan a package/skill **before it is installed** via the sideband [`POST /install-scan`](./adapter-api.md) endpoint. Install-time rules live in their own `policies.install` block — separate from `policies.rules`, because a package has no tool name, annotations, or arguments to match on:
+
+```yaml
+policies:
+  install:
+    default: allow # or deny — applied when no rule matches
+    rules:
+      - name: block-unverified-npm
+        match:
+          name: 'evil-*' # glob on the package name (same engine as match.tool)
+          source: npm # exact ecosystem match (npm | pip | …)
+        action: deny_install
+        feedback:
+          message: 'This package is blocked by policy.'
+      - name: gate-by-sender
+        match:
+          metadata: # install rules support match.metadata too
+            sender_id: { regex: '^EXT-' }
+        action: deny_install
+```
+
+- Rules are first-match-wins; if none match, `install.default` applies (defaults to `allow`).
+- `action` is `deny_install` or `allow`. A `deny_install` outcome returns `decision: "deny"` to the adapter and records an audit row with `record_kind: install_scan` and `block_reason: install_denied`.
+- When no `policies.install` block is configured, `/install-scan` stays **observational** (always allows) so adapters can call it safely before any rules exist.
+- Install-time policy is only reachable through the sideband; it has no effect on the MCP path.
+
 ## Rate Limits
 
 Rate limits use a **sliding window** algorithm to track calls per key. Configure them with the `limits` block on a `rate_limit` rule:
 
-| Field       | Type     | Required | Description                                                                                               |
-| ----------- | -------- | -------- | --------------------------------------------------------------------------------------------------------- |
-| `max_calls` | integer  | Yes      | Maximum number of calls allowed in the window.                                                            |
-| `window`    | duration | Yes      | Sliding window size (e.g. `1h`, `5m`, `30s`).                                                             |
-| `key`       | string   | No       | Aggregation scope: `tool` (default), `session`, or `agent` (currently unsupported; falls back to `tool`). |
+| Field       | Type     | Required | Description                                                                                                         |
+| ----------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `max_calls` | integer  | Yes      | Maximum number of calls allowed in the window.                                                                      |
+| `window`    | duration | Yes      | Sliding window size (e.g. `1h`, `5m`, `30s`).                                                                       |
+| `key`       | string   | No       | Aggregation scope: `tool` (default), `session`, `sender_id`, or `agent` (unsupported on MCP; falls back to `tool`). |
 
 **Key scoping:**
 
 - `tool` (default) — One shared limit per tool name, across all sessions.
 - `session` — Each MCP session has its own independent limit.
+- `sender_id` — One limit per adapter-supplied `sender_id` (host-enforced path). Requires the SDK sideband (`sdk.enabled: true`) — Helio **rejects** the config otherwise, since a sender-keyed limit is meaningless without a sender. On the MCP path (which has no sender) it falls back to `tool` with a one-time warning.
 - `agent` — Currently unsupported on MCP requests; Helio logs a warning and falls back to `tool`.
 
 **Important behaviors:**
@@ -322,13 +382,15 @@ Rate limits use a **sliding window** algorithm to track calls per key. Configure
 
 Spend limits track cumulative monetary amounts extracted from tool call arguments. Configure them with `limits.max_spend`:
 
-| Field      | Type     | Required | Description                                                                                               |
-| ---------- | -------- | -------- | --------------------------------------------------------------------------------------------------------- |
-| `field`    | string   | Yes      | JSONPath-style dot path to the amount field in tool arguments (e.g. `$.amount`).                          |
-| `limit`    | number   | Yes      | Maximum cumulative spend in the window.                                                                   |
-| `currency` | string   | Yes      | Currency label for display (e.g. `USD`, `EUR`).                                                           |
-| `window`   | duration | Yes      | Sliding window size.                                                                                      |
-| `key`      | string   | No       | Aggregation scope: `tool` (default), `session`, or `agent` (currently unsupported; falls back to `tool`). |
+| Field      | Type     | Required | Description                                                                                                         |
+| ---------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `field`    | string   | Yes      | JSONPath-style dot path to the amount field in tool arguments (e.g. `$.amount`).                                    |
+| `limit`    | number   | Yes      | Maximum cumulative spend in the window.                                                                             |
+| `currency` | string   | Yes      | Currency label for display (e.g. `USD`, `EUR`).                                                                     |
+| `window`   | duration | Yes      | Sliding window size.                                                                                                |
+| `key`      | string   | No       | Aggregation scope: `tool` (default), `session`, `sender_id`, or `agent` (unsupported on MCP; falls back to `tool`). |
+
+`key: sender_id` keys the budget per adapter-supplied sender (host-enforced path) and, like rate limits, requires `sdk.enabled: true` or the config is rejected.
 
 **Important behaviors:**
 

--- a/packages/dashboard/src/outcome.test.ts
+++ b/packages/dashboard/src/outcome.test.ts
@@ -35,6 +35,12 @@ describe('outcome helpers', () => {
     expect(deriveDisplayOutcome({ block_reason: 'shutdown_cancelled' })).toBe('shutdown_cancelled')
   })
 
+  it('renders an install_denied block_reason as deny independent of policy_decision', () => {
+    // Belt-and-braces: even if policy_decision is not 'deny', a blocked install
+    // must never render as "allow".
+    expect(deriveDisplayOutcome({ block_reason: 'install_denied' })).toBe('deny')
+  })
+
   it('derives dry_run with highest priority', () => {
     expect(
       deriveDisplayOutcome({

--- a/packages/dashboard/src/outcome.ts
+++ b/packages/dashboard/src/outcome.ts
@@ -46,6 +46,11 @@ export function deriveDisplayOutcome(record: DecisionLike): DisplayOutcome {
       return 'client_disconnected'
     case 'shutdown_cancelled':
       return 'shutdown_cancelled'
+    case 'install_denied':
+      // Install-time denial (issue #13). Rendered as a deny; #16 may add a
+      // dedicated chip. Pinned here so a blocked install never falls through to
+      // "allow" regardless of policy_decision.
+      return 'deny'
     default:
       break
   }

--- a/packages/proxy/src/__tests__/sideband-shared-limiter.test.ts
+++ b/packages/proxy/src/__tests__/sideband-shared-limiter.test.ts
@@ -72,4 +72,50 @@ describe('sideband ↔ MCP shared rate limiter', () => {
     rateLimiter.close()
     service.close()
   })
+
+  it('keys rate limits by sender_id across evaluate→audit loops, independently per sender', () => {
+    const policy = compilePolicies({
+      default: 'allow',
+      dry_run: false,
+      rules: [
+        {
+          name: 'rl',
+          match: { tool: 'send' },
+          action: 'rate_limit',
+          limits: { max_calls: 2, window: '60s', key: 'sender_id' },
+        },
+      ],
+    }).policy
+
+    const rateLimiter = new RateLimiter({ cleanupIntervalMs: 0 })
+    const service = new GovernanceService({ policy, rateLimiter, sweepIntervalMs: 0 })
+
+    const runFor = (sender: string) => {
+      const ev = service.evaluate({
+        origin: 'openclaw',
+        agent_id: null,
+        session_id: null,
+        tool: { name: 'send' },
+        arguments: {},
+        metadata: { sender_id: sender },
+      })
+      const decision = ev.body['decision'] as string
+      if (decision === 'allow') {
+        service.audit({ evaluation_id: ev.body['evaluation_id'] as string, status: 'success' }, 'h')
+      }
+      return decision
+    }
+
+    // U1 consumes both of its slots, then is limited; U2 is on its own budget.
+    expect(runFor('U1')).toBe('allow')
+    expect(runFor('U1')).toBe('allow')
+    expect(runFor('U1')).toBe('rate_limited')
+    expect(rateLimiter.getKeyState('sender:U1')?.current).toBe(2)
+
+    expect(runFor('U2')).toBe('allow')
+    expect(rateLimiter.getKeyState('sender:U2')?.current).toBe(1)
+
+    rateLimiter.close()
+    service.close()
+  })
 })

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -59,6 +59,62 @@ describe('parseDuration', () => {
 // ---------------------------------------------------------------------------
 
 describe('helioConfigSchema', () => {
+  describe('sender_id limit key requires the sideband (issue #13)', () => {
+    const senderRateRule = {
+      match: { tool: 'send' },
+      action: 'rate_limit',
+      limits: { max_calls: 1, window: '1m', key: 'sender_id' },
+    }
+    const senderSpendRule = {
+      match: { tool: 'pay' },
+      action: 'spend_limit',
+      limits: {
+        max_spend: { field: '$.amt', limit: 5, currency: 'USD', window: '1h', key: 'sender_id' },
+      },
+    }
+
+    it('rejects limits.key: sender_id when sdk.enabled is false (default)', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ policies: { rules: [senderRateRule] } }),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects max_spend.key: sender_id when sdk.enabled is false', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ policies: { rules: [senderSpendRule] } }),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts sender_id keys when sdk.enabled is true', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          sdk: { enabled: true },
+          policies: { rules: [senderRateRule, senderSpendRule] },
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('still accepts session/tool keys with sdk disabled', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          policies: {
+            rules: [
+              {
+                match: { tool: 'send' },
+                action: 'rate_limit',
+                limits: { max_calls: 1, window: '1m', key: 'session' },
+              },
+            ],
+          },
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+  })
+
   describe('minimal config', () => {
     it('parses with dashboard explicitly disabled', () => {
       const result = helioConfigSchema.safeParse(minimalConfig())

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -144,12 +144,32 @@ const annotationsMatchSchema = z
   })
   .strict()
 
+// A metadata condition is either a bare string (eq shorthand) or an operator
+// object restricted to the string-friendly subset (issue #13). Numeric
+// comparators are deliberately excluded — metadata values (channel_id, …) are
+// strings.
+const metadataConditionSchema = z.union([
+  z.string(),
+  z
+    .object({
+      eq: z.string().optional(),
+      neq: z.string().optional(),
+      contains: z.string().optional(),
+      regex: z.string().optional(),
+    })
+    .strict()
+    .refine((obj) => Object.keys(obj).length > 0, {
+      message: 'At least one metadata condition operator is required',
+    }),
+])
+
 const matchSchema = z
   .object({
     tool: z.string().optional(),
     annotations: annotationsMatchSchema.optional(),
     input: z.record(z.string(), inputConditionSchema).optional(),
     environment: z.string().optional(),
+    metadata: z.record(z.string(), metadataConditionSchema).optional(),
   })
   .strict()
 
@@ -187,7 +207,7 @@ const spendLimitSchema = z
     limit: z.number(),
     currency: z.string(),
     window: durationSchema,
-    key: z.enum(['tool', 'agent', 'session']).optional(),
+    key: z.enum(['tool', 'agent', 'session', 'sender_id']).optional(),
   })
   .strict()
 
@@ -195,7 +215,7 @@ const limitsSchema = z
   .object({
     max_calls: z.number().int().positive().optional(),
     window: durationSchema.optional(),
-    key: z.enum(['tool', 'agent', 'session']).optional(),
+    key: z.enum(['tool', 'agent', 'session', 'sender_id']).optional(),
     max_spend: spendLimitSchema.optional(),
   })
   .strict()
@@ -222,6 +242,35 @@ const policyRuleSchema = z
   .strict()
 
 // ---------------------------------------------------------------------------
+// Install-time policy (issue #13 — deny_install). A separate rule list because a
+// package has no tool/annotations/input to match on (issue #13).
+// ---------------------------------------------------------------------------
+
+const installMatchSchema = z
+  .object({
+    name: z.string().optional(), // glob, picomatch (same engine as match.tool)
+    source: z.string().optional(), // exact ecosystem match (npm | pip | …)
+    metadata: z.record(z.string(), metadataConditionSchema).optional(),
+  })
+  .strict()
+
+const installRuleSchema = z
+  .object({
+    name: z.string().optional(),
+    match: installMatchSchema,
+    action: z.enum(['deny_install', 'allow']),
+    feedback: feedbackSchema.optional(),
+  })
+  .strict()
+
+const installSchema = z
+  .object({
+    default: z.enum(['allow', 'deny']).default('allow'),
+    rules: z.array(installRuleSchema).default([]),
+  })
+  .strict()
+
+// ---------------------------------------------------------------------------
 // Policies
 // ---------------------------------------------------------------------------
 
@@ -231,6 +280,8 @@ const policiesSchema = z
     flag_destructive: z.enum(['log', 'require_approval']).optional(),
     dry_run: z.boolean().default(false),
     rules: z.array(policyRuleSchema).default([]),
+    /** Install-time policy (issue #13 — deny_install). Optional; absent ⇒ observational. */
+    install: installSchema.optional(),
     /**
      * How to treat calls to a tool whose definition (annotations, schemas,
      * description) has drifted from the baseline Helio captured on first
@@ -421,6 +472,31 @@ export const helioConfigSchema = helioConfigBaseSchema.superRefine((cfg, ctx) =>
           `Rule sets match.environment="${rule.match.environment}" but top-level ` +
           '`environment` is not configured. Set top-level environment to enable env-scoped rules.',
       })
+    }
+
+    // sender_id is an adapter (host-enforced) context field that only exists on
+    // the sideband. Without the sideband a sender-keyed limit is dead config that
+    // would silently collapse to tool scope on the MCP path — reject it up front
+    // (issue #13). Mirrors the match.environment / top-level-environment guard.
+    if (!cfg.sdk.enabled) {
+      if (rule.limits?.key === 'sender_id') {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['policies', 'rules', ruleIndex, 'limits', 'key'],
+          message:
+            'limits.key "sender_id" requires the SDK sideband (sdk.enabled: true) — ' +
+            'sender_id is supplied by hook adapters and is absent on the MCP path.',
+        })
+      }
+      if (rule.limits?.max_spend?.key === 'sender_id') {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['policies', 'rules', ruleIndex, 'limits', 'max_spend', 'key'],
+          message:
+            'limits.max_spend.key "sender_id" requires the SDK sideband (sdk.enabled: true) — ' +
+            'sender_id is supplied by hook adapters and is absent on the MCP path.',
+        })
+      }
     }
 
     if (rule.action === 'rate_limit') {

--- a/packages/proxy/src/policy/decision-pipeline.test.ts
+++ b/packages/proxy/src/policy/decision-pipeline.test.ts
@@ -35,6 +35,56 @@ const drift = (aspects: string[]): ToolDriftEvent => ({
 })
 
 // ---------------------------------------------------------------------------
+// match.metadata threading (issue #13)
+// ---------------------------------------------------------------------------
+
+describe('match.metadata threading (issue #13)', () => {
+  const denyOnChannel = (key: string, value: string) =>
+    compile({
+      default: 'allow',
+      rules: [{ match: { metadata: { [key]: value } }, action: 'deny' }],
+    })
+
+  it('a metadata-keyed rule matches when the keyed context is supplied', () => {
+    const policy = denyOnChannel('channel_id', 'C1')
+    const r = decide(input({ policy, metadata: { channel_id: 'C1' } }))
+    expect(r.decision.action).toBe('deny')
+  })
+
+  it('is inert when metadata is absent (MCP path) — falls through to default', () => {
+    const policy = denyOnChannel('channel_id', 'C1')
+    const r = decide(input({ policy }))
+    expect(r.decision.action).toBe('allow')
+  })
+
+  it('does not match when the supplied metadata value differs', () => {
+    const policy = denyOnChannel('channel_id', 'C1')
+    const r = decide(input({ policy, metadata: { channel_id: 'C2' } }))
+    expect(r.decision.action).toBe('allow')
+  })
+
+  it('matches the virtual agent_id key against the request agent id', () => {
+    const policy = denyOnChannel('agent_id', 'main')
+    const r = decide(input({ policy, agentId: 'main' }))
+    expect(r.decision.action).toBe('deny')
+  })
+
+  it('matches the virtual agent_id even with no metadata object present', () => {
+    const policy = denyOnChannel('agent_id', 'main')
+    // metadata undefined, only agentId provided
+    const r = decide(input({ policy, agentId: 'main', metadata: undefined }))
+    expect(r.decision.action).toBe('deny')
+  })
+
+  it('the request agent_id shadows a literal metadata.agent_id at match time', () => {
+    const policy = denyOnChannel('agent_id', 'main')
+    // even if a literal metadata.agent_id sneaks through, the virtual key wins
+    const r = decide(input({ policy, agentId: 'main', metadata: { agent_id: 'other' } }))
+    expect(r.decision.action).toBe('deny')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // decide()
 // ---------------------------------------------------------------------------
 

--- a/packages/proxy/src/policy/decision-pipeline.ts
+++ b/packages/proxy/src/policy/decision-pipeline.ts
@@ -42,6 +42,16 @@ export interface DecideInput {
   readonly currentAnnotations: ToolAnnotationHints | undefined
   /** Active drift event for this tool, if its definition moved off baseline. */
   readonly driftEvent: ToolDriftEvent | undefined
+  /**
+   * Adapter-supplied context for `match.metadata.*` (issue #13). Present only on
+   * the sideband path; undefined on the MCP path (metadata rules inert there).
+   */
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined
+  /**
+   * The request's `agent_id`, merged into the metadata view as the virtual
+   * `agent_id` match key — it shadows any literal `metadata.agent_id`.
+   */
+  readonly agentId?: string | undefined
 }
 
 /** The decision plus all the metadata the execution/audit steps consume. */
@@ -76,11 +86,17 @@ export function decide(input: DecideInput): PipelineDecision {
   const driftEvent = input.driftEvent
   const driftMode: DriftMode = policy.onToolDrift ?? 'block'
 
+  // Merge the virtual `agent_id` key (from the request column) into the
+  // adapter-supplied metadata for `match.metadata.*`. The virtual key shadows any
+  // literal `metadata.agent_id`; absent on the MCP path → undefined.
+  const metadata = buildMetadataView(input.metadata, input.agentId)
+
   let decision = evaluatePolicy(policy, {
     toolName,
     annotations,
     toolArguments,
     environment,
+    metadata,
   })
 
   // In log mode a drifted tool is evaluated against BOTH the baseline
@@ -93,6 +109,7 @@ export function decide(input: DecideInput): PipelineDecision {
       annotations: input.currentAnnotations,
       toolArguments,
       environment,
+      metadata,
     })
     decision = stricterDecision(decision, currentDecision)
   }
@@ -239,4 +256,21 @@ const ACTION_SEVERITY: Record<PolicyAction, number> = {
 /** Pick the stricter of two policy decisions (ties keep the first). */
 export function stricterDecision(a: PolicyDecision, b: PolicyDecision): PolicyDecision {
   return ACTION_SEVERITY[b.action] > ACTION_SEVERITY[a.action] ? b : a
+}
+
+/**
+ * Build the metadata match view for `match.metadata.*` (issue #13).
+ *
+ * Merges the request's `agent_id` in as a virtual `agent_id` key that shadows any
+ * literal `metadata.agent_id` (the adapter-supplied object is rejected for that key
+ * at the service boundary, but the shadow keeps match semantics deterministic even
+ * if it slips through an embedder). Returns undefined when neither source is present
+ * so a `match.metadata` rule stays inert (MCP path).
+ */
+function buildMetadataView(
+  metadata: Readonly<Record<string, unknown>> | undefined,
+  agentId: string | undefined,
+): Readonly<Record<string, unknown>> | undefined {
+  if (agentId === undefined) return metadata
+  return { ...(metadata ?? {}), agent_id: agentId }
 }

--- a/packages/proxy/src/policy/governed-forwarder.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder.test.ts
@@ -2478,6 +2478,31 @@ describe('GovernedForwarder', () => {
       expect(errorFromResult(result).data['reason']).toBe('rate_limited')
     })
 
+    it('falls back to tool scope (with a one-time warning) for key: sender_id on the MCP path', async () => {
+      const inner = mockForwarder()
+      const { limiter } = createRateLimiter()
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            match: { tool: 'get_weather' },
+            action: 'rate_limit',
+            limits: { max_calls: 1, window: '1m', key: 'sender_id' },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, { rateLimiter: limiter })
+
+      // No sender on MCP → both calls share the tool-scoped bucket; the second blocks.
+      await governed.forward(toolsCallRequest('get_weather'))
+      const result = await governed.forward(toolsCallRequest('get_weather'))
+      expect(errorFromResult(result).data['reason']).toBe('rate_limited')
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('sender_id'))
+
+      consoleSpy.mockRestore()
+    })
+
     it('allows calls again after window slides', async () => {
       const inner = mockForwarder()
       const { limiter, advance } = createRateLimiter()

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -82,6 +82,7 @@ export class GovernedForwarder implements McpForwarder {
   private readonly spendLimiter: SpendLimiter | undefined
   private readonly annotationCache = new ToolAnnotationCache()
   private agentKeyWarned = false
+  private senderKeyWarned = false
 
   constructor(inner: McpForwarder, policy: CompiledPolicy, options?: GovernedForwarderOptions) {
     this.inner = inner
@@ -680,7 +681,7 @@ export class GovernedForwarder implements McpForwarder {
 
   /** Construct a limit bucket key based on the configured key type. */
   private buildLimitKey(
-    keyType: 'tool' | 'agent' | 'session' | undefined,
+    keyType: 'tool' | 'agent' | 'session' | 'sender_id' | undefined,
     toolName: string,
     request: McpRequest,
   ): string {
@@ -694,6 +695,18 @@ export class GovernedForwarder implements McpForwarder {
           // eslint-disable-next-line no-console -- Intentional operational warning
           console.error(
             '[helio] Warning: limits.key "agent" is not yet supported, falling back to "tool"',
+          )
+        }
+        return `tool:${toolName}`
+      case 'sender_id':
+        // sender_id is an adapter (host-enforced) context field — absent on the
+        // MCP path, so fall back to tool scope. Config validation rejects this
+        // combination when the sideband is disabled (issue #13).
+        if (!this.senderKeyWarned) {
+          this.senderKeyWarned = true
+          // eslint-disable-next-line no-console -- Intentional operational warning
+          console.error(
+            '[helio] Warning: limits.key "sender_id" has no sender on the MCP path, falling back to "tool"',
           )
         }
         return `tool:${toolName}`

--- a/packages/proxy/src/policy/matchers.test.ts
+++ b/packages/proxy/src/policy/matchers.test.ts
@@ -1,8 +1,21 @@
 import { describe, it, expect } from 'vitest'
 import { compilePolicies } from './parser.js'
-import { matchRule, matchTool, matchAnnotations, matchInput, matchEnvironment } from './matchers.js'
+import {
+  matchRule,
+  matchTool,
+  matchAnnotations,
+  matchInput,
+  matchEnvironment,
+  matchMetadata,
+} from './matchers.js'
 import type { PoliciesConfig } from '../config/schema.js'
-import type { AnnotationMatch, CompiledPolicyRule, InputCondition, MatchContext } from './types.js'
+import type {
+  AnnotationMatch,
+  CompiledPolicyRule,
+  InputCondition,
+  MatchContext,
+  MetadataCondition,
+} from './types.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -31,6 +44,73 @@ function toolMatcher(rule: CompiledPolicyRule) {
   if (!matcher) throw new Error('expected a tool matcher on the compiled rule')
   return matcher
 }
+
+/** Build a metadata condition tersely. */
+function meta(
+  key: string,
+  operator: MetadataCondition['operator'],
+  value: unknown,
+  regex?: RegExp,
+): MetadataCondition {
+  return { key, operator, value, ...(regex ? { regex } : {}) }
+}
+
+// ---------------------------------------------------------------------------
+// matchMetadata (issue #13 — match.metadata.*)
+// ---------------------------------------------------------------------------
+
+describe('matchMetadata', () => {
+  it('empty condition list always matches', () => {
+    expect(matchMetadata([], ctx({}))).toBe(true)
+    expect(matchMetadata([], ctx({ metadata: { channel_id: 'C1' } }))).toBe(true)
+  })
+
+  it('returns false when metadata is absent but a condition exists (skip, not match)', () => {
+    expect(matchMetadata([meta('channel_id', 'eq', 'C1')], ctx({}))).toBe(false)
+  })
+
+  it('eq matches when the metadata key equals the value', () => {
+    const conditions = [meta('channel_id', 'eq', 'C1')]
+    expect(matchMetadata(conditions, ctx({ metadata: { channel_id: 'C1' } }))).toBe(true)
+    expect(matchMetadata(conditions, ctx({ metadata: { channel_id: 'C2' } }))).toBe(false)
+  })
+
+  it('returns false when the specific keyed field is missing from present metadata', () => {
+    expect(
+      matchMetadata([meta('sender_id', 'eq', 'U1')], ctx({ metadata: { channel_id: 'C1' } })),
+    ).toBe(false)
+  })
+
+  it('neq matches a differing present value but not a missing one', () => {
+    const conditions = [meta('sender_id', 'neq', 'U1')]
+    expect(matchMetadata(conditions, ctx({ metadata: { sender_id: 'U2' } }))).toBe(true)
+    expect(matchMetadata(conditions, ctx({ metadata: { sender_id: 'U1' } }))).toBe(false)
+    // absent value is not "not equal" — it's absent
+    expect(matchMetadata(conditions, ctx({ metadata: { channel_id: 'C1' } }))).toBe(false)
+  })
+
+  it('contains matches a substring of a string value', () => {
+    const conditions = [meta('sender_name', 'contains', 'ali')]
+    expect(matchMetadata(conditions, ctx({ metadata: { sender_name: 'alice' } }))).toBe(true)
+    expect(matchMetadata(conditions, ctx({ metadata: { sender_name: 'bob' } }))).toBe(false)
+  })
+
+  it('regex matches against a precompiled pattern', () => {
+    const conditions = [meta('sender_id', 'regex', '^U0[0-9]+$', /^U0[0-9]+$/)]
+    expect(matchMetadata(conditions, ctx({ metadata: { sender_id: 'U07' } }))).toBe(true)
+    expect(matchMetadata(conditions, ctx({ metadata: { sender_id: 'A07' } }))).toBe(false)
+  })
+
+  it('AND-combines multiple keyed conditions', () => {
+    const conditions = [meta('channel_id', 'eq', 'C1'), meta('sender_id', 'eq', 'U1')]
+    expect(
+      matchMetadata(conditions, ctx({ metadata: { channel_id: 'C1', sender_id: 'U1' } })),
+    ).toBe(true)
+    expect(
+      matchMetadata(conditions, ctx({ metadata: { channel_id: 'C1', sender_id: 'U2' } })),
+    ).toBe(false)
+  })
+})
 
 // ---------------------------------------------------------------------------
 // matchTool

--- a/packages/proxy/src/policy/matchers.ts
+++ b/packages/proxy/src/policy/matchers.ts
@@ -10,6 +10,7 @@ import type {
   CompiledPolicyRule,
   InputCondition,
   MatchContext,
+  MetadataCondition,
   ToolAnnotationHints,
   ToolMatcher,
 } from './types.js'
@@ -157,6 +158,42 @@ export function matchEnvironment(required: string, ctx: MatchContext): boolean {
   return ctx.environment === required
 }
 
+/**
+ * Test whether ALL metadata conditions match against the adapter-supplied context
+ * (issue #13 — `match.metadata.*`). Conditions are AND'd; every condition must pass.
+ *
+ * Returns false when `ctx.metadata` is absent and any condition exists — metadata is
+ * only present on the sideband (host-enforced) path, so a metadata rule is skipped
+ * (NOT denied) on the MCP path. Keys are read flat (no JSONPath traversal); the
+ * virtual `agent_id` key is merged into `ctx.metadata` upstream by the decision
+ * pipeline.
+ */
+export function matchMetadata(
+  conditions: readonly MetadataCondition[],
+  ctx: MatchContext,
+): boolean {
+  if (conditions.length === 0) return true
+  if (ctx.metadata === undefined) return false
+
+  for (const condition of conditions) {
+    const value = ctx.metadata[condition.key]
+    // Reuse the shared scalar evaluator; metadata reads a flat key rather than a
+    // JSONPath, so adapt the condition shape (path is irrelevant here).
+    const matched = evaluateCondition(
+      {
+        path: condition.key,
+        operator: condition.operator,
+        value: condition.value,
+        regex: condition.regex,
+      },
+      value,
+    )
+    if (!matched) return false
+  }
+
+  return true
+}
+
 // ---------------------------------------------------------------------------
 // Top-level rule matcher
 // ---------------------------------------------------------------------------
@@ -175,6 +212,7 @@ export function matchRule(rule: CompiledPolicyRule, ctx: MatchContext): boolean 
   if (match.annotations !== undefined && !matchAnnotations(match.annotations, ctx)) return false
   if (match.input !== undefined && !matchInput(match.input, ctx)) return false
   if (match.environment !== undefined && !matchEnvironment(match.environment, ctx)) return false
+  if (match.metadata !== undefined && !matchMetadata(match.metadata, ctx)) return false
 
   return true
 }

--- a/packages/proxy/src/policy/parser.test.ts
+++ b/packages/proxy/src/policy/parser.test.ts
@@ -196,6 +196,133 @@ describe('annotation matching', () => {
 // Input condition flattening
 // ---------------------------------------------------------------------------
 
+describe('install policy compilation (issue #13)', () => {
+  it('compiles install rules with a name glob, source, and default', () => {
+    const { policy } = compilePolicies(
+      minimalPolicies({
+        install: {
+          default: 'allow',
+          rules: [
+            {
+              name: 'block-evil',
+              match: { name: 'evil-*', source: 'npm' },
+              action: 'deny_install',
+            },
+          ],
+        },
+      }),
+    )
+    expect(policy.install?.defaultAction).toBe('allow')
+    const rule = policy.install?.rules[0]
+    expect(rule?.action).toBe('deny_install')
+    expect(rule?.match.source).toBe('npm')
+    expect(rule?.match.name?.test('evil-pkg')).toBe(true)
+    expect(rule?.match.name?.test('left-pad')).toBe(false)
+  })
+
+  it('compiles install-rule metadata conditions', () => {
+    const { policy } = compilePolicies(
+      minimalPolicies({
+        install: {
+          default: 'deny',
+          rules: [{ match: { metadata: { sender_id: 'U9' } }, action: 'deny_install' }],
+        },
+      }),
+    )
+    expect(policy.install?.defaultAction).toBe('deny')
+    expect(policy.install?.rules[0]?.match.metadata?.[0]?.key).toBe('sender_id')
+  })
+
+  it('leaves install undefined when no install section is configured', () => {
+    const { policy } = compilePolicies(minimalPolicies({ rules: [] }))
+    expect(policy.install).toBeUndefined()
+  })
+})
+
+describe('metadata condition flattening (issue #13)', () => {
+  it('bare-string shorthand compiles to an eq condition', () => {
+    const { rule } = firstRule(
+      minimalPolicies({
+        rules: [{ match: { metadata: { channel_id: 'C123' } }, action: 'deny' }],
+      }),
+    )
+    const metadata = rule.match.metadata
+    expect(metadata).toBeDefined()
+    expect(metadata).toHaveLength(1)
+    expect(metadata?.[0]?.key).toBe('channel_id')
+    expect(metadata?.[0]?.operator).toBe('eq')
+    expect(metadata?.[0]?.value).toBe('C123')
+    expect(metadata?.[0]?.regex).toBeUndefined()
+  })
+
+  it('operator object compiles to the named operator', () => {
+    const { rule } = firstRule(
+      minimalPolicies({
+        rules: [{ match: { metadata: { sender_name: { contains: 'ali' } } }, action: 'deny' }],
+      }),
+    )
+    expect(rule.match.metadata?.[0]?.operator).toBe('contains')
+    expect(rule.match.metadata?.[0]?.value).toBe('ali')
+  })
+
+  it('the virtual agent_id key is a permitted metadata key', () => {
+    const { rule } = firstRule(
+      minimalPolicies({
+        rules: [{ match: { metadata: { agent_id: 'main' } }, action: 'deny' }],
+      }),
+    )
+    expect(rule.match.metadata?.[0]?.key).toBe('agent_id')
+    expect(rule.match.metadata?.[0]?.operator).toBe('eq')
+  })
+
+  it('multiple keys flatten to multiple conditions', () => {
+    const { rule } = firstRule(
+      minimalPolicies({
+        rules: [
+          {
+            match: { metadata: { channel_id: 'C1', sender_id: { regex: '^U0[0-9]+$' } } },
+            action: 'deny',
+          },
+        ],
+      }),
+    )
+    expect(rule.match.metadata).toHaveLength(2)
+  })
+
+  it('regex operator pre-compiles to a RegExp', () => {
+    const { rule } = firstRule(
+      minimalPolicies({
+        rules: [{ match: { metadata: { sender_id: { regex: '^U0[0-9]+$' } } }, action: 'deny' }],
+      }),
+    )
+    const cond = rule.match.metadata?.[0]
+    expect(cond?.operator).toBe('regex')
+    expect(cond?.regex).toBeInstanceOf(RegExp)
+    expect(cond?.regex?.test('U07')).toBe(true)
+    expect(cond?.regex?.test('A07')).toBe(false)
+  })
+
+  it('rejects a catastrophic regex at compile time (reuses the safe-regex analyzer)', () => {
+    expect(() =>
+      compilePolicies(
+        minimalPolicies({
+          rules: [{ match: { metadata: { sender_id: { regex: '^(a+)+$' } } }, action: 'deny' }],
+        }),
+      ),
+    ).toThrow(PolicyParseError)
+  })
+
+  it('invalid regex throws PolicyParseError', () => {
+    expect(() =>
+      compilePolicies(
+        minimalPolicies({
+          rules: [{ match: { metadata: { sender_id: { regex: '[invalid(' } } }, action: 'deny' }],
+        }),
+      ),
+    ).toThrow(PolicyParseError)
+  })
+})
+
 describe('input condition flattening', () => {
   it('single path, single operator', () => {
     const { rule } = firstRule(

--- a/packages/proxy/src/policy/parser.ts
+++ b/packages/proxy/src/policy/parser.ts
@@ -5,18 +5,23 @@ import type { PoliciesConfig, PolicyRule } from '../config/schema.js'
 import { PolicyParseError } from './errors.js'
 import type {
   CompiledApproval,
+  CompiledInstallPolicy,
   CompiledLimits,
   CompiledMatch,
   CompiledPolicy,
   CompiledPolicyRule,
   CompilePoliciesResult,
   InputCondition,
+  MetadataCondition,
   PolicyParseWarning,
   ToolMatcher,
 } from './types.js'
 
 /** Operators that can appear in an input condition object. */
 const INPUT_OPERATORS = ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'contains', 'regex'] as const
+
+/** Operators that can appear in a metadata condition object (string subset). */
+const METADATA_OPERATORS = ['eq', 'neq', 'contains', 'regex'] as const
 
 /**
  * Compile a validated PoliciesConfig into engine-ready form.
@@ -38,9 +43,44 @@ export function compilePolicies(config: PoliciesConfig): CompilePoliciesResult {
     ...(config.dry_run && { dryRun: true }),
     ...(config.on_tool_drift && { onToolDrift: config.on_tool_drift }),
     rules,
+    ...(config.install && { install: compileInstallPolicy(config.install) }),
   }
 
   return { policy, warnings }
+}
+
+function compileInstallPolicy(
+  install: NonNullable<PoliciesConfig['install']>,
+): CompiledInstallPolicy {
+  return {
+    defaultAction: install.default,
+    rules: install.rules.map((rule, index) => {
+      const name =
+        rule.match.name !== undefined
+          ? compileToolMatcher(rule.match.name, index, rule.name)
+          : undefined
+      const metadata =
+        rule.match.metadata !== undefined
+          ? flattenMetadataConditions(rule.match.metadata, index, rule.name)
+          : undefined
+      return {
+        index,
+        ...(rule.name !== undefined && { name: rule.name }),
+        match: {
+          ...(name !== undefined && { name }),
+          ...(rule.match.source !== undefined && { source: rule.match.source }),
+          ...(metadata !== undefined && { metadata }),
+        },
+        action: rule.action,
+        ...(rule.feedback !== undefined && {
+          feedback: {
+            message: rule.feedback.message,
+            ...(rule.feedback.suggestion !== undefined && { suggestion: rule.feedback.suggestion }),
+          },
+        }),
+      }
+    }),
+  }
 }
 
 function compileRule(
@@ -87,6 +127,9 @@ function compileMatch(
       input: flattenInputConditions(match.input, ruleIndex, ruleName),
     }),
     ...(match.environment !== undefined && { environment: match.environment }),
+    ...(match.metadata !== undefined && {
+      metadata: flattenMetadataConditions(match.metadata, ruleIndex, ruleName),
+    }),
   }
 }
 
@@ -149,6 +192,57 @@ function flattenInputConditions(
         conditions.push({ path, operator: op, value, regex: compiledRegex })
       } else {
         conditions.push({ path, operator: op, value })
+      }
+    }
+  }
+
+  return conditions
+}
+
+function flattenMetadataConditions(
+  metadata: Record<string, string | Record<string, string | undefined>>,
+  ruleIndex: number,
+  ruleName?: string,
+): MetadataCondition[] {
+  const conditions: MetadataCondition[] = []
+
+  for (const [key, raw] of Object.entries(metadata)) {
+    // Bare-string shorthand → eq.
+    if (typeof raw === 'string') {
+      conditions.push({ key, operator: 'eq', value: raw })
+      continue
+    }
+
+    for (const op of METADATA_OPERATORS) {
+      const value = raw[op]
+      if (value === undefined) continue
+
+      if (op === 'regex') {
+        // Reuse the same ReDoS analyzer + compile path as input regexes so a
+        // fat-fingered metadata regex cannot hang the policy hot path.
+        if (!safeRegex(value)) {
+          throw new PolicyParseError(
+            `catastrophic regex "${value}" for metadata key "${key}": ` +
+              `pattern is vulnerable to ReDoS and has been rejected. ` +
+              `Rewrite with bounded quantifiers (e.g. {1,100}) or split into simpler rules.`,
+            ruleIndex,
+            ruleName,
+          )
+        }
+        let compiledRegex: RegExp
+        try {
+          compiledRegex = new RegExp(value)
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          throw new PolicyParseError(
+            `invalid regex "${value}" for metadata key "${key}": ${msg}`,
+            ruleIndex,
+            ruleName,
+          )
+        }
+        conditions.push({ key, operator: op, value, regex: compiledRegex })
+      } else {
+        conditions.push({ key, operator: op, value })
       }
     }
   }

--- a/packages/proxy/src/policy/types.ts
+++ b/packages/proxy/src/policy/types.ts
@@ -40,6 +40,23 @@ export interface InputCondition {
   readonly regex?: RegExp
 }
 
+/**
+ * A single flattened metadata condition (issue #13 — `match.metadata.*`).
+ *
+ * Mirrors InputCondition but matches a flat top-level key of the adapter-supplied
+ * context object (no JSONPath traversal), and is restricted to the string-friendly
+ * operator subset — metadata values (channel_id, sender_id, …) are strings, so the
+ * numeric comparators are deliberately excluded.
+ */
+export interface MetadataCondition {
+  /** The metadata key to read (e.g. "channel_id", "sender_id", or virtual "agent_id"). */
+  readonly key: string
+  readonly operator: 'eq' | 'neq' | 'contains' | 'regex'
+  readonly value: unknown
+  /** Pre-compiled RegExp when operator is 'regex'. */
+  readonly regex?: RegExp
+}
+
 /** Compiled match block for a policy rule. */
 export interface CompiledMatch {
   readonly tool?: ToolMatcher
@@ -47,6 +64,8 @@ export interface CompiledMatch {
   /** Flattened list of input conditions (one entry per path+operator pair). */
   readonly input?: readonly InputCondition[]
   readonly environment?: string
+  /** Flattened list of metadata conditions (one entry per key+operator pair). */
+  readonly metadata?: readonly MetadataCondition[]
 }
 
 /** Compiled approval configuration with durations as milliseconds. */
@@ -63,14 +82,14 @@ export interface CompiledSpendLimit {
   readonly limit: number
   readonly currency: string
   readonly windowMs: number
-  readonly key?: 'tool' | 'agent' | 'session'
+  readonly key?: 'tool' | 'agent' | 'session' | 'sender_id'
 }
 
 /** Compiled rate/spend limit configuration. */
 export interface CompiledLimits {
   readonly maxCalls?: number
   readonly windowMs?: number
-  readonly key?: 'tool' | 'agent' | 'session'
+  readonly key?: 'tool' | 'agent' | 'session' | 'sender_id'
   readonly maxSpend?: CompiledSpendLimit
 }
 
@@ -105,6 +124,31 @@ export interface CompiledPolicyRule {
   readonly feedback?: { readonly message: string; readonly suggestion?: string }
 }
 
+/** Compiled match block for an install-time rule (issue #13). */
+export interface CompiledInstallMatch {
+  /** Glob matcher on the package name. */
+  readonly name?: ToolMatcher
+  /** Exact ecosystem/source match (npm | pip | …). */
+  readonly source?: string
+  /** Flattened metadata conditions (sender/channel-gated installs). */
+  readonly metadata?: readonly MetadataCondition[]
+}
+
+/** A compiled install-time rule. */
+export interface CompiledInstallRule {
+  readonly index: number
+  readonly name?: string
+  readonly match: CompiledInstallMatch
+  readonly action: 'deny_install' | 'allow'
+  readonly feedback?: { readonly message: string; readonly suggestion?: string }
+}
+
+/** Compiled install-time policy (issue #13). */
+export interface CompiledInstallPolicy {
+  readonly defaultAction: 'allow' | 'deny'
+  readonly rules: readonly CompiledInstallRule[]
+}
+
 /** Top-level compiled policy — what the engine consumes. */
 export interface CompiledPolicy {
   readonly defaultAction: 'allow' | 'deny'
@@ -116,6 +160,8 @@ export interface CompiledPolicy {
    */
   readonly onToolDrift?: 'block' | 'require_approval' | 'log'
   readonly rules: readonly CompiledPolicyRule[]
+  /** Install-time policy (issue #13 — deny_install). Undefined ⇒ observational. */
+  readonly install?: CompiledInstallPolicy
 }
 
 /** A non-fatal warning produced during policy compilation. */
@@ -163,4 +209,11 @@ export interface MatchContext {
   readonly toolArguments?: Readonly<Record<string, unknown>>
   /** The configured environment label (e.g. "production", "staging"). */
   readonly environment?: string
+  /**
+   * Adapter-supplied context for `match.metadata.*` (issue #13). Present only on
+   * the sideband (host-enforced) path; always absent on the MCP path, so metadata
+   * rules are inert there by construction. The virtual `agent_id` key (from the
+   * request column) is merged in by the decision pipeline, not stored here twice.
+   */
+  readonly metadata?: Readonly<Record<string, unknown>>
 }

--- a/packages/proxy/src/sideband/governance-api.test.ts
+++ b/packages/proxy/src/sideband/governance-api.test.ts
@@ -179,7 +179,7 @@ describe('sideband governance routes', () => {
     expect(res.status).toBe(403)
   })
 
-  describe('scoped tokens (F6)', () => {
+  describe('scoped tokens', () => {
     it('governance routes require the adapter token, not the SDK token', async () => {
       const ctx = setup({ tokens: true })
       store = ctx.store

--- a/packages/proxy/src/sideband/governance-api.test.ts
+++ b/packages/proxy/src/sideband/governance-api.test.ts
@@ -11,13 +11,19 @@ import { compilePolicies } from '../policy/parser.js'
 const SDK_TOKEN = 'sdk-token-aaaaaaaaaaaaaaaa'
 const ADAPTER_TOKEN = 'adapter-token-bbbbbbbbbbbb'
 
-function setup(opts?: { withGovernance?: boolean; tokens?: boolean }) {
+function setup(opts?: {
+  withGovernance?: boolean
+  tokens?: boolean
+  policy?: Parameters<typeof compilePolicies>[0]
+}) {
   const store = new EvidenceStore({ cleanupIntervalMs: 0 })
-  const policy = compilePolicies({
-    default: 'allow',
-    dry_run: false,
-    rules: [{ name: 'no-send', match: { tool: 'blocked' }, action: 'deny' }],
-  }).policy
+  const policy = compilePolicies(
+    opts?.policy ?? {
+      default: 'allow',
+      dry_run: false,
+      rules: [{ name: 'no-send', match: { tool: 'blocked' }, action: 'deny' }],
+    },
+  ).policy
 
   const governance =
     opts?.withGovernance === false
@@ -78,6 +84,65 @@ describe('sideband governance routes', () => {
     const res = await ctx.post('/evaluate', evalBody())
     expect(res.status).toBe(503)
     expect(((await res.json()) as { error: string }).error).toBe('governance_unavailable')
+  })
+
+  it('gates an evaluate on match.metadata.channel_id end-to-end', async () => {
+    const ctx = setup({
+      policy: {
+        default: 'allow',
+        dry_run: false,
+        rules: [{ name: 'block-chan', match: { metadata: { channel_id: 'C1' } }, action: 'deny' }],
+      },
+    })
+    store = ctx.store
+    governance = ctx.governance ?? null
+
+    const denied = await ctx.post('/evaluate', evalBody({ metadata: { channel_id: 'C1' } }))
+    expect(((await denied.json()) as { decision: string }).decision).toBe('deny')
+
+    const allowed = await ctx.post('/evaluate', evalBody({ metadata: { channel_id: 'C2' } }))
+    expect(((await allowed.json()) as { decision: string }).decision).toBe('allow')
+  })
+
+  it('denies a matching install through /install-scan end-to-end (deny_install)', async () => {
+    const ctx = setup({
+      policy: {
+        default: 'allow',
+        dry_run: false,
+        rules: [],
+        install: {
+          default: 'allow',
+          rules: [
+            {
+              name: 'block-evil',
+              match: { name: 'evil-*', source: 'npm' },
+              action: 'deny_install',
+            },
+          ],
+        },
+      },
+    })
+    store = ctx.store
+    governance = ctx.governance ?? null
+    const res = await ctx.post('/install-scan', {
+      origin: 'openclaw',
+      package: { name: 'evil-pkg', source: 'npm' },
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { decision: string; matched_rule: string }
+    expect(json.decision).toBe('deny')
+    expect(json.matched_rule).toBe('block-evil')
+  })
+
+  it('rejects a reserved agent_id key inside metadata with 400', async () => {
+    const ctx = setup()
+    store = ctx.store
+    governance = ctx.governance ?? null
+    const res = await ctx.post('/evaluate', evalBody({ metadata: { agent_id: 'spoofed' } }))
+    expect(res.status).toBe(400)
+    expect((await res.json()) as { error: string }).toMatchObject({
+      error: 'reserved_metadata_key',
+    })
   })
 
   it('rejects malformed JSON with 400', async () => {

--- a/packages/proxy/src/sideband/governance-api.ts
+++ b/packages/proxy/src/sideband/governance-api.ts
@@ -8,7 +8,7 @@ import { formatZodErrors } from '../util/format-zod-errors.js'
 
 // ---------------------------------------------------------------------------
 // Request schemas (issue #12). snake_case crosses the wire; the contract is
-// framework-neutral (D13) — no adapter-specific field names or enums.
+// framework-neutral — no adapter-specific field names or enums.
 // ---------------------------------------------------------------------------
 
 const originSchema = z
@@ -67,7 +67,7 @@ const resolveBody = z.object({
   scope: z.enum(['once', 'always']).optional(),
 })
 
-/** Max serialized size of the `metadata` object (D11/D15). */
+/** Max serialized size of the `metadata` object. */
 const MAX_METADATA_BYTES = 4 * 1_024
 
 // ---------------------------------------------------------------------------
@@ -192,7 +192,7 @@ function metadataTooLarge(metadata: Record<string, unknown> | null | undefined):
 }
 
 /**
- * SHA-256 over the canonical JSON of the semantic /audit fields (D5). Key
+ * SHA-256 over the canonical JSON of the semantic /audit fields. Key
  * order, whitespace, and omitted-vs-default fields cannot produce spurious
  * idempotency conflicts; a retry that recomputes duration_ms is an adapter bug
  * and correctly surfaces as a conflict.

--- a/packages/proxy/src/sideband/governance-api.ts
+++ b/packages/proxy/src/sideband/governance-api.ts
@@ -16,6 +16,9 @@ const originSchema = z
   .regex(/^[a-z0-9_-]{1,64}$/, 'origin must match ^[a-z0-9_-]{1,64}$')
   .default('sideband')
 
+// Reserved keys that have their own audit column (currently `agent_id`) are rejected
+// at the service layer (GovernanceService.evaluate/installScan), which also covers
+// direct embedders — so there is intentionally no route-level guard here.
 const metadataSchema = z.record(z.string(), z.unknown()).nullish()
 
 const toolDefinitionSchema = z.object({

--- a/packages/proxy/src/sideband/governance-service.test.ts
+++ b/packages/proxy/src/sideband/governance-service.test.ts
@@ -262,7 +262,7 @@ describe('GovernanceService.evaluate', () => {
     expect(approvalRouter?.getTicket(approval.id)?.channel_name).toBe('native:openclaw')
   })
 
-  describe('drift guard (D6)', () => {
+  describe('drift guard', () => {
     it('detects drift across two evaluates and gates per on_tool_drift: block', () => {
       const policy = compile({ default: 'allow', on_tool_drift: 'block', rules: [] })
       const { service } = makeService({ policy })
@@ -286,7 +286,7 @@ describe('GovernanceService.evaluate', () => {
     })
   })
 
-  describe('memory budgets (D15)', () => {
+  describe('memory budgets', () => {
     it('rejects tool_input over 64 KiB with 413', () => {
       const { service } = makeService()
       const big = 'x'.repeat(70 * 1024)
@@ -740,7 +740,7 @@ describe('GovernanceService approvals and deadlines', () => {
 })
 
 // ---------------------------------------------------------------------------
-// actual_amount validation (§4 policy) and memory-budget overshoot
+// actual_amount validation and memory-budget overshoot
 // ---------------------------------------------------------------------------
 
 describe('GovernanceService /audit validation and budgets', () => {

--- a/packages/proxy/src/sideband/governance-service.test.ts
+++ b/packages/proxy/src/sideband/governance-service.test.ts
@@ -57,6 +57,7 @@ function makeService(opts?: {
   withApprovals?: boolean
   withEvidence?: boolean
   ttlMs?: number
+  maxSenderKeys?: number
 }): ServiceHarness {
   let time = 1_000_000
   const now = () => time
@@ -95,6 +96,7 @@ function makeService(opts?: {
     ttlMs: opts?.ttlMs ?? 600_000,
     now,
     sweepIntervalMs: 0,
+    ...(opts?.maxSenderKeys !== undefined && { maxSenderKeys: opts.maxSenderKeys }),
   })
 
   return { service, records, advance, rateLimiter, spendLimiter, approvalRouter, evidenceStore }
@@ -119,6 +121,67 @@ function auditInput(id: string, overrides?: Partial<AuditInput>): AuditInput {
 // ---------------------------------------------------------------------------
 // evaluate
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// match.metadata + reserved-key rejection (issue #13)
+// ---------------------------------------------------------------------------
+
+describe('GovernanceService — match.metadata threading', () => {
+  const denyOnChannel = compile({
+    default: 'allow',
+    rules: [{ match: { metadata: { channel_id: 'C1' } }, action: 'deny' }],
+  })
+
+  it('a metadata-keyed rule denies when the matching context is supplied', () => {
+    const { service } = makeService({ policy: denyOnChannel })
+    const res = service.evaluate(evalInput({ metadata: { channel_id: 'C1' } }))
+    expect(res.body).toMatchObject({ decision: 'deny' })
+  })
+
+  it('the same rule is inert when the context differs / is absent', () => {
+    const { service } = makeService({ policy: denyOnChannel })
+    expect(service.evaluate(evalInput({ metadata: { channel_id: 'C2' } })).body).toMatchObject({
+      decision: 'allow',
+    })
+    expect(service.evaluate(evalInput({ metadata: null })).body).toMatchObject({
+      decision: 'allow',
+    })
+  })
+
+  it('matches the virtual agent_id key against the request agent_id', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [{ match: { metadata: { agent_id: 'main' } }, action: 'deny' }],
+    })
+    const { service } = makeService({ policy })
+    expect(service.evaluate(evalInput({ agent_id: 'main', metadata: null })).body).toMatchObject({
+      decision: 'deny',
+    })
+    expect(service.evaluate(evalInput({ agent_id: 'other', metadata: null })).body).toMatchObject({
+      decision: 'allow',
+    })
+  })
+
+  it('rejects a reserved agent_id key inside metadata at the SERVICE layer', () => {
+    const { service } = makeService()
+    const res = service.evaluate(evalInput({ metadata: { agent_id: 'spoofed' } }))
+    expect(res.status).toBe(400)
+    expect(res.body).toMatchObject({ error: 'reserved_metadata_key', key: 'agent_id' })
+  })
+
+  it('rejects a reserved agent_id key inside install-scan metadata too', () => {
+    const { service } = makeService()
+    const res = service.installScan({
+      origin: 'openclaw',
+      agent_id: 'main',
+      session_id: null,
+      package: { name: 'left-pad', source: 'npm' },
+      metadata: { agent_id: 'spoofed' },
+    })
+    expect(res.status).toBe(400)
+    expect(res.body).toMatchObject({ error: 'reserved_metadata_key', key: 'agent_id' })
+  })
+})
 
 describe('GovernanceService.evaluate', () => {
   it('returns allow for a default-allow policy and creates a pending entry', () => {
@@ -339,6 +402,249 @@ describe('GovernanceService.audit', () => {
     const id = ev.body['evaluation_id'] as string
     service.audit(auditInput(id, { actual_amount: 42 }), 'h')
     expect(spendLimiter?.getKeyState('tool:send')?.current_spend).toBe(42)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deny_install (issue #13)
+// ---------------------------------------------------------------------------
+
+describe('GovernanceService.installScan — deny_install', () => {
+  const blockEvilNpm = compile({
+    default: 'allow',
+    rules: [],
+    install: {
+      default: 'allow',
+      rules: [
+        { name: 'block-evil', match: { name: 'evil-*', source: 'npm' }, action: 'deny_install' },
+      ],
+    },
+  })
+
+  const scan = (
+    service: GovernanceService,
+    pkg: { name: string; source?: string },
+    metadata: Record<string, unknown> | null = null,
+  ) =>
+    service.installScan({
+      origin: 'openclaw',
+      agent_id: 'main',
+      session_id: null,
+      package: pkg,
+      metadata,
+    })
+
+  it('denies a matching install — decision deny, install_denied, policy_decision deny', () => {
+    const { service, records } = makeService({ policy: blockEvilNpm })
+    const res = scan(service, { name: 'evil-pkg', source: 'npm' })
+    expect(res.status).toBe(200)
+    expect(res.body['decision']).toBe('deny')
+    expect(res.body['matched_rule']).toBe('block-evil')
+    const rec = records.at(-1)?.record
+    // policy_decision MUST be 'deny' (not 'deny_install'), else the dashboard
+    // renders the blocked install as "allow".
+    expect(rec?.policy_decision).toBe('deny')
+    expect(rec?.block_reason).toBe('install_denied')
+    expect(rec?.record_kind).toBe('install_scan')
+  })
+
+  it('allows a non-matching package name', () => {
+    const { service } = makeService({ policy: blockEvilNpm })
+    expect(scan(service, { name: 'left-pad', source: 'npm' }).body['decision']).toBe('allow')
+  })
+
+  it('respects the source matcher (evil-* but pip → no match)', () => {
+    const { service } = makeService({ policy: blockEvilNpm })
+    expect(scan(service, { name: 'evil-pkg', source: 'pip' }).body['decision']).toBe('allow')
+  })
+
+  it('honors install.default: deny', () => {
+    const denyAll = compile({
+      default: 'allow',
+      rules: [],
+      install: { default: 'deny', rules: [] },
+    })
+    const { service, records } = makeService({ policy: denyAll })
+    const res = scan(service, { name: 'anything', source: 'npm' })
+    expect(res.body['decision']).toBe('deny')
+    expect(records.at(-1)?.record.block_reason).toBe('install_denied')
+  })
+
+  it('can gate installs on metadata (sender_id)', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [],
+      install: {
+        default: 'allow',
+        rules: [{ match: { metadata: { sender_id: 'U9' } }, action: 'deny_install' }],
+      },
+    })
+    const { service } = makeService({ policy })
+    expect(scan(service, { name: 'x', source: 'npm' }, { sender_id: 'U9' }).body['decision']).toBe(
+      'deny',
+    )
+    expect(scan(service, { name: 'x', source: 'npm' }, { sender_id: 'U1' }).body['decision']).toBe(
+      'allow',
+    )
+  })
+
+  it('still allows with the observational reason when no install rules exist', () => {
+    const { service } = makeService()
+    const res = scan(service, { name: 'left-pad', source: 'npm' })
+    expect(res.body['decision']).toBe('allow')
+    expect(res.body['reason']).toBe('no install-time rules defined')
+  })
+
+  it('picks up install rules added by a hot-reload (updatePolicy)', () => {
+    const { service } = makeService()
+    expect(scan(service, { name: 'evil-pkg', source: 'npm' }).body['decision']).toBe('allow')
+    service.updatePolicy(blockEvilNpm)
+    expect(scan(service, { name: 'evil-pkg', source: 'npm' }).body['decision']).toBe('deny')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sender_id limit scoping (issue #13)
+// ---------------------------------------------------------------------------
+
+describe('GovernanceService — sender_id keyed limits', () => {
+  const rateBySender = compile({
+    default: 'allow',
+    rules: [
+      {
+        match: { tool: 'send' },
+        action: 'rate_limit',
+        limits: { max_calls: 1, window: '1m', key: 'sender_id' },
+      },
+    ],
+  })
+
+  function consume(service: GovernanceService, sender: string) {
+    const ev = service.evaluate(evalInput({ metadata: { sender_id: sender } }))
+    const id = ev.body['evaluation_id'] as string
+    service.audit(auditInput(id), 'h')
+    return ev
+  }
+
+  it('keys the rate bucket by sender_id, not tool', () => {
+    const { service, rateLimiter } = makeService({ policy: rateBySender, withLimiters: true })
+    consume(service, 'U1')
+    expect(rateLimiter?.getKeyState('sender:U1')?.current).toBe(1)
+    expect(rateLimiter?.getKeyState('tool:send')).toBeUndefined()
+  })
+
+  it('gives different senders independent buckets', () => {
+    const { service } = makeService({ policy: rateBySender, withLimiters: true })
+    consume(service, 'U1') // U1 now at its limit
+    // U1's next call is rate_limited; U2 is unaffected.
+    expect(service.evaluate(evalInput({ metadata: { sender_id: 'U1' } })).body['decision']).toBe(
+      'rate_limited',
+    )
+    expect(service.evaluate(evalInput({ metadata: { sender_id: 'U2' } })).body['decision']).toBe(
+      'allow',
+    )
+  })
+
+  it('falls back to sender:unknown when sender_id is absent', () => {
+    const { service, rateLimiter } = makeService({ policy: rateBySender, withLimiters: true })
+    const ev = service.evaluate(evalInput({ metadata: null }))
+    const id = ev.body['evaluation_id'] as string
+    service.audit(auditInput(id), 'h')
+    expect(rateLimiter?.getKeyState('sender:unknown')?.current).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sender-key reservation registry (issue #13)
+// ---------------------------------------------------------------------------
+
+describe('GovernanceService — sender-key cardinality registry', () => {
+  // Rooms enough peek headroom that the limiter never blocks; the registry is
+  // what we're exercising.
+  const rateBySender = compile({
+    default: 'allow',
+    rules: [
+      {
+        match: { tool: 'send' },
+        action: 'rate_limit',
+        limits: { max_calls: 5, window: '1m', key: 'sender_id' },
+      },
+    ],
+  })
+
+  const evalSender = (sender: string) => evalInput({ metadata: { sender_id: sender } })
+
+  it('admits distinct senders up to the cap, then fails new ones closed with 503', () => {
+    const { service } = makeService({ policy: rateBySender, withLimiters: true, maxSenderKeys: 1 })
+    // First sender reserves the only slot.
+    expect(service.evaluate(evalSender('U1')).status).toBe(200)
+    // A different sender would mint a second key → fail closed.
+    const res = service.evaluate(evalSender('U2'))
+    expect(res.status).toBe(503)
+    expect(res.body['error']).toBe('limit_capacity_exhausted')
+    // The already-reserved sender keeps working (not a new key).
+    expect(service.evaluate(evalSender('U1')).status).toBe(200)
+  })
+
+  it('does not gate tool/session-keyed limits (no cross-door starvation)', () => {
+    const sessionRule = compile({
+      default: 'allow',
+      rules: [
+        {
+          match: { tool: 'send' },
+          action: 'rate_limit',
+          limits: { max_calls: 5, window: '1m', key: 'session' },
+        },
+      ],
+    })
+    const { service } = makeService({ policy: sessionRule, withLimiters: true, maxSenderKeys: 1 })
+    // Many distinct sessions never consume sender-registry slots.
+    expect(service.evaluate(evalInput({ session_id: 'sess-a' })).status).toBe(200)
+    expect(service.evaluate(evalInput({ session_id: 'sess-b' })).status).toBe(200)
+    expect(service.evaluate(evalInput({ session_id: 'sess-c' })).status).toBe(200)
+  })
+
+  it('releases a reservation when its evaluation expires (sweep prune)', () => {
+    const { service, advance } = makeService({
+      policy: rateBySender,
+      withLimiters: true,
+      maxSenderKeys: 1,
+      ttlMs: 1000,
+    })
+    service.evaluate(evalSender('U1')) // reserves U1 (pending, never audited)
+    expect(service.evaluate(evalSender('U2')).status).toBe(503)
+
+    advance(2000) // U1's evaluation passes TTL
+    service.sweep() // expires the pending entry and prunes the freed key
+
+    // The slot is now free for a new sender.
+    expect(service.evaluate(evalSender('U2')).status).toBe(200)
+  })
+
+  it('lazily prunes an emptied bucket on a capacity-pressured evaluate', () => {
+    const tightRate = compile({
+      default: 'allow',
+      rules: [
+        {
+          match: { tool: 'send' },
+          action: 'rate_limit',
+          limits: { max_calls: 1, window: '1m', key: 'sender_id' },
+        },
+      ],
+    })
+    const { service, advance } = makeService({
+      policy: tightRate,
+      withLimiters: true,
+      maxSenderKeys: 1,
+    })
+    // U1 consumes its bucket.
+    const ev = service.evaluate(evalSender('U1'))
+    service.audit(auditInput(ev.body['evaluation_id'] as string), 'h')
+
+    advance(61_000) // U1's window slides; its bucket is now empty/evictable
+
+    // A new sender at cap triggers a lazy prune of the dead U1 key → admitted.
+    expect(service.evaluate(evalSender('U2')).status).toBe(200)
   })
 })
 

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -16,11 +16,16 @@
 // ---------------------------------------------------------------------------
 
 import { randomUUID } from 'node:crypto'
-import type { CompiledPolicy, PolicyAction, CompiledLimits } from '../policy/types.js'
+import type {
+  CompiledPolicy,
+  PolicyAction,
+  CompiledLimits,
+  CompiledInstallRule,
+} from '../policy/types.js'
 import { decide } from '../policy/decision-pipeline.js'
 import { ToolAnnotationCache } from '../policy/annotation-cache.js'
 import type { ToolDriftChange } from '../policy/annotation-cache.js'
-import { resolvePath } from '../policy/matchers.js'
+import { resolvePath, matchMetadata } from '../policy/matchers.js'
 import { canonicalize } from '../util/canonical-json.js'
 import type { EvidenceStore } from '../evidence/store.js'
 import type { AuditWriter } from '../audit/writer.js'
@@ -40,6 +45,10 @@ const MAX_TOOLS_PER_ORIGIN = 1_024
 const MAX_TOOL_INPUT_BYTES = 64 * 1_024
 const MAX_PENDING_COUNT = 10_000
 const MAX_PENDING_BYTES = 64 * 1_024 * 1_024
+// Distinct sender_id (caller-controlled) limit keys held in the shared limiters.
+// Capped here in the service (NOT in the limiters) so the evaluate/audit split can
+// reserve pre-execution and the MCP door is never gated (issue #13).
+const MAX_SENDER_KEYS = 50_000
 
 const SWEEP_INTERVAL_MS = 30_000
 
@@ -176,6 +185,8 @@ export interface GovernanceServiceOptions {
   readonly maxPending?: number
   /** Max pending-evaluation footprint (serialized bytes). Default 64 MiB (D15). */
   readonly maxPendingBytes?: number
+  /** Max distinct sender_id limit keys (issue #13). Default 50,000. Overridable for tests. */
+  readonly maxSenderKeys?: number
 }
 
 // ---------------------------------------------------------------------------
@@ -195,7 +206,10 @@ export class GovernanceService {
   private readonly now: () => number
   private readonly maxPending: number
   private readonly maxPendingBytes: number
+  private readonly maxSenderKeys: number
 
+  /** Distinct sender_id limit keys with live state (reservation registry, issue #13). */
+  private readonly senderKeys = new Set<string>()
   private readonly pending = new Map<string, PendingEvaluation>()
   private readonly tombstones = new Map<string, Tombstone>()
   private readonly caches = new Map<string, ToolAnnotationCache>()
@@ -219,6 +233,7 @@ export class GovernanceService {
     this.now = options.now ?? Date.now
     this.maxPending = options.maxPending ?? MAX_PENDING_COUNT
     this.maxPendingBytes = options.maxPendingBytes ?? MAX_PENDING_BYTES
+    this.maxSenderKeys = options.maxSenderKeys ?? MAX_SENDER_KEYS
     this.assertApprovalRouter(this.policy)
 
     const sweepMs = options.sweepIntervalMs ?? SWEEP_INTERVAL_MS
@@ -241,6 +256,15 @@ export class GovernanceService {
   // -------------------------------------------------------------------------
 
   evaluate(req: EvaluateInput): ServiceResult {
+    // Reserved-key invariant: agent_id has its own first-class column, so a
+    // metadata.agent_id would create a conflicting stored value vs the virtual
+    // match-time key. Enforced HERE (service layer) so direct embedders are
+    // covered, not just the HTTP route schema. (issue #13)
+    const reserved = reservedMetadataKey(req.metadata)
+    if (reserved) {
+      return { status: 400, body: { error: 'reserved_metadata_key', key: reserved } }
+    }
+
     // D15 budgets: tool_input size, origin cardinality, pending pressure.
     const inputBytes = byteLength(req.arguments ?? {})
     if (inputBytes > MAX_TOOL_INPUT_BYTES) {
@@ -283,6 +307,8 @@ export class GovernanceService {
       baselineAnnotations: cache.get(toolName),
       currentAnnotations: cache.getCurrent(toolName),
       driftEvent: cache.getDrift(toolName),
+      metadata: req.metadata ?? undefined,
+      agentId: req.agent_id ?? undefined,
     })
 
     const { decision } = pipeline
@@ -294,6 +320,9 @@ export class GovernanceService {
     let limitPlan: LimitPlan | undefined
     let limitsBlock: Record<string, unknown> | undefined
 
+    // sender_id is sourced from adapter metadata (host-enforced path only).
+    const senderId = senderIdOf(req.metadata)
+
     if (pipeline.isDryRun) {
       wire = 'dry_run'
     } else if (decision.action === 'deny') {
@@ -301,12 +330,18 @@ export class GovernanceService {
     } else if (decision.action === 'require_approval') {
       wire = 'require_approval'
     } else if (decision.action === 'rate_limit') {
-      const planned = this.planRate(decision, toolName, req.session_id)
+      const planned = this.planRate(decision, toolName, req.session_id, senderId)
+      if (planned?.plan && !this.reserveSenderKey(planned.plan.key)) {
+        return { status: 503, body: { error: 'limit_capacity_exhausted' } }
+      }
       limitPlan = planned?.plan
       limitsBlock = planned?.block ? { rate: planned.block } : undefined
       wire = planned?.allowed ? 'allow' : 'rate_limited'
     } else if (decision.action === 'spend_limit') {
-      const planned = this.planSpend(decision, toolName, req.session_id, req.arguments)
+      const planned = this.planSpend(decision, toolName, req.session_id, req.arguments, senderId)
+      if (planned?.plan && !this.reserveSenderKey(planned.plan.key)) {
+        return { status: 503, body: { error: 'limit_capacity_exhausted' } }
+      }
       limitPlan = planned?.plan
       limitsBlock = planned?.block ? { spend: planned.block } : undefined
       wire = planned?.allowed ? 'allow' : 'spend_limited'
@@ -550,8 +585,16 @@ export class GovernanceService {
   // -------------------------------------------------------------------------
 
   installScan(req: InstallScanInput): ServiceResult {
+    const reserved = reservedMetadataKey(req.metadata)
+    if (reserved) {
+      return { status: 400, body: { error: 'reserved_metadata_key', key: reserved } }
+    }
     const evaluationId = randomUUID()
     const toolName = `install:${req.package.source ?? 'pkg'}:${req.package.name}`
+
+    const verdict = this.evaluateInstall(req)
+    const denied = verdict.decision === 'deny'
+
     const auditId = this.writeAudit({
       timestampIso: new Date(this.now()).toISOString(),
       origin: req.origin,
@@ -560,10 +603,13 @@ export class GovernanceService {
       toolName,
       toolInput: { ...req.package },
       metadata: req.metadata,
-      action: 'allow',
-      wire: 'allow',
-      matchedRuleName: null,
-      matchedRuleIndex: null,
+      // policy_decision is 'deny' (NOT 'deny_install') so the dashboard renders a
+      // blocked install as a block, not an allow. The install context lives in
+      // record_kind + block_reason.
+      action: denied ? 'deny' : 'allow',
+      wire: denied ? 'deny' : 'allow',
+      matchedRuleName: verdict.matchedRule?.name ?? null,
+      matchedRuleIndex: verdict.matchedRule?.index ?? null,
       flaggedDestructive: false,
       dryRun: false,
       recordKind: 'install_scan',
@@ -574,15 +620,48 @@ export class GovernanceService {
       finalizedBy: 'evaluate',
       expiresAtMs: this.now() + this.ttlMs,
     })
+
+    const body: Record<string, unknown> = {
+      evaluation_id: evaluationId,
+      decision: verdict.decision,
+      reason: verdict.reason,
+      matched_rule: verdict.matchedRule?.name ?? null,
+      matched_rule_index: verdict.matchedRule?.index ?? null,
+    }
+    if (denied) {
+      body['feedback'] = buildFeedback(verdict.matchedRule, verdict.reason)
+    }
+    return { status: 200, body }
+  }
+
+  /** First-match-wins evaluation of the compiled install policy (issue #13). */
+  private evaluateInstall(req: InstallScanInput): {
+    decision: 'allow' | 'deny'
+    matchedRule?: CompiledInstallRule
+    reason: string
+  } {
+    const install = this.policy.install
+    if (!install) {
+      return { decision: 'allow', reason: 'no install-time rules defined' }
+    }
+    const metadataView =
+      req.agent_id != null
+        ? { ...(req.metadata ?? {}), agent_id: req.agent_id }
+        : (req.metadata ?? undefined)
+
+    for (const rule of install.rules) {
+      if (matchInstallRule(rule, req.package, metadataView)) {
+        const label = rule.name ? `"${rule.name}"` : `install_rule[${String(rule.index)}]`
+        return {
+          decision: rule.action === 'deny_install' ? 'deny' : 'allow',
+          matchedRule: rule,
+          reason: `Matched ${label} → ${rule.action}`,
+        }
+      }
+    }
     return {
-      status: 200,
-      body: {
-        evaluation_id: evaluationId,
-        decision: 'allow',
-        reason: 'no install-time rules defined',
-        matched_rule: null,
-        matched_rule_index: null,
-      },
+      decision: install.defaultAction,
+      reason: `No matching install rule; default ${install.defaultAction}`,
     }
   }
 
@@ -639,6 +718,59 @@ export class GovernanceService {
     for (const [id, tomb] of this.tombstones) {
       if (tomb.expiresAtMs <= now) this.tombstones.delete(id)
     }
+    this.pruneSenderKeys()
+  }
+
+  /**
+   * Reserve a cardinality slot for a sender-keyed limit (issue #13).
+   *
+   * Only `sender:*` keys are gated — tool/session families are bounded by upstream
+   * cardinality, and the MCP path never reaches here, so structural traffic cannot
+   * be starved. A key already backed by live state (registry or a live limiter
+   * bucket) costs no new slot. At capacity we lazily prune dead keys before failing
+   * closed, so an emptied bucket frees its slot without waiting for the sweep.
+   */
+  private reserveSenderKey(key: string): boolean {
+    if (!key.startsWith('sender:')) return true
+    if (this.senderKeys.has(key)) return true
+    if (this.hasLiveBucket(key)) {
+      this.senderKeys.add(key)
+      return true
+    }
+    if (this.senderKeys.size >= this.maxSenderKeys) {
+      this.pruneSenderKeys()
+      if (this.senderKeys.size >= this.maxSenderKeys) return false
+    }
+    this.senderKeys.add(key)
+    return true
+  }
+
+  /** Drop registry keys with no pending evaluation AND no live limiter bucket. */
+  private pruneSenderKeys(): void {
+    if (this.senderKeys.size === 0) return
+    const inUse = new Set<string>()
+    for (const entry of this.pending.values()) {
+      if (entry.limitPlan && entry.limitPlan.key.startsWith('sender:')) {
+        inUse.add(entry.limitPlan.key)
+      }
+    }
+    for (const key of this.senderKeys) {
+      if (inUse.has(key)) continue
+      if (this.hasLiveBucket(key)) continue
+      this.senderKeys.delete(key)
+    }
+  }
+
+  /**
+   * Whether either limiter still holds a live bucket for `key`. Uses the public
+   * `getKeyState()` — never the limiters' private maps — and its lazy eviction of
+   * an emptied bucket IS the prune-on-touch mechanism.
+   */
+  private hasLiveBucket(key: string): boolean {
+    return (
+      this.rateLimiter?.getKeyState(key) !== undefined ||
+      this.spendLimiter?.getKeyState(key) !== undefined
+    )
   }
 
   close(): void {
@@ -651,6 +783,7 @@ export class GovernanceService {
     this.pending.clear()
     this.tombstones.clear()
     this.caches.clear()
+    this.senderKeys.clear()
     this.pendingBytes = 0
   }
 
@@ -734,12 +867,13 @@ export class GovernanceService {
     decision: ReturnType<typeof decide>['decision'],
     toolName: string,
     sessionId: string | null,
+    senderId: string | null,
   ): { plan?: LimitPlan; block?: Record<string, unknown>; allowed: boolean } | undefined {
     const limits = decision.matchedRule?.limits
     if (!this.rateLimiter || !limits?.maxCalls || !limits.windowMs) {
       return { allowed: true }
     }
-    const key = buildLimitKey(limits.key, toolName, sessionId)
+    const key = buildLimitKey(limits.key, toolName, sessionId, senderId)
     const peek = this.rateLimiter.peek({
       key,
       maxCalls: limits.maxCalls,
@@ -762,11 +896,12 @@ export class GovernanceService {
     toolName: string,
     sessionId: string | null,
     args: Record<string, unknown> | undefined,
+    senderId: string | null,
   ): { plan?: LimitPlan; block?: Record<string, unknown>; allowed: boolean } | undefined {
     const maxSpend = decision.matchedRule?.limits?.maxSpend
     if (!this.spendLimiter || !maxSpend) return { allowed: true }
 
-    const key = buildLimitKey(maxSpend.key, toolName, sessionId)
+    const key = buildLimitKey(maxSpend.key, toolName, sessionId, senderId)
     const rawAmount = resolvePath(maxSpend.field, args ?? {})
     if (typeof rawAmount !== 'number' || !Number.isFinite(rawAmount) || rawAmount < 0) {
       // Invalid amount — terminal block (mirrors the MCP invalid-amount deny).
@@ -929,6 +1064,9 @@ interface WriteAuditArgs {
 
 function deriveBlockReason(args: WriteAuditArgs): string | null {
   if (args.recordKind === 'evaluation_expired') return null // bypass signal, not a block (F4)
+  // Install-time denials get their own block_reason so #16 can discriminate them
+  // and so they count into blocked_total (issue #13).
+  if (args.recordKind === 'install_scan') return args.wire === 'deny' ? 'install_denied' : null
   if (args.dryRun) return null
   if (args.approvalStatus === 'denied') return 'approval_denied'
   if (args.approvalStatus === 'timeout') return 'approval_timeout'
@@ -972,18 +1110,52 @@ function policyCanRequireApproval(policy: CompiledPolicy): boolean {
 }
 
 function buildLimitKey(
-  keyType: 'tool' | 'agent' | 'session' | undefined,
+  keyType: 'tool' | 'agent' | 'session' | 'sender_id' | undefined,
   toolName: string,
   sessionId: string | null,
+  senderId: string | null,
 ): string {
   switch (keyType) {
     case 'session':
       return `session:${sessionId ?? 'unknown'}`
+    case 'sender_id':
+      return `sender:${senderId ?? 'unknown'}`
     case 'agent':
     case 'tool':
     default:
       return `tool:${toolName}`
   }
+}
+
+/** Read a string sender_id out of the adapter metadata, else null. */
+function senderIdOf(metadata: Record<string, unknown> | null): string | null {
+  const v = metadata?.['sender_id']
+  return typeof v === 'string' ? v : null
+}
+
+/** Match one compiled install rule against a package + metadata view (issue #13). */
+function matchInstallRule(
+  rule: CompiledInstallRule,
+  pkg: InstallScanInput['package'],
+  metadataView: Readonly<Record<string, unknown>> | undefined,
+): boolean {
+  if (rule.match.name && !rule.match.name.test(pkg.name)) return false
+  if (rule.match.source !== undefined && rule.match.source !== pkg.source) return false
+  if (rule.match.metadata && !matchMetadata(rule.match.metadata, { metadata: metadataView })) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Keys that have a first-class column and therefore must not be smuggled inside the
+ * free-form metadata object (issue #13). Returns the offending key or null.
+ */
+function reservedMetadataKey(metadata: Record<string, unknown> | null): string | null {
+  if (metadata && Object.prototype.hasOwnProperty.call(metadata, 'agent_id')) {
+    return 'agent_id'
+  }
+  return null
 }
 
 function definitionProvided(tool: WireToolDefinition): boolean {

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -9,10 +9,10 @@
 //   /approval/:id/resolve → record a natively-handled approval
 //
 // This service owns the decision pipeline reuse (shared with the MCP path),
-// the pending-evaluation registry with TTL + memory budgets (D4/D15), per-
-// origin drift caches (D6), idempotent finalize semantics (D5), and the
-// native-approval deadline rules (D10). It deliberately holds NO HTTP concern;
-// the route layer (governance-api.ts) validates and adapts.
+// the pending-evaluation registry with TTL + memory budgets, per-origin drift
+// caches, idempotent finalize semantics, and the native-approval deadline
+// rules. It deliberately holds NO HTTP concern; the route layer
+// (governance-api.ts) validates and adapts.
 // ---------------------------------------------------------------------------
 
 import { randomUUID } from 'node:crypto'
@@ -37,7 +37,7 @@ import type { SpendLimiter } from '../policy/spend-limiter.js'
 import { GovernanceConfigError } from './errors.js'
 
 // ---------------------------------------------------------------------------
-// Memory budgets (D15) — constants in v1, tunable later without contract change
+// Memory budgets (issue #12) — constants in v1, tunable later without contract change
 // ---------------------------------------------------------------------------
 
 const MAX_ORIGINS = 32
@@ -56,7 +56,7 @@ const SWEEP_INTERVAL_MS = 30_000
 // Wire-facing types (snake_case crosses the boundary; the route layer maps)
 // ---------------------------------------------------------------------------
 
-/** The outcome vocabulary adapters branch on (D8) — never internal rule actions. */
+/** The outcome vocabulary adapters branch on — never internal rule actions. */
 export type WireDecision =
   | 'allow'
   | 'deny'
@@ -181,9 +181,9 @@ export interface GovernanceServiceOptions {
   readonly now?: () => number
   /** Sweep interval (ms). 0 disables the periodic GC backstop. Default 30s. */
   readonly sweepIntervalMs?: number
-  /** Max pending evaluations (count). Default 10,000 (D15). Overridable for tests. */
+  /** Max pending evaluations (count). Default 10,000. Overridable for tests. */
   readonly maxPending?: number
-  /** Max pending-evaluation footprint (serialized bytes). Default 64 MiB (D15). */
+  /** Max pending-evaluation footprint (serialized bytes). Default 64 MiB. */
   readonly maxPendingBytes?: number
   /** Max distinct sender_id limit keys (issue #13). Default 50,000. Overridable for tests. */
   readonly maxSenderKeys?: number
@@ -214,7 +214,7 @@ export class GovernanceService {
   private readonly tombstones = new Map<string, Tombstone>()
   private readonly caches = new Map<string, ToolAnnotationCache>()
   /** Native approval ticket id → its pending evaluation id, for on-access
-   * deadline enforcement on the resolve path (R4-1). */
+   * deadline enforcement on the resolve path. */
   private readonly ticketToEvaluation = new Map<string, string>()
   private pendingBytes = 0
   private sweepTimer: ReturnType<typeof setInterval> | null = null
@@ -265,7 +265,7 @@ export class GovernanceService {
       return { status: 400, body: { error: 'reserved_metadata_key', key: reserved } }
     }
 
-    // D15 budgets: tool_input size, origin cardinality, pending pressure.
+    // Memory budgets: tool_input size, origin cardinality, pending pressure.
     const inputBytes = byteLength(req.arguments ?? {})
     if (inputBytes > MAX_TOOL_INPUT_BYTES) {
       return { status: 413, body: { error: 'tool_input_too_large' } }
@@ -286,7 +286,7 @@ export class GovernanceService {
     const cache = this.cacheFor(req.origin)
     const toolName = req.tool.name
 
-    // Drift guard (D6): merge the supplied definition into the per-origin
+    // Drift guard: merge the supplied definition into the per-origin
     // cache. A first-seen tool past the per-origin cap is refused fail-closed;
     // updates to already-baselined tools always proceed.
     const hasDefinition = definitionProvided(req.tool)
@@ -374,7 +374,7 @@ export class GovernanceService {
       responseBody['tool_drift'] = { changes: pipeline.driftEvent.changes }
     }
 
-    // Terminal decisions (D5): audit immediately, tombstone, no pending entry.
+    // Terminal decisions: audit immediately, tombstone, no pending entry.
     if (isTerminalAtEvaluate(wire)) {
       const auditId = this.writeAudit({
         timestampIso,
@@ -469,7 +469,7 @@ export class GovernanceService {
   audit(req: AuditInput, payloadHash: string): ServiceResult {
     const id = req.evaluation_id
 
-    // Idempotency: a prior finalize leaves a tombstone (D5 response matrix).
+    // Idempotency: a prior finalize leaves a tombstone.
     const tomb = this.tombstones.get(id)
     if (tomb) {
       if (tomb.finalizedBy === 'expired') {
@@ -502,13 +502,13 @@ export class GovernanceService {
       return { status: 404, body: { error: 'evaluation_unknown' } }
     }
 
-    // On-access deadline enforcement (R4-1): apply any crossed deadline before
+    // On-access deadline enforcement: apply any crossed deadline before
     // handling, so behavior is deterministic regardless of sweep timing.
     if (this.enforceDeadlines(entry) === 'expired') {
       return { status: 404, body: { error: 'evaluation_expired' } }
     }
 
-    // require_approval must be resolved before auditing (D10). Retryable.
+    // require_approval must be resolved before auditing. Retryable.
     let approvalStatus: string | null = null
     let approvedBy: string | null = null
     if (entry.approvalTicketId) {
@@ -521,7 +521,7 @@ export class GovernanceService {
       approvedBy = ticket.resolved_by ?? null
     }
 
-    // Validate the optional post-hoc spend override (§4 actual_amount policy).
+    // Validate the optional post-hoc spend override.
     // Done before any state mutation: a bad value is an adapter bug we reject
     // explicitly rather than letting it throw inside the limiter.
     if (req.actual_amount !== undefined) {
@@ -535,7 +535,7 @@ export class GovernanceService {
 
     const callHappened = req.status === 'success' || req.status === 'error'
 
-    // Consume limit counters now (D3) — only when the call actually executed.
+    // Consume limit counters now — only when the call actually executed.
     let limitsChain: Record<string, unknown> | undefined
     if (callHappened && entry.limitPlan) {
       limitsChain = this.commitLimit(entry.limitPlan, req.actual_amount)
@@ -581,7 +581,7 @@ export class GovernanceService {
   }
 
   // -------------------------------------------------------------------------
-  // POST /install-scan (observational until #13 — D9)
+  // POST /install-scan — evaluates install-time policy (issue #13)
   // -------------------------------------------------------------------------
 
   installScan(req: InstallScanInput): ServiceResult {
@@ -666,7 +666,7 @@ export class GovernanceService {
   }
 
   // -------------------------------------------------------------------------
-  // POST /approval/:id/resolve (D10)
+  // POST /approval/:id/resolve
   // -------------------------------------------------------------------------
 
   resolveApproval(ticketId: string, req: ResolveApprovalInput): ServiceResult {
@@ -681,7 +681,7 @@ export class GovernanceService {
       return { status: 409, body: { error: 'not_a_native_ticket' } }
     }
 
-    // On-access deadline enforcement (R4-1): a resolve arriving after the
+    // On-access deadline enforcement: a resolve arriving after the
     // ticket/evaluation deadline but before the sweep must not succeed. Apply
     // any crossed deadline to the linked evaluation first, then read the ticket
     // post-transition — exactly as the /audit path does.
@@ -707,7 +707,7 @@ export class GovernanceService {
   }
 
   // -------------------------------------------------------------------------
-  // Sweep — GC backstop for callers that never return (D4/D10/R4-1)
+  // Sweep — GC backstop for callers that never return
   // -------------------------------------------------------------------------
 
   sweep(): void {
@@ -1063,7 +1063,7 @@ interface WriteAuditArgs {
 }
 
 function deriveBlockReason(args: WriteAuditArgs): string | null {
-  if (args.recordKind === 'evaluation_expired') return null // bypass signal, not a block (F4)
+  if (args.recordKind === 'evaluation_expired') return null // bypass signal, not a block
   // Install-time denials get their own block_reason so #16 can discriminate them
   // and so they count into blocked_total (issue #13).
   if (args.recordKind === 'install_scan') return args.wire === 'deny' ? 'install_denied' : null


### PR DESCRIPTION
## Description

Adds three context-aware policy primitives for hook-based (host-enforced) adapters, building on the #12 sideband governance API. Third step of the OpenClaw adapter runway (#12 → #13 → #16 → #11).

- **`match.metadata.*`** — rules can match on adapter-supplied context (`channel_id`, `sender_id`, `sender_name`, `conversation_id`) plus a virtual `agent_id` key (read from the request column). Bare-string = `eq`, or an operator object (`eq`/`neq`/`contains`/`regex`, regex through the existing ReDoS analyzer). Threaded through the shared decision pipeline; **inert on the MCP path by construction** (no metadata there). Reserved `agent_id` inside `metadata` is rejected as a service-layer invariant (`400 reserved_metadata_key`).
- **`scope: by: sender_id`** — rate/spend limits keyed per adapter sender, backed by a `GovernanceService` reservation registry that caps distinct sender keys (fail-closed, `sender:*`-scoped only, default 50k) so caller-minted sender ids cannot starve the shared MCP-path limiter. Rejected at config when `sdk.enabled` is false; falls back to `tool:` with a warning on the MCP path.
- **`deny_install`** — install-time policy (`policies.install`) evaluated by `POST /install-scan`. Blocked installs persist `policy_decision: deny` + `block_reason: install_denied` and render as a deny in the dashboard.

MCP-path behavior is unchanged (the full existing proxy suite passes); docs (`policies.md`, `adapter-api.md`, `audit.md`) updated alongside the code.

Closes #13

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [x] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. **`match.metadata`** — add a rule `match: { metadata: { channel_id: "C1" } }, action: deny`, enable the SDK sideband (`sdk.enabled: true`), and `POST /evaluate` with `metadata: { channel_id: "C1" }` → `decision: deny`; with `channel_id: "C2"` or no metadata → `allow`. Confirm the same rule never fires on the MCP path.
2. **`sender_id` limits** — a `rate_limit` rule with `limits: { key: sender_id, … }`: two `/evaluate→/audit` loops for the same `sender_id` consume one bucket; a different sender is independent. Set `sdk.enabled: false` and confirm `helio validate` rejects `key: sender_id`.
3. **`deny_install`** — add `policies.install.rules` with a `deny_install` rule (`match: { name: "evil-*", source: npm }`), `POST /install-scan` a matching package → `decision: deny`, and confirm the audit row shows `record_kind: install_scan` + `block_reason: install_denied`.
4. **Reserved key** — `POST /evaluate` with `metadata: { agent_id: "x" }` → `400 reserved_metadata_key`.
5. `pnpm --filter @gethelio/proxy test` (1565) and `pnpm --filter @gethelio/dashboard test` (281) — full suites pass.

## Additional Context

<!-- Screenshots, config snippets, performance benchmarks, or anything else that helps reviewers. -->
