### PR TITLE
feat(proxy): surface audit-only (allow-all) default at startup and in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ This single package includes the built-in dashboard UI bundle.
 
 ### 2. Configure
 
-`npx @gethelio/proxy init` already created a `helio.yaml` in your project root. Open it and point `upstream.url` at your existing MCP server. Helio v0.1 proxies a single upstream MCP server. A fuller example with policies, audit, and a dashboard secret:
+`npx @gethelio/proxy init` already created a `helio.yaml` in your project root. Open it and point `upstream.url` at your existing MCP server. Helio v0.1 proxies a single upstream MCP server.
+
+> **Heads up — Helio starts in audit-only mode.** `init` scaffolds the `policies` section **commented out**, so out of the box Helio runs with `default: allow` and **zero rules**: it records every tool call to the audit trail but **blocks nothing**. Uncomment and edit `policies` (or paste your own rules) to start enforcing. See the [Policy Guide](./docs/policies.md) for rule syntax.
+
+The block below is an **illustrative target** — not the file `init` writes — showing policies, audit, and a dashboard secret:
 
 ```yaml
 version: '1'

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,9 @@ helio init
 
 ## Step 2: Configure
 
-Open `helio.yaml` and set `upstream.url` to point at your MCP server:
+Open `helio.yaml` and set `upstream.url` to point at your MCP server.
+
+> **Helio starts in audit-only mode.** `helio init` scaffolds the `policies` section **commented out**, so out of the box Helio runs with `default: allow` and **zero rules** — it records every tool call but **blocks nothing** until you add rules. The example below is an **illustrative target** (not the file `init` writes); uncomment and adapt `policies` to start enforcing. See the [Policy Guide](./policies.md) for rule syntax.
 
 ```yaml
 version: '1'
