### PR TITLE
ci(release): publish the docker image for linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
     name: Docker Build & Push
     needs: ci
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -189,6 +189,9 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: scripts/set-release-version.sh "$VERSION"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -217,9 +220,15 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Attestations (explicit for documentation): attach full build
+          # provenance to the image. No image SBOM here — the `sbom` job below
+          # publishes a CycloneDX dependency SBOM as a release asset instead.
+          provenance: mode=max
+          sbom: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -229,7 +238,9 @@ jobs:
       - name: Sign image with cosign
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
-        run: cosign sign --yes "ghcr.io/gethelio/helio@${DIGEST}"
+        # --recursive signs the multi-arch index AND each per-platform child
+        # image, so the amd64/arm64 images users actually pull are each signed.
+        run: cosign sign --yes --recursive "ghcr.io/gethelio/helio@${DIGEST}"
 
   sbom:
     name: Generate SBOM


### PR DESCRIPTION
## Description

The release build published a `linux/amd64`-only image, so `docker pull` fails on
Apple Silicon (arm64) with `no matching manifest`. This makes the release image
multi-arch.

Changes to the `docker` job in `.github/workflows/release.yml`:

- Add a **Set up QEMU** step and set `platforms: linux/amd64,linux/arm64` on the
  build so both architectures are published in one manifest list.
- Set `provenance: mode=max` and `sbom: false` explicitly to document the
  attestation posture (the dedicated `sbom` job publishes a CycloneDX dependency
  SBOM as a release asset; the image doesn't attach its own).
- `cosign sign --recursive` so the index **and** each per-platform child image are
  signed (not just the index) — preserves the "the image you pull is signed"
  guarantee for both arches.
- Raise the job timeout 15 → 30 min for the slower emulated arm64 build.

Closes #101.

## Type of Change

- [x] CI / build / tooling

## Packages Affected

- [x] Root config / monorepo tooling

## Checklist

- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] All CI checks pass
- [x] Commit messages follow Conventional Commits

## How to Test

`release.yml` only runs on `v*.*.*` tags, so this PR's CI does not exercise it.
Verified locally instead: `docker buildx build --platform linux/amd64,linux/arm64
-f docker/Dockerfile --output type=oci` builds both arches and produces a manifest
list containing `linux/amd64` + `linux/arm64`. Full end-to-end validation (push +
recursive cosign over the pushed index) happens on the next release tag.

## Additional Context

Reviewed by an external agent; the recursive-cosign fix and the explicit
provenance/sbom settings came out of that round-trip. When the next release ships
a multi-arch image, remove the arm64 `--platform` caveat added to
`docs/deployment-sidecar.md` in #102.