### PR TITLE
test(ci): smoke-test the docker compose demo stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,48 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: false
-          tags: helio:ci-${{ github.sha }}
+          load: true
+          tags: helio:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Validate the demo config
+        working-directory: docker
+        run: |
+          docker run --rm \
+            -e HELIO_DASHBOARD_SECRET=ci-placeholder \
+            -v "$PWD/helio.docker.yaml:/config/helio.yaml:ro" \
+            helio:ci node packages/proxy/dist/cli.js validate -c /config/helio.yaml
+
+      - name: Assert the missing-secret guard aborts with the documented message
+        working-directory: docker
+        run: |
+          # With the secret unset, `docker compose config` must abort (non-zero)
+          # AND print the documented remediation. Assert both, so neither the
+          # fail-closed behavior nor the message can drift from the README.
+          if out=$(docker compose --env-file /dev/null config 2>&1); then
+            echo "guard did not fire: compose config exited 0 with the secret unset"
+            echo "$out"
+            exit 1
+          fi
+          if ! grep -q 'required variable HELIO_DASHBOARD_SECRET is missing' <<<"$out"; then
+            echo "missing-secret guard message drifted from the README:"
+            echo "$out"
+            exit 1
+          fi
+          echo "ok: missing-secret guard aborts with the documented message"
+
+      - name: Smoke test the compose stack
+        working-directory: docker
+        run: |
+          echo "HELIO_DASHBOARD_SECRET=$(openssl rand -hex 32)" > .env
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml \
+            up -d --no-build --wait --wait-timeout 120
+          ../scripts/docker-smoke.sh
+
+      - name: Tear down the compose stack
+        if: always()
+        working-directory: docker
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v || true
+          rm -f .env

--- a/docker/README.md
+++ b/docker/README.md
@@ -170,10 +170,11 @@ OAuth, etc.).
 
 ## What's in this directory
 
-| File                  | Purpose                                                                                         |
-| --------------------- | ----------------------------------------------------------------------------------------------- |
-| `Dockerfile`          | 4-stage build (deps, build, prod-deps, runtime) with `tini`, a non-root user, and a healthcheck |
-| `docker-compose.yml`  | Orchestrates `helio` + `mcp-server` (the demo upstream)                                         |
-| `helio.docker.yaml`   | Helio config loaded by the proxy container                                                      |
-| `mcp-echo-server.mjs` | Zero-dependency MCP echo server for the demo                                                    |
-| `.env.example`        | Template for local env vars (copy to `.env`, fill in the secret)                                |
+| File                    | Purpose                                                                                               |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| `Dockerfile`            | 4-stage build (deps, build, prod-deps, runtime) with `tini`, a non-root user, and a healthcheck       |
+| `docker-compose.yml`    | Orchestrates `helio` + `mcp-server` (the demo upstream)                                               |
+| `docker-compose.ci.yml` | CI-only override that runs the smoke test against the prebuilt image (see `.github/workflows/ci.yml`) |
+| `helio.docker.yaml`     | Helio config loaded by the proxy container                                                            |
+| `mcp-echo-server.mjs`   | Zero-dependency MCP echo server for the demo                                                          |
+| `.env.example`          | Template for local env vars (copy to `.env`, fill in the secret)                                      |

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -1,0 +1,12 @@
+# CI-only override for the docker job in .github/workflows/ci.yml.
+#
+# The build-push-action step builds and loads the proxy image as `helio:ci`.
+# This override points the `helio` service at that pre-built image so the
+# smoke test runs against the exact image CI just validated, with no rebuild.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --no-build --wait
+services:
+  helio:
+    image: helio:ci
+    pull_policy: never

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Smoke test for the Docker Compose demo stack (docker/).
+#
+# Assumes the stack is already running (docker compose up) and the proxy's
+# MCP edge is reachable at $HELIO_MCP_URL (default http://localhost:3000/mcp).
+# Asserts the governance contract end to end against the bundled echo server:
+#
+#   - tools/list returns the demo tools
+#   - get_weather (read-only)   is ALLOWED
+#   - delete_record (destructive) is DENIED by the block-destructive rule
+#
+# Exits non-zero on the first failed assertion. Used by the docker job in
+# .github/workflows/ci.yml, and runnable locally against a running stack.
+
+set -euo pipefail
+
+MCP_URL="${HELIO_MCP_URL:-http://localhost:3000/mcp}"
+
+fail() {
+  echo "SMOKE FAIL: $1" >&2
+  exit 1
+}
+
+post() {
+  curl -sS --max-time 10 -X POST "$MCP_URL" \
+    -H 'Content-Type: application/json' \
+    -d "$1"
+}
+
+echo "Smoke testing $MCP_URL"
+
+# 1. tools/list returns the demo tools.
+list=$(post '{"jsonrpc":"2.0","id":1,"method":"tools/list"}')
+for tool in get_weather send_email delete_record; do
+  if ! grep -q "\"$tool\"" <<<"$list"; then
+    fail "tools/list is missing \"$tool\" (got: $list)"
+  fi
+done
+echo "ok: tools/list returned the demo tools"
+
+# 2. get_weather is read-only, so the allow-reads rule permits it.
+weather=$(post '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_weather","arguments":{"city":"London"}}}')
+if grep -q '"error"' <<<"$weather"; then
+  fail "get_weather should have been allowed (got: $weather)"
+fi
+if ! grep -q 'Sunny' <<<"$weather"; then
+  fail "get_weather did not return the expected result (got: $weather)"
+fi
+echo "ok: get_weather allowed"
+
+# 3. delete_record is destructive, so the block-destructive rule denies it.
+del=$(post '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"delete_record","arguments":{"id":"rec_42"}}}')
+if ! grep -q '"error"' <<<"$del"; then
+  fail "delete_record should have been blocked (got: $del)"
+fi
+if ! grep -q 'block-destructive' <<<"$del"; then
+  fail "delete_record denial did not name the block-destructive rule (got: $del)"
+fi
+echo "ok: delete_record denied by block-destructive"
+
+echo "SMOKE PASS: governance enforced (read allowed, destructive denied)"


