### PR TITLE
fix(dashboard): make login-secret copy deployment-neutral

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -66,7 +66,7 @@ export function App() {
   async function handleLogin(event: SyntheticEvent<HTMLFormElement, SubmitEvent>): Promise<void> {
     event.preventDefault()
     if (!secretInput.trim()) {
-      setAuthMessage('Enter the dashboard secret from helio.yaml.')
+      setAuthMessage('Enter the dashboard secret from your Helio config.')
       return
     }
     setViewState('authenticating')
@@ -81,7 +81,7 @@ export function App() {
       setCsrfToken(undefined)
       setViewState('locked')
       if (error instanceof ApiError && error.status === 401) {
-        setAuthMessage('Invalid dashboard secret. Check helio.yaml and try again.')
+        setAuthMessage('Invalid dashboard secret. Check your Helio config and try again.')
       } else {
         setAuthMessage('Sign in failed due to a network or server error. Try again.')
       }
@@ -121,8 +121,9 @@ export function App() {
         >
           <h1 className="text-lg font-semibold text-gray-900">Dashboard Locked</h1>
           <p className="mt-2 text-sm text-gray-600">
-            Enter the dashboard secret configured in <code>helio.yaml</code> under{' '}
-            <code>dashboard.api_secret</code>.
+            Enter your dashboard secret, the <code>dashboard.api_secret</code> value from your Helio
+            config. If that is an env placeholder (for example{' '}
+            <code>{'${HELIO_DASHBOARD_SECRET}'}</code>), enter the value it resolves to.
           </p>
           <label
             htmlFor="dashboard-secret"


### PR DESCRIPTION
## Description

The dashboard lock screen told users to read the secret from `helio.yaml`
under `dashboard.api_secret`. That is correct only when the value is a literal
in the file (the `helio init` case). Deployments that use the documented
`${VAR}` indirection, including the Docker quickstart and hand-authored configs,
keep the value in the environment, so the old wording pointed those users at a
placeholder.

Rewords the three auth-screen strings in `packages/dashboard/src/App.tsx` to
name the Helio config without assuming a literal, and to tell env-placeholder
users to enter the value the placeholder resolves to. Copy only, no behavior
change.

New copy:

- Empty secret: "Enter the dashboard secret from your Helio config."
- Invalid secret: "Invalid dashboard secret. Check your Helio config and try again."
- Lock card: "Enter your dashboard secret, the `dashboard.api_secret` value from
  your Helio config. If that is an env placeholder (for example
  `${HELIO_DASHBOARD_SECRET}`), enter the value it resolves to."

Closes #94

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Packages Affected

- [x] `packages/dashboard`

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode, no `any` types or `@ts-ignore` without justification
- [ ] I have added or updated tests for my changes
- [x] All CI checks pass
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow Conventional Commits

Copy-only change. No test asserts these strings (verified), so there is nothing
to update; the rendered result was confirmed against a Docker build.

## How to Test

1. Start the proxy with `dashboard.api_secret` set (any config, or the Docker
   quickstart).
2. Open the dashboard at http://localhost:3100 without a session (incognito, or
   click Logout) to reach the lock screen.
3. Confirm the card reads "Enter your dashboard secret, the `dashboard.api_secret`
   value from your Helio config..." and that `${HELIO_DASHBOARD_SECRET}` renders
   literally.

## Additional Context

Verified by rebuilding the Docker image and rendering the lock screen: the new
copy displays correctly, with the env placeholder shown literally. Lint,
format:check, typecheck, and the dashboard build all pass.