@@ -70,7 +72,7 @@ audit:
   include_responses: true
 ```
 
-This configuration blocks any tool marked as destructive, explicitly allows read-only tools, and falls through to `default: allow` for everything else. Every tool call is recorded to a local SQLite database.
+This example configuration blocks any tool marked as destructive, explicitly allows read-only tools, and falls through to `default: allow` for everything else. Every tool call is recorded to a local SQLite database. (Until you uncomment a `policies` block like this one, the scaffolded config blocks nothing.)
 
 If you use the `${HELIO_DASHBOARD_SECRET}` placeholder above, export it before starting:
 

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -32,6 +32,7 @@ import {
   warnIfWebhookChannelUnreachable,
   warnIfSdkSidebandExposed,
   warnIfDashboardOpenMode,
+  warnIfNoEnforcement,
 } from './startup-warnings.js'
 import { drainForCrash, registerCrashDrainHook } from './crash-drain.js'
 
@@ -526,6 +527,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   console.error(
     `Policies: ${String(ruleCount)} rule${ruleCount !== 1 ? 's' : ''} loaded (default: ${policy.defaultAction})`,
   )
+  warnIfNoEnforcement(policy)
   if (config.upstream.transport === 'stdio') {
     console.error(`Upstream: ${config.upstream.command ?? ''} (stdio)`)
   } else {

--- a/packages/proxy/src/startup-warnings.test.ts
+++ b/packages/proxy/src/startup-warnings.test.ts
@@ -3,6 +3,7 @@ import {
   warnIfWebhookChannelUnreachable,
   warnIfSdkSidebandExposed,
   warnIfDashboardOpenMode,
+  warnIfNoEnforcement,
 } from './startup-warnings.js'
 
 describe('warnIfWebhookChannelUnreachable', () => {
@@ -180,6 +181,63 @@ describe('warnIfDashboardOpenMode', () => {
     const messages: string[] = []
     const warned = warnIfDashboardOpenMode(makeConfig({ allowOpenMode: false }), (m) =>
       messages.push(m),
+    )
+
+    expect(warned).toBe(false)
+    expect(messages).toHaveLength(0)
+  })
+})
+
+describe('warnIfNoEnforcement', () => {
+  function makePolicy(args: {
+    readonly ruleCount?: number
+    readonly defaultAction?: 'allow' | 'deny'
+    readonly dryRun?: boolean
+  }) {
+    return {
+      rules: Array.from({ length: args.ruleCount ?? 0 }, (_, i) => ({ name: `rule-${String(i)}` })),
+      defaultAction: args.defaultAction ?? 'allow',
+      dryRun: args.dryRun,
+    }
+  }
+
+  it('warns when zero rules are loaded and the default action is allow', () => {
+    const messages: string[] = []
+    const warned = warnIfNoEnforcement(makePolicy({ ruleCount: 0, defaultAction: 'allow' }), (m) =>
+      messages.push(m),
+    )
+
+    expect(warned).toBe(true)
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toContain('NOT blocking anything')
+    expect(messages[0]).toContain('audit trail')
+  })
+
+  it('does not warn when at least one rule is loaded', () => {
+    const messages: string[] = []
+    const warned = warnIfNoEnforcement(makePolicy({ ruleCount: 1, defaultAction: 'allow' }), (m) =>
+      messages.push(m),
+    )
+
+    expect(warned).toBe(false)
+    expect(messages).toHaveLength(0)
+  })
+
+  it('does not warn when the default action is deny', () => {
+    const messages: string[] = []
+    const warned = warnIfNoEnforcement(makePolicy({ ruleCount: 0, defaultAction: 'deny' }), (m) =>
+      messages.push(m),
+    )
+
+    expect(warned).toBe(false)
+    expect(messages).toHaveLength(0)
+  })
+
+  it('does not warn in dry-run mode even with zero rules and default allow', () => {
+    const messages: string[] = []
+    const warned = warnIfNoEnforcement(
+      makePolicy({ ruleCount: 0, defaultAction: 'allow', dryRun: true }),
+      (m) => messages.push(m),
     )
 
     expect(warned).toBe(false)

--- a/packages/proxy/src/startup-warnings.ts
+++ b/packages/proxy/src/startup-warnings.ts
@@ -80,3 +80,28 @@ export function warnIfDashboardOpenMode(
   )
   return true
 }
+
+/**
+ * Emit a startup warning when the loaded policy enforces nothing — zero rules
+ * with `default: allow`. In that state Helio records a full audit trail but
+ * blocks no tool calls, which is easy to miss in the "Policies: 0 rules loaded
+ * (default: allow)" line. Dry-run is excluded: it forwards nothing upstream, so
+ * "not blocking" would be misleading.
+ */
+export function warnIfNoEnforcement(
+  policy: {
+    rules: ReadonlyArray<unknown>
+    defaultAction: 'allow' | 'deny'
+    dryRun?: boolean
+  },
+  log: (message: string) => void = console.error,
+): boolean {
+  if (policy.rules.length > 0 || policy.defaultAction !== 'allow' || policy.dryRun) return false
+
+  log(
+    '[helio] No policy rules are loaded and the default action is "allow" - ' +
+      'Helio is recording an audit trail but NOT blocking anything. Add rules ' +
+      'under `policies:` in helio.yaml to start enforcing (see docs/policies.md).',
+  )
+  return true
+}


### PR DESCRIPTION
## Description

Out of the box, `helio init` scaffolds the `policies` section commented out, so
Helio runs with `default: allow` and zero rules. It records a full audit trail
but blocks nothing. This change makes that audit-only state explicit in two
places so it can't be missed:

- proxy: a new `warnIfNoEnforcement(policy)` startup banner, printed right after
  the `Policies: N rules loaded` line when there are zero rules and
  `default: allow`. It is suppressed when there is at least one rule, when
  `default: deny`, and in dry-run (which forwards nothing upstream anyway).
- docs: the README and getting-started now state that `init` scaffolds policies
  commented out (audit-only), label the fuller YAML as an illustrative target
  rather than the generated file, and link the Policy Guide.

Closes #80
Closes #81

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation

## Packages Affected

- [x] `packages/proxy`
- [x] `docs/`

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode, no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (secrets:scan, docs:check:ci, audit, build, lint, format:check, typecheck, test)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow Conventional Commits

## How to Test

1. Build the proxy: `pnpm --filter @gethelio/proxy build:proxy`
2. Start with a config whose `policies` are commented out (or a fresh `helio init`
   config). The banner prints on the line right after
   `Policies: 0 rules loaded (default: allow)`.
3. Add a rule, or set `default: deny`, then restart. The banner no longer prints.

## Additional Context

The startup banner wording and the docs' audit-only phrasing are intentionally
aligned, so the runtime and the docs reinforce the same message.
