### PR TITLE
docs(policies): note full self-repair fields and neq edge case

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -128,6 +128,8 @@ match:
 | `contains` | string | Substring match          | `contains: "@example.com"` |
 | `regex`    | string | Regular expression match | `regex: "^admin_"`         |
 
+A `neq` condition matches only when the field is present; an absent field does not satisfy `neq`.
+
 Multiple conditions on the same or different fields are AND-combined:
 
 ```yaml
@@ -231,6 +233,8 @@ The request is blocked immediately. No upstream request is made. The response is
   }
 }
 ```
+
+The `data` object also carries `ruleIndex` and `policy_reason`; the fields shown above are the ones an agent typically acts on.
 
 ### require_approval
 
@@ -440,12 +444,14 @@ When evidence is missing, the proxy returns self-repair feedback telling the age
       "blocked": true,
       "reason": "evidence_missing",
       "missing_evidence": ["order_lookup"],
-      "suggestion": "Call order_lookup tool first to provide evidence, then retry",
+      "suggestion": "Call the order_lookup tool first to provide the required evidence, then retry this action.",
       "retry_allowed": true
     }
   }
 }
 ```
+
+The `data` object also carries `rule`, `ruleIndex`, `action`, `expired_evidence`, and `missing_dependencies`.
 
 Evidence entries have a configurable TTL (default: 300 seconds). If evidence has expired, the response includes `"reason": "evidence_expired"` with a suggestion to refresh it.
 


### PR DESCRIPTION
## What

Small accuracy pass over `docs/policies.md`, verified against the policy
engine source and the live CLI.

## Changes

- The self-repair error `data` returned on the wire is the full feedback
  object (`{ ...feedback }`). The deny and evidence-missing JSON examples
  showed only a subset, so note the additional fields each response
  carries: `ruleIndex` + `policy_reason` on deny, and `rule`, `ruleIndex`,
  `action`, `expired_evidence`, `missing_dependencies` on evidence-missing.
- Correct the evidence-missing `suggestion` to the exact string the proxy
  emits (`self-repair.ts`).
- Note that a `neq` match condition does not match when the field is absent
  (`matchers.ts` guards on `value !== undefined`).

## Verification

- `pnpm format:check` and the docs-drift check pass.
- Claims verified against `policy/`, `feedback/self-repair.ts`, `evidence/`,
  and `sideband/governance-service.ts`; example configs live-validated with
  `npx @gethelio/proxy@0.7.0 validate`.

Docs-only; no code changes.

## Follow-up

The self-repair payload mixes `ruleIndex` (camelCase) with snake_case
siblings. It is the documented, established wire shape (AGENTS.md) and
renaming it is breaking, so it is tracked separately rather than changed
here.
