### PR TITLE
docs(quickstart): add a zero-dependency upstream and agent-free testing paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ dashboard:
 
 If your upstream requires a static credential (for example `Authorization: Bearer …` on a hosted MCP server), set [`upstream.headers`](docs/configuration.md#static-request-headers) — values support `${VAR}` interpolation so secrets stay out of the file.
 
+No MCP server to test against? Helio ships a zero-dependency echo server you can run in one command — see the [Getting Started guide](./docs/getting-started.md#no-mcp-server-to-test-with).
+
 About `dashboard.api_secret`:
 
 - **If you ran `npx @gethelio/proxy init`**, your `helio.yaml` already contains a generated `api_secret` (a literal 32-byte hex value, also printed when you ran `init`). It's set — skip this step.
@@ -148,6 +150,16 @@ npx @gethelio/proxy start
   }
 }
 ```
+
+**No agent handy?** You don't need one to see Helio work. Point the official [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector) at `http://localhost:3000/mcp` (run `npx @modelcontextprotocol/inspector`, transport: Streamable HTTP), or send a call straight through the proxy from the terminal:
+
+```bash
+curl -s -X POST http://localhost:3000/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{"city":"London"}}}'
+```
+
+Either way the call appears in the dashboard with its policy decision. (`get_weather` is one of the demo tools in Helio's [echo server](./docs/getting-started.md#no-mcp-server-to-test-with).)
 
 ### 5. Open the dashboard
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,18 @@ Get Helio running in under 5 minutes. By the end, you'll have an MCP governance 
 
 - **Node.js 22+** — check with `node --version`
 - **`jq` (optional)** — used in examples below for pretty-printing JSON. If unavailable, remove `| jq` and read raw JSON output.
-- **An MCP server to govern** — any server that speaks Streamable HTTP, SSE, or stdio. Helio works with any spec-compliant MCP server (e.g. FastMCP, the official MCP SDKs) with zero changes to the server. If you don't have one, use the echo server included in the [examples](../examples/basic/).
+- **An MCP server to govern** — any server that speaks Streamable HTTP, SSE, or stdio. Helio works with any spec-compliant MCP server (e.g. FastMCP, the official MCP SDKs) with zero changes to the server. **No server to test against?** Use the zero-dependency echo server below — no clone or install needed. (If you've cloned the repo as a contributor, you can instead run the bundled examples with `pnpm start`; see [`examples/basic/`](../examples/basic/).)
+
+### No MCP server to test with?
+
+Helio ships a tiny echo server that speaks MCP over plain `node:http` — no dependencies, no install. Save it and run it on the default upstream port:
+
+```bash
+curl -O https://raw.githubusercontent.com/gethelio/helio/main/examples/_shared/mcp-echo-server.mjs
+node mcp-echo-server.mjs
+```
+
+It prints `MCP echo server listening on http://127.0.0.1:8080/mcp` and exposes a handful of demo tools (`get_weather`, `send_email`, `delete_record`, `create_payment`, `create_refund`) with realistic annotations, so the policy examples below have something meaningful to match. Leave it running in its own terminal — the default `upstream.url` (`http://localhost:8080/mcp`) already points at it.
 
 ## Step 1: Install
 
@@ -129,6 +140,11 @@ Instead of connecting your MCP client directly to the upstream server, point it 
 ```
 
 **Any HTTP MCP client** — change the server URL from `http://localhost:8080/mcp` to `http://localhost:3000/mcp`. The proxy is fully transparent: it forwards all MCP methods unchanged and only intercepts `tools/call` for policy evaluation.
+
+**No client or agent handy?** You don't need one to try Helio:
+
+- **MCP Inspector** — run `npx @modelcontextprotocol/inspector`, choose the Streamable HTTP transport, and point it at `http://localhost:3000/mcp`. Every tool call you make appears in the dashboard with its policy decision.
+- **curl** — send a request straight through the proxy (see [Step 6](#step-6-send-a-test-tool-call) below). This works against any upstream, including the echo server.
 
 ### Error normalization behavior
 


### PR DESCRIPTION
## Description

Smooth two first-time friction points in the quick start so a brand-new npm
user can complete it without a repo clone or an existing agent.

- Point readers without an MCP server at Helio's bundled zero-dependency echo
  server (plain `node:http`, runs with one `curl`-and-`node`), and stop sending
  npm-only users to `examples/basic`, which needs a repo clone and build. The
  contributor path is still documented.
- Give Step 4 an agent-free way to drive a tool call: the MCP Inspector pointed
  at the proxy, or a copy-paste curl smoke test (added to the README, which had
  none).

Closes #83
Closes #84

## Type of Change

- [x] Documentation

## Packages Affected

- [x] `docs/`
- [x] Root config / monorepo tooling (`README.md`)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] All CI checks pass
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow Conventional Commits
- [ ] Tests: n/a (docs-only)

## How to Test

1. In an empty directory, grab the echo server and run it:
   `curl -O https://raw.githubusercontent.com/gethelio/helio/main/examples/_shared/mcp-echo-server.mjs && node mcp-echo-server.mjs`
2. `npx @gethelio/proxy init`, then `npx @gethelio/proxy start`.
3. Run the README curl smoke test against `http://localhost:3000/mcp`; confirm a
   `get_weather` result comes back and shows up in the dashboard.
4. Or point MCP Inspector (`npx @modelcontextprotocol/inspector`) at
   `http://localhost:3000/mcp`.

## Additional Context

Verified end-to-end: downloading the echo server from the raw URL, starting
Helio against it, and running the README curl returns a real `get_weather`
result through the proxy.
