### PR TITLE
docs(quickstart): clarify dashboard login, SDK-token scope, and how to open the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This single package includes the built-in dashboard UI bundle.
 
 ### 2. Configure
 
-`npx @gethelio/proxy init` already created a `helio.yaml` in your project root. Open it and point `upstream.url` at your existing MCP server. Helio v0.1 proxies a single upstream MCP server.
+`npx @gethelio/proxy init` already created a `helio.yaml` in your project root. Open it (e.g. `nano helio.yaml`, or in your editor) and point `upstream.url` at your existing MCP server. Helio v0.1 proxies a single upstream MCP server.
 
 > **Heads up — Helio starts in audit-only mode.** `init` scaffolds the `policies` section **commented out**, so out of the box Helio runs with `default: allow` and **zero rules**: it records every tool call to the audit trail but **blocks nothing**. Uncomment and edit `policies` (or paste your own rules) to start enforcing. See the [Policy Guide](./docs/policies.md) for rule syntax.
 
@@ -170,6 +170,8 @@ Either way the call appears in the dashboard with its policy decision. (`get_wea
 http://localhost:3100
 ```
 
+If prompted, log in with the `dashboard.api_secret` that `init` generated (also printed when you ran it).
+
 That's it. Every tool call now passes through Helio with a full audit trail, rate limits, and spend controls.
 
 Want human-in-the-loop approvals for write operations? See [docs/approvals.md](./docs/approvals.md) for the full Slack and dashboard approval flow, or copy [examples/slack-approvals/](./examples/slack-approvals/) as a starting point.
@@ -212,7 +214,7 @@ with HelioContext() as ctx:
     ctx.mark_evidence("orders.lookup", "order_data", result)
 ```
 
-The SDK talks to the proxy over the sideband API (default `127.0.0.1:3200`; bind host is configurable via `sdk.host`). On every `helio start` the proxy generates a fresh 32-byte hex token and prints it to stderr:
+The SDK talks to the proxy over the sideband API (default `127.0.0.1:3200`; bind host is configurable via `sdk.host`). When the SDK sideband is enabled (`sdk.enabled: true`, off by default), the proxy generates a fresh 32-byte hex token on every `helio start` and prints it to stderr:
 
 ```
 SDK sideband listening on http://127.0.0.1:3200


### PR DESCRIPTION
## Description

Three small README polish fixes in the quick start.

- Step 5 now reminds the reader to log in with the `dashboard.api_secret` that
  `init` generated (after `init`, the dashboard shows a login screen the README
  never mentioned).
- The SDK-token paragraph is scoped to `sdk.enabled: true` (off by default), so
  readers don't expect a token line that only prints when the sideband is enabled.
- Step 2 gains a short "open it" hint.

Closes #85

## Type of Change

- [x] Documentation

## Packages Affected

- [x] Root config / monorepo tooling (`README.md`)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] ESLint + Prettier pass
- [x] All CI checks pass
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow Conventional Commits
- [ ] Tests: n/a (README-only, no behavior change)

## How to Test

1. Read README Step 5 — confirms the login reminder.
2. Read the Evidence Grounding SDK-token note — confirms it's scoped to `sdk.enabled: true`.
