### PR TITLE
docs(sidecar): note the image is amd64-only on Apple Silicon

### DIFF
--- a/docs/deployment-sidecar.md
+++ b/docs/deployment-sidecar.md
@@ -82,6 +82,13 @@ volumes:
   helio-data: {}
 ```
 
+> **Apple Silicon / arm64:** the published image is currently `linux/amd64` only,
+> so `docker compose up` (or `docker pull`) fails on arm64 hosts with a
+> `no matching manifest` error. Until multi-arch images ship
+> ([#101](https://github.com/gethelio/helio/issues/101)), either add
+> `platform: linux/amd64` to the `helio` service above (it runs under emulation)
+> or build from `docker/Dockerfile`.
+
 Note what is and isn't published:
 
 - **`mcp-server` has no `ports:`** — it is never published to the host or the


### PR DESCRIPTION
## Description

The published `ghcr.io/gethelio/helio` image currently ships `linux/amd64` only,
so `docker compose up` / `docker pull` fails on Apple Silicon (arm64) with a
`no matching manifest` error. Adds a note to the sidecar guide pointing arm64
readers at `platform: linux/amd64` (emulation) or building from
`docker/Dockerfile`, and links the multi-arch tracking issue so the note can be
removed once fixed.

Stopgap for #101.

## Type of Change

- [x] Documentation

## Packages Affected

- [x] `docs/`

## Checklist

- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] All CI checks pass
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow Conventional Commits

## How to Test

Read the note after the compose block in `docs/deployment-sidecar.md`; it links
#101 and gives both the `platform: linux/amd64` and build-from-Dockerfile options.