### PR TITLE
docs(config): standardize config section order on the request lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ listen:
 policies:
   default: allow
 
+  # These rules match on tool-name globs (deny / rate-limit / spend-limit):
   rules:
     # Block destructive operations
     - match:
@@ -119,6 +120,8 @@ dashboard:
   port: 3100
   api_secret: '${HELIO_DASHBOARD_SECRET}'
 ```
+
+Omitted fields like `listen.host`, `dashboard.host`, and `audit.path` fall back to safe defaults (`127.0.0.1` for both hosts — loopback only — and `./helio-audit.db`). The [Configuration Reference](./docs/configuration.md) is the authoritative list of every field, its default, and the canonical section order.
 
 If your upstream requires a static credential (for example `Authorization: Bearer …` on a hosted MCP server), set [`upstream.headers`](docs/configuration.md#static-request-headers) — values support `${VAR}` interpolation so secrets stay out of the file.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,14 +36,6 @@ listen:
   port: 3000 # Proxy listening port
   host: '127.0.0.1' # Bind address
 
-dashboard:
-  enabled: true # Serve the dashboard UI
-  port: 3100 # Dashboard API port
-  host: '127.0.0.1' # Dashboard bind address
-  api_secret: 'your-secret' # Manual dashboard login secret + optional Bearer auth for API clients
-  allow_open_mode: false # Explicit local-only opt-in for running without api_secret
-  sse_heartbeat_interval: '30s' # SSE keepalive interval
-
 environment: 'production' # Label for policy matching
 
 policies:
@@ -79,6 +71,14 @@ audit:
   path: ./helio-audit.db # SQLite database file
   retention: '90d' # Auto-delete records older than this
   include_responses: true # Store full upstream responses
+
+dashboard:
+  enabled: true # Serve the dashboard UI
+  port: 3100 # Dashboard API port
+  host: '127.0.0.1' # Dashboard bind address
+  api_secret: 'your-secret' # Manual dashboard login secret + optional Bearer auth for API clients
+  allow_open_mode: false # Explicit local-only opt-in for running without api_secret
+  sse_heartbeat_interval: '30s' # SSE keepalive interval
 
 sdk:
   enabled: false # Enable the Python SDK sideband API
@@ -175,25 +175,6 @@ Where the proxy listens for incoming MCP requests.
 | ------ | ------- | -------- | ----------- | ----------------------- |
 | `port` | integer | No       | `3000`      | Port number (1–65535).  |
 | `host` | string  | No       | `127.0.0.1` | Hostname or IP to bind. |
-
-### dashboard
-
-Configuration for the built-in web dashboard.
-
-When `dashboard.enabled: true`, Helio requires bundled dashboard assets to be present in the proxy package. If assets are missing, `helio start` and `helio validate` fail fast with an explicit error.
-
-> **Security — open dashboard mode:** with `dashboard.enabled: true`, you must either set a non-empty `dashboard.api_secret` or explicitly opt in to local open mode with `dashboard.allow_open_mode: true`. Open mode is allowed only on loopback hosts (`127.0.0.1`, `localhost`, `::1`) and should never be exposed via shared or non-local deployments. If you use `api_secret: '${VAR}'`, a missing `${VAR}` fails config loading; only an explicitly empty value (or omitted secret with open-mode opt-in) runs unauthenticated.
->
-> `helio init` generates a secure `dashboard.api_secret` by default. Do not remove it unless you intentionally want local open mode.
-
-| Field                    | Type     | Required    | Default     | Description                                                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | -------- | ----------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`                | boolean  | No          | `true`      | Enable the dashboard UI and sideband API server.                                                                                                                                                                                                                                                                                                                                       |
-| `port`                   | integer  | No          | `3100`      | Dashboard sideband API port (1–65535).                                                                                                                                                                                                                                                                                                                                                 |
-| `host`                   | string   | No          | `127.0.0.1` | Dashboard sideband bind address.                                                                                                                                                                                                                                                                                                                                                       |
-| `api_secret`             | string   | Conditional | —           | Shared dashboard secret. Required when `dashboard.enabled: true` unless `dashboard.allow_open_mode: true`. Also required whenever any rule uses `action: require_approval` or `policies.flag_destructive: require_approval`. Browser operators enter it once on the dashboard login card to mint an HttpOnly session cookie; machine clients may send `Authorization: Bearer <token>`. |
-| `allow_open_mode`        | boolean  | No          | `false`     | Explicit opt-in to run the dashboard sideband without `api_secret`. Only valid on loopback hosts and intended for trusted local development only.                                                                                                                                                                                                                                      |
-| `sse_heartbeat_interval` | duration | No          | `30s`       | Interval between SSE keepalive messages.                                                                                                                                                                                                                                                                                                                                               |
 
 ### environment
 
@@ -295,6 +276,25 @@ Audit rows also include:
 
 - `environment` — runtime environment label captured at decision time (nullable if unset)
 - `matched_rule_index` — zero-based rule index when a rule matched; `null` when default policy applied
