### PR TITLE
docs(changelog): record the audit-only startup change under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Maintainer notes:
 - Keep entries user-visible and operator-relevant (new behavior, defaults,
   security posture, and breaking changes).
 
+## [Unreleased]
+
+### Added
+
+- **Audit-only default surfaced at startup and in the docs (#80, #81).** When
+  Helio starts with zero policy rules and `default: allow`, it now prints a
+  startup line noting that it is recording a full audit trail but not blocking
+  anything, so the audit-only posture is not missed. The line is suppressed when
+  at least one rule is loaded, when `default: deny`, or in dry-run. The README
+  and getting-started guides now also state that `helio init` scaffolds the
+  `policies` section commented out (audit-only) until you add rules.
+
 ## [0.6.0] - 2026-06-19
 
 ### Added
@@ -259,8 +271,11 @@ Helio's first public release.
 - Secret scanning is now part of the default quality gate (pre-commit + CI),
   designed to prevent accidental credential commits before merge.
 
-[Unreleased]: https://github.com/gethelio/helio/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/gethelio/helio/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/gethelio/helio/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/gethelio/helio/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/gethelio/helio/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/gethelio/helio/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gethelio/helio/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/gethelio/helio/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/gethelio/helio/releases/tag/v0.1.0


### PR DESCRIPTION
## Description

Backfill the CHANGELOG so the post-v0.6.0 change is recorded under Unreleased,
and repair the version compare links in the footer. Follow-up to #86, which
shipped without a changelog entry. No code or behavior change.

- Add an `## [Unreleased]` section documenting the audit-only startup banner and
  the quickstart docs clarification.
- Fix the `[Unreleased]` compare link to base on v0.6.0 (it still pointed at v0.5.0).
- Add the missing `[0.6.0]`, `[0.4.0]`, and `[0.3.0]` footer compare links so the
  version history is complete and in order.

## Type of Change

- [x] Documentation

## Packages Affected

- [x] Root config / monorepo tooling (`CHANGELOG.md`)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] All CI checks pass
- [x] Commit messages follow Conventional Commits
- [ ] Tests: n/a (docs-only, no behavior change)

## How to Test

1. Open `CHANGELOG.md`; confirm the `Unreleased` section lists the audit-only startup change.
2. Confirm the footer links are complete and descending, and `Unreleased` compares `v0.6.0...HEAD`.