### PR DESCRIPTION
## Description

The `docker` job only built the image, so a broken demo config or compose
wiring could ship without any check noticing. This adds a smoke test that boots
the demo stack and proves governance still enforces.

New steps in the `docker` job:

- Build and `load` the image as `helio:ci`.
- Validate `helio.docker.yaml` against the proxy schema.
- Assert the missing-secret guard aborts (non-zero exit) with the documented
  message, so neither the fail-closed behavior nor the message can drift from
  the README.
- Boot the stack (`up --no-build --wait`) and run `scripts/docker-smoke.sh`,
  which confirms `tools/list` returns the demo tools, `get_weather` is allowed,
  and `delete_record` is denied by the `block-destructive` rule.
- Always tear down (`down -v`).

`docker/docker-compose.ci.yml` is a CI-only override that pins the `helio`
service to the prebuilt `helio:ci` image (`pull_policy: never`), so the smoke
test reuses the image the build step already made instead of rebuilding.

Closes #95

## Type of Change

- [x] CI / build / tooling

## Packages Affected

- [x] Root config / monorepo tooling

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode, no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow Conventional Commits

The smoke script is the test. It also gates negatively: an unreachable proxy or
a `delete_record` that is not blocked exits non-zero.

## How to Test

Locally, tag any built proxy image as `helio:ci`, then from `docker/`:

```bash
docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --no-build --wait
../scripts/docker-smoke.sh
docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
```

The smoke script prints `SMOKE PASS` and exits 0. Remove the `block-destructive`
rule from `helio.docker.yaml` and re-run: the smoke test should fail, since
`delete_record` is no longer denied.

In CI, the `docker` job runs all of the above on every PR.

## Additional Context

Verified locally end to end: build and load, config validate (2 rules),
guard-message abort (exit 1), a full up/smoke/down cycle, and a negative test
(unreachable proxy exits non-zero). An external review confirmed the design; the
guard step was hardened to assert the non-zero exit, and the override file was
documented in the docker README.