+
+### dashboard
+
+Configuration for the built-in web dashboard.
+
+When `dashboard.enabled: true`, Helio requires bundled dashboard assets to be present in the proxy package. If assets are missing, `helio start` and `helio validate` fail fast with an explicit error.
+
+> **Security — open dashboard mode:** with `dashboard.enabled: true`, you must either set a non-empty `dashboard.api_secret` or explicitly opt in to local open mode with `dashboard.allow_open_mode: true`. Open mode is allowed only on loopback hosts (`127.0.0.1`, `localhost`, `::1`) and should never be exposed via shared or non-local deployments. If you use `api_secret: '${VAR}'`, a missing `${VAR}` fails config loading; only an explicitly empty value (or omitted secret with open-mode opt-in) runs unauthenticated.
+>
+> `helio init` generates a secure `dashboard.api_secret` by default. Do not remove it unless you intentionally want local open mode.
+
+| Field                    | Type     | Required    | Default     | Description                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | -------- | ----------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                | boolean  | No          | `true`      | Enable the dashboard UI and sideband API server.                                                                                                                                                                                                                                                                                                                                       |
+| `port`                   | integer  | No          | `3100`      | Dashboard sideband API port (1–65535).                                                                                                                                                                                                                                                                                                                                                 |
+| `host`                   | string   | No          | `127.0.0.1` | Dashboard sideband bind address.                                                                                                                                                                                                                                                                                                                                                       |
+| `api_secret`             | string   | Conditional | —           | Shared dashboard secret. Required when `dashboard.enabled: true` unless `dashboard.allow_open_mode: true`. Also required whenever any rule uses `action: require_approval` or `policies.flag_destructive: require_approval`. Browser operators enter it once on the dashboard login card to mint an HttpOnly session cookie; machine clients may send `Authorization: Bearer <token>`. |
+| `allow_open_mode`        | boolean  | No          | `false`     | Explicit opt-in to run the dashboard sideband without `api_secret`. Only valid on loopback hosts and intended for trusted local development only.                                                                                                                                                                                                                                      |
+| `sse_heartbeat_interval` | duration | No          | `30s`       | Interval between SSE keepalive messages.                                                                                                                                                                                                                                                                                                                                               |
 
 ### sdk
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,15 +51,10 @@ upstream:
 
 listen:
   port: 3000
-  host: '127.0.0.1'
-
-dashboard:
-  enabled: true
-  port: 3100
-  api_secret: '${HELIO_DASHBOARD_SECRET}'
 
 policies:
   default: allow
+  # These rules match on MCP tool annotations (readOnlyHint / destructiveHint):
   rules:
     - name: block-destructive
       match:
@@ -78,10 +73,16 @@ policies:
 
 audit:
   storage: sqlite
-  path: ./helio-audit.db
   retention: 90d
   include_responses: true
+
+dashboard:
+  enabled: true
+  port: 3100
+  api_secret: '${HELIO_DASHBOARD_SECRET}'
 ```
+
+Omitted fields like `listen.host`, `dashboard.host`, and `audit.path` fall back to safe defaults (`127.0.0.1` for both hosts — loopback only — and `./helio-audit.db`). The section order here (`upstream → listen → policies → audit → dashboard`) matches what `helio init` scaffolds and the [Configuration Reference](./configuration.md).
 
 This example configuration blocks any tool marked as destructive, explicitly allows read-only tools, and falls through to `default: allow` for everything else. Every tool call is recorded to a local SQLite database. (Until you uncomment a `policies` block like this one, the scaffolded config blocks nothing.)
 

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -113,18 +113,6 @@ upstream:
 #   headers:
 #     Authorization: "Bearer \${UPSTREAM_TOKEN}"
 
-# Operator dashboard + approval REST API. Bound to 127.0.0.1 by default — do
-# not change to 0.0.0.0 without putting an authenticating reverse proxy in
-# front. dashboard.api_secret is the manual dashboard login secret and also
-# supports machine Bearer auth for sideband API clients. Store it safely; it
-# stays valid until you rotate it. Rotate by editing this file and restarting
-# (or hot-reloading) the proxy. Rotation invalidates active dashboard sessions.
-dashboard:
-  enabled: true
-  port: 3100
-  host: 127.0.0.1
-  api_secret: "${apiSecret}"
-
 # listen:
 #   port: 3000
 #   host: 127.0.0.1
@@ -144,6 +132,18 @@ dashboard:
 #   path: ./helio-audit.db
 #   retention: 90d
 #   include_responses: true
+
+# Operator dashboard + approval REST API. Bound to 127.0.0.1 by default — do
+# not change to 0.0.0.0 without putting an authenticating reverse proxy in
+# front. dashboard.api_secret is the manual dashboard login secret and also
+# supports machine Bearer auth for sideband API clients. Store it safely; it
+# stays valid until you rotate it. Rotate by editing this file and restarting
+# (or hot-reloading) the proxy. Rotation invalidates active dashboard sessions.
+dashboard:
+  enabled: true
+  port: 3100
+  host: 127.0.0.1
+  api_secret: "${apiSecret}"
 
 # sdk:
 #   enabled: false


### PR DESCRIPTION
## Description

Standardize the config section order across the README quick start, the
getting-started guide, the `init` scaffold, and the Configuration Reference,
which had all drifted apart. Settle on one order that follows the request
lifecycle (wire, govern, record, observe):

`upstream → listen → policies → approval → audit → dashboard → sdk`

This keeps `policies` (the core) right after the wiring, puts `approval` beside
the policy action it serves, places the `dashboard` after the audit trail and
approval queue it visualizes, and leaves the optional `sdk` last.

Closes #82

## Type of Change

- [x] Documentation

## Packages Affected

- [x] `docs/`
- [x] Root config / monorepo tooling (`README.md`)
- [x] `packages/proxy` (the `init` scaffold template only — no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] ESLint + Prettier pass
- [x] All CI checks pass (1596 tests, typecheck, lint, format)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow Conventional Commits
- [ ] Tests: n/a (presentational; `init` output reordered, verified still schema-valid)

## How to Test

1. `npx @gethelio/proxy init` and confirm the scaffold reads
   `upstream → listen → policies → approval → audit → dashboard → sdk`.
2. Compare against the README and getting-started samples and `configuration.md` — all match.
