### PR TITLE
docs(changelog): note the docker quickstart and dashboard login changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Changed
+
+- **Dashboard login prompt is deployment-neutral (#94).** The lock screen no
+  longer assumes the dashboard secret is a literal in `helio.yaml`. It now points
+  to the `dashboard.api_secret` value in your Helio config and explains the
+  `${HELIO_DASHBOARD_SECRET}` env-placeholder case used by the Docker quickstart
+  and hand-authored configs.
+- **Docker quickstart hardened (#93).** The `docker/README.md` walkthrough now
+  covers cloning and `cd docker`, writing the dashboard secret into `.env`, and
+  states up front that the stack is a self-contained demo, with a pointer to the
+  sidecar guide for governing your own server. Added an "Exercise it" section
+  with allow and deny tool-call examples and a "Reset the demo" note, and aligned
+  `helio.docker.yaml` with the canonical config section order.
+
 ## [0.7.0] - 2026-06-30
 
 ### Added


### PR DESCRIPTION
## Description

Adds `[Unreleased]` CHANGELOG entries for the two user-facing changes merged
after v0.7.0: the deployment-neutral dashboard login prompt (#94) and the
hardened Docker quickstart (#93). The CI smoke test (#95) is internal tooling,
so it is intentionally not listed.

No release is being cut now; these entries are staged under `Unreleased` for the
next release.

## Type of Change

- [x] Documentation

## Packages Affected

- [x] Root config / monorepo tooling

## Checklist

- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] All CI checks pass
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow Conventional Commits

## How to Test

Read the `[Unreleased]` section of `CHANGELOG.md`; entries reference #93 and #94
and follow the existing Keep a Changelog format.