### PR TITLE
fix(docker): make the demo's approval flow actually fire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ Maintainer notes:
   with allow and deny tool-call examples and a "Reset the demo" note, and aligned
   `helio.docker.yaml` with the canonical config section order.
 
+### Fixed
+
+- **Docker demo approvals now fire (#104).** The demo config configured an
+  approval channel but nothing ever reached it — `flag_destructive` was dead
+  because the `block-destructive` rule matched first. `send_email` now requires
+  approval, so calling it populates the dashboard Approvals page as the README
+  promised; the "Exercise it" section walks through it.
+
 ## [0.7.0] - 2026-06-30
 
 ### Added

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,8 +72,8 @@ dashboard API calls.
 
 The demo runs Helio's policy engine in front of the echo server, so you
 can watch governance act. The config (`helio.docker.yaml`) allows
-read-only tools and blocks destructive ones. Send a couple of calls
-through the proxy on port 3000:
+read-only tools, denies destructive ones, and requires approval before
+sending email. Send a couple of calls through the proxy on port 3000:
 
 ```bash
 # Allowed: get_weather is read-only
@@ -81,15 +81,31 @@ curl -s -X POST http://localhost:3000/mcp \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{"city":"London"}}}'
 
-# Blocked: delete_record is destructive, so the policy denies it
+# Denied: delete_record is destructive, so the policy blocks it
 curl -s -X POST http://localhost:3000/mcp \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delete_record","arguments":{"id":"rec_42"}}}'
 ```
 
-The first returns a result; the second returns a policy denial that
-names the `block-destructive` rule. Both appear in the dashboard
+`get_weather` returns a result; `delete_record` returns a policy denial
+that names the `block-destructive` rule. Both appear in the dashboard
 activity feed with their decision.
+
+Now trigger a human-in-the-loop approval. This call **waits** for a
+decision:
+
+```bash
+# Requires approval: send_email pauses until you approve it
+curl -s -X POST http://localhost:3000/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"send_email","arguments":{"to":"ceo@example.com","body":"hi"}}}'
+```
+
+The command hangs because the call is pending. Open the dashboard at
+<http://localhost:3100>, go to **Approvals**, and approve the
+`send_email` ticket — the curl then returns `Email sent to
+ceo@example.com`. (Deny it, or wait past the 120s timeout, and the call
+is denied instead.)
 
 No agent handy? You can also point the official
 [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector)

--- a/docker/helio.docker.yaml
+++ b/docker/helio.docker.yaml
@@ -2,10 +2,11 @@
 #
 # This config is used by docker-compose.yml. It demonstrates governance
 # with a mix of policies: read-only tools are allowed, destructive tools
-# are denied, and everything else falls through to the default (allow).
+# are denied, sending email requires approval, and everything else falls
+# through to the default (allow).
 #
-# The dashboard approval channel is enabled so you can see the approvals
-# page working in the UI at http://localhost:3100.
+# The `send_email` rule routes to the dashboard approval channel, so calling
+# that tool makes the approvals page populate at http://localhost:3100.
 #
 # Sections follow the canonical request-lifecycle order from
 # docs/configuration.md: upstream, listen, policies, approval, audit,
@@ -23,8 +24,15 @@ listen:
 
 policies:
   default: allow
-  flag_destructive: require_approval
   rules:
+    # Sending email pauses for human approval in the dashboard.
+    - name: approve-send-email
+      match:
+        tool: 'send_email'
+      action: require_approval
+      approval:
+        channel: dashboard
+
     - name: block-destructive
       match:
         annotations:


### PR DESCRIPTION
## Description

The Docker demo advertised approvals (`helio.docker.yaml` configured an approval
channel and its comment said "you can see the approvals page working"), but no
tool ever routed to approval — `flag_destructive` was dead because the
`block-destructive` deny rule matched first (the annotation matcher defaults a
missing `destructiveHint` to `true`, so it also catches unannotated tools).

This adds a `send_email` rule with `action: require_approval` routed to the
dashboard, and drops the dead `flag_destructive`. Calling `send_email` now pends
and populates the dashboard Approvals page. Destructive tools still hard-deny and
read-only tools still allow, so the existing "Exercise it" curls and the CI smoke
test are unchanged. The quickstart's "Exercise it" section now walks through the
approval step.

Closes #104

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Packages Affected

- [x] Root config / monorepo tooling
- [x] `docs/`

## Checklist

- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] All CI checks pass
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow Conventional Commits

## How to Test

`docker compose up` in `docker/`, then:
1. `get_weather` → allow, `delete_record` → deny (unchanged).
2. Call `send_email` (see the README "Exercise it" curl) — it pends. Open the
   dashboard Approvals page, approve the ticket, and the call returns
   `Email sent to ...`.

Verified end-to-end live, including approving through the dashboard UI (pending
ticket renders → Approve → the blocked call completes) and the 120s timeout path.
Config validates warning-free (3 rules); the smoke test still passes.