### PR TITLE
feat(audit): record denial reasons and escalation on approval records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Added
+
+- **Audit records keep denial reasons and escalation history (#110).** Approval
+  resolutions with context worth keeping now write an `evidence_chain.approval`
+  block onto the call's audit record: `ticket_id`, `denial_reason` when the
+  denier supplied one, and `escalated_at` / `escalated_to` when the approval
+  escalated before resolution. Previously this context lived only on the
+  in-memory ticket and was lost an hour after resolution. Applies to both the
+  MCP path and sideband-governed calls; the dashboard's audit detail panel
+  renders the new block. Plain approvals are unchanged (`evidence_chain` stays
+  null).
+
 ### Changed
 
 - **Sidecar deployment guide clarified and corrected (#105).** Reframed

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -13,7 +13,7 @@ Rule-level `approval` config is optional. If a `require_approval` rule omits it,
 5. A human approves, denies, the timeout fires, the client disconnects, or the proxy shuts down.
 6. The proxy either forwards the request upstream (approved, break-glass, or timed out with `default_on_timeout: allow`) or returns a structured error (`denied`, `timeout` with `default_on_timeout: deny`, `client_disconnected`, or `shutdown_cancelled`).
 
-The resolution is recorded in the [audit trail](./audit.md) on the tool call's audit record (`approval_status`, `approved_by`, `approval_wait_ms`). The ticket itself is held in memory only — it stays queryable through the approvals REST API and dashboard for an hour after resolution, then it is cleaned up.
+The resolution is recorded in the [audit trail](./audit.md) on the tool call's audit record (`approval_status`, `approved_by`, `approval_wait_ms`, and — when there is a denial reason or an escalation — an `evidence_chain.approval` block with those details). The ticket itself is held in memory only — it stays queryable through the approvals REST API and dashboard for an hour after resolution, then it is cleaned up.
 
 ## Channels
 
@@ -80,7 +80,7 @@ approval:
 
 The Slack channel sends a Block Kit message with interactive Approve and Deny buttons to a Slack channel. When a user clicks a button, Helio resolves the ticket and updates the message with the result.
 
-> **Slack deny does not capture a denial reason.** The router supports optional denial reasons (`denial_reason` in the JSON-RPC error response, and on the ticket when a reason is supplied), but Slack button clicks have no free-text input, so Slack-resolved denials always return `denial_reason: null` to the caller. The dashboard's deny modal does capture a reason. A future Slack modal flow could capture reasons too — tracked as a follow-up.
+> **Slack deny does not capture a denial reason.** The router supports optional denial reasons (`denial_reason` in the JSON-RPC error response; a supplied reason is also stored on the ticket and in the audit record's `evidence_chain.approval`), but Slack button clicks have no free-text input, so Slack-resolved denials always return `denial_reason: null` to the caller. The dashboard's deny modal does capture a reason. A future Slack modal flow could capture reasons too — tracked as a follow-up.
 
 ```yaml
 approval:
@@ -264,7 +264,7 @@ If an approval hasn't been resolved within a specified time, Helio can escalate 
 - `escalation_after` must be shorter than `timeout` to fire before the ticket times out.
 - `delegates` is an array of channel names to notify on escalation. If omitted, the primary channel is re-notified.
 - Delegate values must reference configured approval channel `name`s (or channel `type`s such as `webhook` / `slack` / `dashboard`). Unknown delegate references are startup-fatal validation errors.
-- Escalation updates the ticket with `escalated_at` and `escalated_to` fields, visible in the dashboard and on `GET /api/approvals/:id` while the ticket is retained. Escalation is not written to the audit trail.
+- Escalation updates the ticket with `escalated_at` and `escalated_to` fields, visible in the dashboard and on `GET /api/approvals/:id` while the ticket is retained. Both fields are also recorded durably on the call's audit record under `evidence_chain.approval`.
 
 Timeouts also emit the same `approval_resolved` dashboard SSE event path used by manual approve/deny/break-glass resolution, so operator dashboards stay state-consistent across all resolution outcomes.
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -19,7 +19,7 @@ Each audit record contains the following fields:
 | `block_reason`         | string \| null | Structured deny/block reason (`evidence_missing`, `approval_timeout`, `client_disconnected`, `shutdown_cancelled`, `install_denied` for a `deny_install` install scan, etc.). Null when not blocked. |
 | `matched_rule`         | string \| null | Name of the policy rule that matched, or null if the default action applied.                                                                                                                         |
 | `matched_rule_index`   | number \| null | Rule index in config order that matched, or null when no rule matched.                                                                                                                               |
-| `evidence_chain`       | object \| null | Evidence and dependency state from the evidence grounding system.                                                                                                                                    |
+| `evidence_chain`       | object \| null | Evidence and dependency state from the evidence grounding system, plus decision-context sub-objects when present (`approval`, `break_glass`, `rate_limit`, `spend_limit`, `tool_drift`, `sideband`). |
 | `approval_status`      | string \| null | Approval outcome: `approved`, `denied`, `timeout`, `break_glass`, `client_disconnected`, or `shutdown_cancelled`. Null if no approval was required.                                                  |
 | `approved_by`          | string \| null | Identity of the human who resolved approval (`approved`, `denied`, or `break_glass`), when applicable.                                                                                               |
 | `upstream_response`    | any \| null    | The upstream MCP server's response. Null for denied calls (no upstream request was made).                                                                                                            |
@@ -35,6 +35,16 @@ Each audit record contains the following fields:
 | `origin`               | string         | Enforcement origin: `mcp` for the proxy path, or an adapter origin string (e.g. `openclaw`) for [sideband-governed](./adapter-api.md) calls.                                                         |
 | `metadata`             | object \| null | Adapter-supplied context (reserved keys `channel_id`, `sender_id`, `sender_name`, `conversation_id`). Null for MCP-origin records.                                                                   |
 | `created_at`           | string         | ISO 8601 timestamp of when the record was persisted to the database.                                                                                                                                 |
+
+### Approval Context
+
+When a `require_approval` decision resolves with context worth keeping — a denial reason or an escalation — the record's `evidence_chain.approval` carries it:
+
+- `ticket_id` — the approval ticket this record corresponds to.
+- `denial_reason` — present when the denier supplied a reason (Slack denials never carry one).
+- `escalated_at` / `escalated_to` — present when the escalation timer fired before resolution.
+
+The block is omitted when neither applies, so a plain approved call keeps `evidence_chain: null`. Break-glass reasons are recorded separately under `evidence_chain.break_glass` (`reason`, `invoked_by`).
 
 ## Tool Definition Drift Records
 

--- a/packages/dashboard/src/components/EvidenceChain.test.tsx
+++ b/packages/dashboard/src/components/EvidenceChain.test.tsx
@@ -73,6 +73,34 @@ describe('EvidenceChain', () => {
     expect(screen.getByText('admin')).toBeTruthy()
   })
 
+  it('renders approval context with denial reason and ticket id', () => {
+    const chain = { approval: { ticket_id: 'abc-123', denial_reason: 'Too risky' } }
+    render(<EvidenceChain chain={chain} />)
+    expect(screen.getByText('Approval')).toBeTruthy()
+    expect(screen.getByText('Too risky')).toBeTruthy()
+    expect(screen.getByText(/abc-123/)).toBeTruthy()
+  })
+
+  it('renders approval escalation timestamp and targets', () => {
+    const chain = {
+      approval: {
+        ticket_id: 'abc-123',
+        escalated_at: '2026-07-02T15:03:34.869Z',
+        escalated_to: ['hooks', 'dashboard'],
+      },
+    }
+    render(<EvidenceChain chain={chain} />)
+    expect(screen.getByText('Approval')).toBeTruthy()
+    expect(screen.getByText(/2026-07-02T15:03:34\.869Z/)).toBeTruthy()
+    expect(screen.getByText(/hooks, dashboard/)).toBeTruthy()
+  })
+
+  it('ignores a malformed approval block', () => {
+    const chain = { approval: { ticket_id: 42, escalated_to: 'oops' } }
+    const { container } = render(<EvidenceChain chain={chain} />)
+    expect(container.innerHTML).toBe('')
+  })
+
   it('applies correct progress bar color based on usage', () => {
     // High usage (100%) should get red
     const chain = { rate_limit: { allowed: false, current: 100, limit: 100 } }

--- a/packages/dashboard/src/components/EvidenceChain.tsx
+++ b/packages/dashboard/src/components/EvidenceChain.tsx
@@ -38,6 +38,13 @@ interface BreakGlassData {
   invoked_by: string
 }
 
+interface ApprovalContextData {
+  ticket_id: string
+  denial_reason?: string
+  escalated_at?: string
+  escalated_to?: string[]
+}
+
 // ---------------------------------------------------------------------------
 // Type guards
 // ---------------------------------------------------------------------------
@@ -70,6 +77,21 @@ function isBreakGlassData(v: unknown): v is BreakGlassData {
   if (!v || typeof v !== 'object') return false
   const o = v as Record<string, unknown>
   return typeof o.reason === 'string' && typeof o.invoked_by === 'string'
+}
+
+function isApprovalContextData(v: unknown): v is ApprovalContextData {
+  if (!v || typeof v !== 'object') return false
+  const o = v as Record<string, unknown>
+  if (typeof o.ticket_id !== 'string') return false
+  if (o.denial_reason !== undefined && typeof o.denial_reason !== 'string') return false
+  if (o.escalated_at !== undefined && typeof o.escalated_at !== 'string') return false
+  if (
+    o.escalated_to !== undefined &&
+    !(Array.isArray(o.escalated_to) && o.escalated_to.every((t) => typeof t === 'string'))
+  ) {
+    return false
+  }
+  return true
 }
 
 // ---------------------------------------------------------------------------
@@ -124,8 +146,9 @@ export function EvidenceChain({ chain }: EvidenceChainProps) {
   const rateLimit = isRateLimitData(chain.rate_limit) ? chain.rate_limit : null
   const spendLimit = isSpendLimitData(chain.spend_limit) ? chain.spend_limit : null
   const breakGlass = isBreakGlassData(chain.break_glass) ? chain.break_glass : null
+  const approval = isApprovalContextData(chain.approval) ? chain.approval : null
 
-  const hasContent = evidence || dependencies || rateLimit || spendLimit || breakGlass
+  const hasContent = evidence || dependencies || rateLimit || spendLimit || breakGlass || approval
   if (!hasContent) return null
 
   return (
@@ -230,6 +253,27 @@ export function EvidenceChain({ chain }: EvidenceChainProps) {
           <p className="text-xs text-amber-700">
             <span className="font-medium">Invoked by:</span> {breakGlass.invoked_by}
           </p>
+        </div>
+      )}
+
+      {/* Approval context (denial reason / escalation) */}
+      {approval && (
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-3">
+          <p className="text-xs font-medium text-gray-700">Approval</p>
+          {approval.denial_reason && (
+            <p className="mt-1 text-xs text-gray-600">
+              <span className="font-medium">Denial reason:</span> {approval.denial_reason}
+            </p>
+          )}
+          {approval.escalated_at && (
+            <p className="mt-1 text-xs text-gray-600">
+              <span className="font-medium">Escalated:</span> {approval.escalated_at}
+              {approval.escalated_to && approval.escalated_to.length > 0
+                ? ` to ${approval.escalated_to.join(', ')}`
+                : ''}
+            </p>
+          )}
+          <p className="mt-1 text-xs text-gray-400">Ticket {approval.ticket_id}</p>
         </div>
       )}
     </div>

--- a/packages/proxy/src/approval/types.ts
+++ b/packages/proxy/src/approval/types.ts
@@ -62,6 +62,20 @@ export interface ApprovalTicket {
   notification_failures?: ApprovalNotificationFailure[]
 }
 
+/**
+ * Approval context snapshotted at resolution time for the audit record.
+ * Emitted as `evidence_chain.approval` only when it has content (a denial
+ * reason or an escalation) — plain approvals do not produce the block.
+ * Shared by the MCP path (governed forwarder) and the sideband path
+ * (governance service) so both emit the same wire shape.
+ */
+export interface ApprovalAuditContext {
+  readonly ticket_id: string
+  readonly denial_reason?: string
+  readonly escalated_at?: string
+  readonly escalated_to?: string[]
+}
+
 /** What the approval router returns to the governed forwarder. */
 export type ApprovalOutcome =
   | { readonly status: 'approved'; readonly resolvedBy: string; readonly ticketId: string }

--- a/packages/proxy/src/policy/governed-forwarder.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder.test.ts
@@ -2062,6 +2062,389 @@ describe('GovernedForwarder', () => {
   })
 
   // -----------------------------------------------------------------------
+  // approval context on audit records (evidence_chain.approval)
+  // -----------------------------------------------------------------------
+
+  describe('approval context on audit records', () => {
+    function createAudit() {
+      const auditStore = new AuditStore({
+        path: ':memory:',
+        retention: '90d',
+        includeResponses: true,
+        cleanupIntervalMs: 0,
+      })
+      const auditWriter = new AuditWriter({ store: auditStore, flushIntervalMs: 0 })
+      return { auditStore, auditWriter }
+    }
+
+    function createApproval(options?: {
+      defaultOnTimeout?: 'allow' | 'deny'
+      resolvedRetentionMs?: number
+    }) {
+      const queue = new ApprovalQueue({
+        cleanupIntervalMs: 0,
+        resolvedRetentionMs: options?.resolvedRetentionMs,
+      })
+      const channels = new Map<string, ApprovalChannel>([['dashboard', new QueueChannel()]])
+      const approvalRouter = new ApprovalRouter({
+        defaultTimeoutMs: 300_000,
+        defaultOnTimeout: options?.defaultOnTimeout ?? 'deny',
+        channels,
+        queue,
+      })
+      return { queue, approvalRouter }
+    }
+
+    const approvalPolicy = () =>
+      compile({
+        default: 'allow',
+        rules: [
+          {
+            match: { tool: 'deploy_production' },
+            action: 'require_approval',
+            approval: { channel: 'dashboard' },
+          },
+        ],
+      })
+
+    it('denied with a reason records evidence_chain.approval with ticket_id and denial_reason', async () => {
+      const inner = mockForwarder()
+      const { auditStore, auditWriter } = createAudit()
+      const { queue, approvalRouter } = createApproval()
+      const governed = new GovernedForwarder(inner, approvalPolicy(), {
+        approvalRouter,
+        auditWriter,
+      })
+
+      const resultPromise = governed.forward(toolsCallRequest('deploy_production', { env: 'prod' }))
+      const ticketId = queue.listPending()[0]?.id as string
+      approvalRouter.deny(ticketId, 'bob', 'Too risky')
+      await resultPromise
+      auditWriter.flush()
+
+      const { records } = auditStore.list()
+      expect(records).toHaveLength(1)
+      const chain = records[0]?.evidence_chain as Record<string, unknown>
+      expect(chain).not.toBeNull()
+      const approval = chain['approval'] as Record<string, unknown>
+      expect(approval['ticket_id']).toBe(ticketId)
+      expect(approval['denial_reason']).toBe('Too risky')
+      expect(approval).not.toHaveProperty('escalated_at')
+      expect(approval).not.toHaveProperty('escalated_to')
+
+      auditWriter.close()
+      approvalRouter.close()
+    })
+
+    it('escalated then approved records escalated_at and escalated_to without denial_reason', async () => {
+      vi.useFakeTimers()
+      try {
+        const inner = mockForwarder()
+        const { auditStore, auditWriter } = createAudit()
+        const { queue, approvalRouter } = createApproval()
+        const policy = compile({
+          default: 'allow',
+          rules: [
+            {
+              match: { tool: 'deploy_production' },
+              action: 'require_approval',
+              approval: { channel: 'dashboard', timeout: '10s', escalation_after: '3s' },
+            },
+          ],
+        })
+        const governed = new GovernedForwarder(inner, policy, { approvalRouter, auditWriter })
+
+        const resultPromise = governed.forward(toolsCallRequest('deploy_production'))
+        const ticketId = queue.listPending()[0]?.id as string
+
+        // Fire the escalation timer, then approve before the timeout
+        vi.advanceTimersByTime(3_001)
+        expect(queue.get(ticketId)?.escalated_at).toBeDefined()
+        approvalRouter.approve(ticketId, 'alice')
+
+        await resultPromise
+        auditWriter.flush()
+
+        const { records } = auditStore.list()
+        expect(records).toHaveLength(1)
+        expect(records[0]?.approval_status).toBe('approved')
+        const chain = records[0]?.evidence_chain as Record<string, unknown>
+        expect(chain).not.toBeNull()
+        const approval = chain['approval'] as Record<string, unknown>
+        expect(approval['ticket_id']).toBe(ticketId)
+        expect(approval['escalated_at']).toBe(queue.get(ticketId)?.escalated_at)
+        expect(approval['escalated_to']).toEqual(['dashboard'])
+        expect(approval).not.toHaveProperty('denial_reason')
+
+        auditWriter.close()
+        approvalRouter.close()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('emits no approval block for the synthetic ticketless denial after router close', async () => {
+      const inner = mockForwarder()
+      const { auditStore, auditWriter } = createAudit()
+      const { approvalRouter } = createApproval()
+      const governed = new GovernedForwarder(inner, approvalPolicy(), {
+        approvalRouter,
+        auditWriter,
+      })
+
+      // A require_approval call racing proxy shutdown: submit() after close()
+      // resolves as a system denial with an empty ticketId and no ticket.
+      approvalRouter.close()
+      const result = await governed.forward(toolsCallRequest('deploy_production'))
+      auditWriter.flush()
+
+      expect(errorFromResult(result).data['reason']).toBe('approval_denied')
+      const { records } = auditStore.list()
+      expect(records).toHaveLength(1)
+      expect(records[0]?.evidence_chain).toBeNull()
+
+      auditWriter.close()
+    })
+
+    it('denied without a reason and without escalation emits no approval block', async () => {
+      const inner = mockForwarder()
+      const { auditStore, auditWriter } = createAudit()
+      const { queue, approvalRouter } = createApproval()
+      const governed = new GovernedForwarder(inner, approvalPolicy(), {
+        approvalRouter,
+        auditWriter,
+      })
+
+      const resultPromise = governed.forward(toolsCallRequest('deploy_production'))
+      const ticketId = queue.listPending()[0]?.id as string
+      approvalRouter.deny(ticketId, 'bob')
+      await resultPromise
+      auditWriter.flush()
+
+      const { records } = auditStore.list()
+      expect(records[0]?.approval_status).toBe('denied')
+      expect(records[0]?.evidence_chain).toBeNull()
+
+      auditWriter.close()
+      approvalRouter.close()
+    })
+
+    it('plain approved without escalation keeps evidence_chain null', async () => {
+      const inner = mockForwarder()
+      const { auditStore, auditWriter } = createAudit()
+      const { queue, approvalRouter } = createApproval()
+      const governed = new GovernedForwarder(inner, approvalPolicy(), {
+        approvalRouter,
+        auditWriter,
+      })
+
+      const resultPromise = governed.forward(toolsCallRequest('deploy_production'))
+      const ticketId = queue.listPending()[0]?.id as string
+      approvalRouter.approve(ticketId, 'alice')
+      await resultPromise
+      auditWriter.flush()
+
+      const { records } = auditStore.list()
+      expect(records[0]?.approval_status).toBe('approved')
+      expect(records[0]?.evidence_chain).toBeNull()
+
+      auditWriter.close()
+      approvalRouter.close()
+    })
+
+    it('escalated then timed out (deny mode) records the escalation', async () => {
+      vi.useFakeTimers()
+      try {
+        const inner = mockForwarder()
+        const { auditStore, auditWriter } = createAudit()
+        const { queue, approvalRouter } = createApproval()
+        const policy = compile({
+          default: 'allow',
+          rules: [
+            {
+              match: { tool: 'deploy_production' },
+              action: 'require_approval',
+              approval: { channel: 'dashboard', timeout: '10s', escalation_after: '3s' },
+            },
+          ],
+        })
+        const governed = new GovernedForwarder(inner, policy, { approvalRouter, auditWriter })
+
+        const resultPromise = governed.forward(toolsCallRequest('deploy_production'))
+        const ticketId = queue.listPending()[0]?.id as string
+
+        vi.advanceTimersByTime(3_001)
+        const escalatedAt = queue.get(ticketId)?.escalated_at
+        vi.advanceTimersByTime(7_000)
+
+        const result = await resultPromise
+        auditWriter.flush()
+
+        expect(inner.forward).not.toHaveBeenCalled()
+        expect(errorFromResult(result).data['reason']).toBe('approval_timeout')
+
+        const { records } = auditStore.list()
+        expect(records[0]?.approval_status).toBe('timeout')
+        const chain = records[0]?.evidence_chain as Record<string, unknown>
+        const approval = chain['approval'] as Record<string, unknown>
+        expect(approval['ticket_id']).toBe(ticketId)
+        expect(approval['escalated_at']).toBe(escalatedAt)
+        expect(approval).not.toHaveProperty('denial_reason')
+
+        auditWriter.close()
+        approvalRouter.close()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('escalated then timed out with default_on_timeout allow forwards and records the escalation', async () => {
+      vi.useFakeTimers()
+      try {
+        const inner = mockForwarder()
+        const { auditStore, auditWriter } = createAudit()
+        const { queue, approvalRouter } = createApproval({ defaultOnTimeout: 'allow' })
+        const policy = compile({
+          default: 'allow',
+          rules: [
+            {
+              match: { tool: 'deploy_production' },
+              action: 'require_approval',
+              approval: { channel: 'dashboard', timeout: '10s', escalation_after: '3s' },
+            },
+          ],
+        })
+        const governed = new GovernedForwarder(inner, policy, { approvalRouter, auditWriter })
+
+        const resultPromise = governed.forward(toolsCallRequest('deploy_production'))
+        const ticketId = queue.listPending()[0]?.id as string
+
+        vi.advanceTimersByTime(3_001)
+        const escalatedAt = queue.get(ticketId)?.escalated_at
+        vi.advanceTimersByTime(7_000)
+
+        await resultPromise
+        auditWriter.flush()
+
+        expect(inner.forward).toHaveBeenCalled()
+
+        const { records } = auditStore.list()
+        expect(records[0]?.approval_status).toBe('timeout')
+        const chain = records[0]?.evidence_chain as Record<string, unknown>
+        const approval = chain['approval'] as Record<string, unknown>
+        expect(approval['escalated_at']).toBe(escalatedAt)
+
+        auditWriter.close()
+        approvalRouter.close()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('break-glass after escalation records both break_glass and approval blocks', async () => {
+      vi.useFakeTimers()
+      try {
+        const inner = mockForwarder()
+        const { auditStore, auditWriter } = createAudit()
+        const { queue, approvalRouter } = createApproval()
+        const policy = compile({
+          default: 'allow',
+          rules: [
+            {
+              match: { tool: 'deploy_production' },
+              action: 'require_approval',
+              approval: { channel: 'dashboard', timeout: '10s', escalation_after: '3s' },
+            },
+          ],
+        })
+        const governed = new GovernedForwarder(inner, policy, { approvalRouter, auditWriter })
+
+        const resultPromise = governed.forward(toolsCallRequest('deploy_production'))
+        const ticketId = queue.listPending()[0]?.id as string
+
+        vi.advanceTimersByTime(3_001)
+        approvalRouter.breakGlass(ticketId, 'admin', 'Emergency hotfix')
+
+        await resultPromise
+        auditWriter.flush()
+
+        const { records } = auditStore.list()
+        expect(records[0]?.approval_status).toBe('break_glass')
+        const chain = records[0]?.evidence_chain as Record<string, unknown>
+        const breakGlass = chain['break_glass'] as Record<string, unknown>
+        expect(breakGlass['reason']).toBe('Emergency hotfix')
+        const approval = chain['approval'] as Record<string, unknown>
+        expect(approval['ticket_id']).toBe(ticketId)
+        expect(approval['escalated_at']).toBeDefined()
+
+        auditWriter.close()
+        approvalRouter.close()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('records the escalation even when the ticket is evicted while the upstream forward is in flight', async () => {
+      vi.useFakeTimers()
+      try {
+        // Upstream forward completes on a 5s timer, well after the ticket is gone
+        const inner: McpForwarder & { forward: ReturnType<typeof vi.fn> } = {
+          forward: vi.fn(
+            () =>
+              new Promise<ForwardResult>((resolve) => {
+                setTimeout(() => {
+                  resolve(successResult({ jsonrpc: '2.0', id: 1, result: { content: [] } }))
+                }, 5_000)
+              }),
+          ),
+        }
+        const { auditStore, auditWriter } = createAudit()
+        const { queue, approvalRouter } = createApproval({ resolvedRetentionMs: 1 })
+        const policy = compile({
+          default: 'allow',
+          rules: [
+            {
+              match: { tool: 'deploy_production' },
+              action: 'require_approval',
+              approval: { channel: 'dashboard', timeout: '30s', escalation_after: '3s' },
+            },
+          ],
+        })
+        const governed = new GovernedForwarder(inner, policy, { approvalRouter, auditWriter })
+
+        const resultPromise = governed.forward(toolsCallRequest('deploy_production'))
+        const ticketId = queue.listPending()[0]?.id as string
+
+        vi.advanceTimersByTime(3_001)
+        const escalatedAt = queue.get(ticketId)?.escalated_at
+        approvalRouter.approve(ticketId, 'alice')
+
+        // Let the snapshot run, then evict the resolved ticket mid-forward
+        await vi.advanceTimersByTimeAsync(10)
+        queue.cleanup()
+        expect(queue.get(ticketId)).toBeUndefined()
+
+        await vi.advanceTimersByTimeAsync(5_000)
+        await resultPromise
+        auditWriter.flush()
+
+        const { records } = auditStore.list()
+        expect(records[0]?.approval_status).toBe('approved')
+        const chain = records[0]?.evidence_chain as Record<string, unknown>
+        expect(chain).not.toBeNull()
+        const approval = chain['approval'] as Record<string, unknown>
+        expect(approval['ticket_id']).toBe(ticketId)
+        expect(approval['escalated_at']).toBe(escalatedAt)
+
+        auditWriter.close()
+        approvalRouter.close()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  // -----------------------------------------------------------------------
   // client_disconnected approval outcome
   // -----------------------------------------------------------------------
 

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -29,7 +29,7 @@ import {
   buildToolDriftFeedback,
 } from '../feedback/self-repair.js'
 import type { ApprovalRouter } from '../approval/router.js'
-import type { ApprovalOutcome } from '../approval/types.js'
+import type { ApprovalAuditContext, ApprovalOutcome } from '../approval/types.js'
 import type { RateLimiter, RateLimitResult } from './rate-limiter.js'
 import type { SpendLimiter, SpendLimitResult } from './spend-limiter.js'
 import { resolvePath } from './matchers.js'
@@ -326,6 +326,7 @@ export class GovernedForwarder implements McpForwarder {
     let result: ForwardResult
     let approvalOutcome: ApprovalOutcome | undefined
     let approvalWaitMs = 0
+    let approvalContext: ApprovalAuditContext | undefined
     let rateLimitResult: RateLimitResult | undefined
     let spendLimitResult: SpendLimitResult | undefined
     let forwardingError: Error | undefined
@@ -355,6 +356,7 @@ export class GovernedForwarder implements McpForwarder {
           result = approvalResult.result
           approvalOutcome = approvalResult.outcome
           approvalWaitMs = approvalResult.approvalWaitMs
+          approvalContext = approvalResult.approvalContext
         }
       } else if (decision.action === 'rate_limit') {
         if (!this.rateLimiter) {
@@ -411,6 +413,7 @@ export class GovernedForwarder implements McpForwarder {
       dependencyResult,
       evidenceBlocked,
       approvalOutcome,
+      approvalContext,
       rateLimitResult,
       spendLimitResult,
       isDryRun,
@@ -426,7 +429,12 @@ export class GovernedForwarder implements McpForwarder {
     decision: PolicyDecision,
     toolName: string,
     toolArguments: Record<string, unknown> | undefined,
-  ): Promise<{ result: ForwardResult; outcome: ApprovalOutcome; approvalWaitMs: number }> {
+  ): Promise<{
+    result: ForwardResult
+    outcome: ApprovalOutcome
+    approvalWaitMs: number
+    approvalContext?: ApprovalAuditContext
+  }> {
     // Caller guarantees this.approvalRouter is defined
     const router = this.approvalRouter as ApprovalRouter
 
@@ -441,6 +449,28 @@ export class GovernedForwarder implements McpForwarder {
       request.signal,
     )
     const approvalWaitMs = performance.now() - approvalStart
+
+    // Snapshot approval context now, before any upstream await: a forwarded
+    // call can outlive the queue's resolved-ticket retention, so a later
+    // ticket read-back could come up empty.
+    const ticket = outcome.ticketId ? router.getTicket(outcome.ticketId) : undefined
+    const denialReason = outcome.status === 'denied' && outcome.reason ? outcome.reason : undefined
+    // The ticketId guard skips the synthetic ticketless denial emitted when
+    // submit() races router close — its "Router is closed" reason is not an
+    // approver decision and there is no ticket for the block to point at.
+    const approvalContext: ApprovalAuditContext | undefined =
+      outcome.ticketId && (denialReason || ticket?.escalated_at)
+        ? {
+            ticket_id: outcome.ticketId,
+            ...(denialReason ? { denial_reason: denialReason } : {}),
+            ...(ticket?.escalated_at
+              ? {
+                  escalated_at: ticket.escalated_at,
+                  escalated_to: [...(ticket.escalated_to ?? [])],
+                }
+              : {}),
+          }
+        : undefined
 
     let result: ForwardResult
 
@@ -475,7 +505,7 @@ export class GovernedForwarder implements McpForwarder {
       }
     }
 
-    return { result, outcome, approvalWaitMs }
+    return { result, outcome, approvalWaitMs, approvalContext }
   }
 
   private async handleRateLimit(
@@ -748,6 +778,7 @@ export class GovernedForwarder implements McpForwarder {
     dependencyResult?: DependencyCheckResult,
     evidenceBlocked?: boolean,
     approvalOutcome?: ApprovalOutcome,
+    approvalContext?: ApprovalAuditContext,
     rateLimitResult?: RateLimitResult,
     spendLimitResult?: SpendLimitResult,
     isDryRun?: boolean,
@@ -795,6 +826,12 @@ export class GovernedForwarder implements McpForwarder {
           reason: approvalOutcome.reason,
           invoked_by: approvalOutcome.resolvedBy,
         },
+      }
+    }
+    if (approvalContext) {
+      evidenceChain = {
+        ...(evidenceChain ?? {}),
+        approval: { ...approvalContext },
       }
     }
     if (rateLimitResult) {

--- a/packages/proxy/src/sideband/governance-service.test.ts
+++ b/packages/proxy/src/sideband/governance-service.test.ts
@@ -677,6 +677,81 @@ describe('GovernanceService approvals and deadlines', () => {
     expect(records.at(-1)?.record.approved_by).toBe('telegram:@oli')
   })
 
+  it('records evidence_chain.approval with denial_reason for a native denial', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [{ name: 'ap', match: { tool: 'send' }, action: 'require_approval' }],
+    })
+    const { service, records } = makeService({ policy, withApprovals: true })
+    const ev = service.evaluate(evalInput())
+    const id = ev.body['evaluation_id'] as string
+    const approval = ev.body['approval'] as { id: string }
+
+    const resolve = service.resolveApproval(approval.id, {
+      resolution: 'denied',
+      resolved_by: 'telegram:@oli',
+      reason: 'Too risky',
+    })
+    expect(resolve.status).toBe(200)
+
+    const audited = service.audit(auditInput(id), 'h')
+    expect(audited.status).toBe(201)
+    const record = records.at(-1)?.record
+    expect(record?.approval_status).toBe('denied')
+    const chain = record?.evidence_chain as Record<string, unknown>
+    expect(chain).not.toBeNull()
+    const approvalBlock = chain['approval'] as Record<string, unknown>
+    expect(approvalBlock['ticket_id']).toBe(approval.id)
+    expect(approvalBlock['denial_reason']).toBe('Too risky')
+    expect(approvalBlock).not.toHaveProperty('escalated_at')
+  })
+
+  it('records no approval block for a native approval without denial reason', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [{ name: 'ap', match: { tool: 'send' }, action: 'require_approval' }],
+    })
+    const { service, records } = makeService({ policy, withApprovals: true })
+    const ev = service.evaluate(evalInput())
+    const id = ev.body['evaluation_id'] as string
+    const approval = ev.body['approval'] as { id: string }
+
+    service.resolveApproval(approval.id, { resolution: 'approved', resolved_by: 'x' })
+
+    expect(service.audit(auditInput(id), 'h').status).toBe(201)
+    expect(records.at(-1)?.record.evidence_chain).toBeNull()
+  })
+
+  it('replays /audit idempotently with the approval block intact', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [{ name: 'ap', match: { tool: 'send' }, action: 'require_approval' }],
+    })
+    const { service, records } = makeService({ policy, withApprovals: true })
+    const ev = service.evaluate(evalInput())
+    const id = ev.body['evaluation_id'] as string
+    const approval = ev.body['approval'] as { id: string }
+
+    service.resolveApproval(approval.id, {
+      resolution: 'denied',
+      resolved_by: 'x',
+      reason: 'nope',
+    })
+
+    const first = service.audit(auditInput(id), 'h')
+    expect(first.status).toBe(201)
+    const recordCount = records.length
+
+    const replay = service.audit(auditInput(id), 'h')
+    expect(replay.status).toBe(200)
+    expect(replay.body['already_finalized']).toBe(true)
+    expect(replay.body['audit_record_id']).toBe(first.body['audit_record_id'])
+    expect(records.length).toBe(recordCount)
+
+    const chain = records.at(-1)?.record.evidence_chain as Record<string, unknown>
+    expect((chain['approval'] as Record<string, unknown>)['denial_reason']).toBe('nope')
+  })
+
   it('enforces evaluation TTL on access (404 evaluation_expired before the sweep)', () => {
     const { service, advance, records } = makeService({ ttlMs: 1000 })
     const ev = service.evaluate(evalInput())

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -31,7 +31,7 @@ import type { EvidenceStore } from '../evidence/store.js'
 import type { AuditWriter } from '../audit/writer.js'
 import type { AuditRecord } from '../audit/types.js'
 import type { ApprovalRouter, NativeResolution } from '../approval/router.js'
-import type { ApprovalTicket } from '../approval/types.js'
+import type { ApprovalAuditContext, ApprovalTicket } from '../approval/types.js'
 import type { RateLimiter } from '../policy/rate-limiter.js'
 import type { SpendLimiter } from '../policy/spend-limiter.js'
 import { GovernanceConfigError } from './errors.js'
@@ -535,6 +535,7 @@ export class GovernanceService {
     // require_approval must be resolved before auditing. Retryable.
     let approvalStatus: string | null = null
     let approvedBy: string | null = null
+    let approvalContext: ApprovalAuditContext | undefined
     if (entry.approvalTicketId) {
       const ticket = this.getTicketStatus(entry.approvalTicketId)
       const status = ticket?.status
@@ -543,6 +544,20 @@ export class GovernanceService {
       }
       approvalStatus = status
       approvedBy = ticket.resolved_by ?? null
+      // Same durable approval context the MCP path emits. Only denial reasons
+      // apply here in practice — native tickets never start escalation timers.
+      if (ticket.denial_reason || ticket.escalated_at) {
+        approvalContext = {
+          ticket_id: entry.approvalTicketId,
+          ...(ticket.denial_reason ? { denial_reason: ticket.denial_reason } : {}),
+          ...(ticket.escalated_at
+            ? {
+                escalated_at: ticket.escalated_at,
+                escalated_to: [...(ticket.escalated_to ?? [])],
+              }
+            : {}),
+        }
+      }
     }
 
     // Validate the optional post-hoc spend override.
@@ -595,6 +610,7 @@ export class GovernanceService {
       limitsChain,
       approvalStatus,
       approvedBy,
+      approvalContext,
       upstreamError: req.status === 'error' ? (req.error ?? 'tool call failed') : null,
       upstreamResponse: req.result ?? null,
       upstreamLatencyMs: req.duration_ms ?? null,
@@ -1078,6 +1094,9 @@ export class GovernanceService {
     if (args.sidebandUnreported) {
       evidenceChain = { ...(evidenceChain ?? {}), sideband: { unreported: true } }
     }
+    if (args.approvalContext) {
+      evidenceChain = { ...(evidenceChain ?? {}), approval: { ...args.approvalContext } }
+    }
 
     const record: Omit<AuditRecord, 'id' | 'created_at'> = {
       timestamp: args.timestampIso,
@@ -1150,6 +1169,7 @@ interface WriteAuditArgs {
   limitsChain?: Record<string, unknown>
   approvalStatus?: string | null
   approvedBy?: string | null
+  approvalContext?: ApprovalAuditContext
   upstreamError?: string | null
   upstreamResponse?: unknown
   upstreamLatencyMs?: number | null


### PR DESCRIPTION
## What

Audit records now durably keep approval denial reasons and escalation
history. Both lived only on the in-memory approval ticket, which is
cleaned up an hour after resolution, so the audit trail could not answer
"who denied this and why" or "did this approval escalate before anyone
acted".

Closes #110.

## Changes

- New `evidence_chain.approval` block on tool-call audit records,
  following the `evidence_chain.break_glass` pattern: `ticket_id`
  (correlates the record to its ticket), `denial_reason` when the denier
  supplied one, and `escalated_at` / `escalated_to` when the escalation
  timer fired before resolution. Emitted only when there is content, so
  plain approvals keep `evidence_chain: null`. Additive: JSON column, no
  migration, CSV export picks it up unchanged.
- MCP path: the governed forwarder snapshots the context immediately
  after the approval resolves, before any upstream await. A forwarded
  call that outlives the ticket retention cannot lose the context; a
  regression test pins this by evicting the ticket mid-forward. The
  synthetic ticketless denial emitted when a submit races router close
  produces no block.
- Sideband path: `/audit` finalization captures the same block from the
  ticket read it already performs. Replay via the tombstone path returns
  the same record with the block intact. Native tickets never escalate,
  so only denial reasons appear there in practice.
- Dashboard: the audit detail panel's evidence chain renders the new
  block behind a type guard that validates every field before use.
- Docs: `docs/audit.md` documents the block; the three `docs/approvals.md`
  sentences that described the old ticket-only behavior now describe the
  durable one; changelog entry added.

## Verification

- TDD throughout: 12 new tests (9 forwarder, 3 sideband, 3 dashboard),
  each watched failing first where they drive behavior.
- Full suite green: 1611 proxy, 303 dashboard, 47 python-sdk;
  `pnpm format:check`, `pnpm lint`, `pnpm -r typecheck`, and the
  docs-drift check pass.
- Plan and diff each went through an external review round; the plan
  review replaced a late ticket read-back with the snapshot design, and
  the diff review surfaced the ticketless-denial edge, fixed here with
  its own regression test.
