### PR TITLE
fix(dashboard): validate CORS origins as private IPv4 literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,19 @@ Maintainer notes:
   approval, so calling it populates the dashboard Approvals page as the README
   promised; the "Exercise it" section walks through it.
 
+### Security
+
+- **Harden dashboard CORS origin validation (GHSA-2c3r-q7gv-hp2m).** The dashboard
+  sideband's private-network origin allowlist matched request origins by
+  hostname prefix, so a public DNS name beginning with a private-range label
+  (for example `192.168.attacker.com`) was admitted. When the dashboard ran in
+  open mode (`dashboard.allow_open_mode: true`, no `dashboard.api_secret`), a
+  browser page on such an origin could read the sideband cross-origin. Origins
+  are now validated as real private IPv4 literals, so hostnames no longer match.
+  Secure mode (`dashboard.api_secret` set) was not affected: cross-origin reads
+  still require a credential the attacker page cannot supply. Affects versions
+  through 0.7.0.
+
 ## [0.7.0] - 2026-06-30
 
 ### Added

--- a/docs/sideband-api.md
+++ b/docs/sideband-api.md
@@ -10,8 +10,8 @@ The dashboard sideband is a read/write REST + SSE surface served on a separate p
 
 - **Default port:** `127.0.0.1:3100` (configurable via `dashboard.port`).
 - **Bind address:** localhost-only by default. Bind publicly only behind a TLS-terminating reverse proxy you control.
-- **Auth:** By default, `dashboard.enabled: true` requires `dashboard.api_secret`. Browser clients unlock with `POST /api/auth/session` + HttpOnly cookie; non-browser clients can use `Authorization: Bearer <api_secret>`. Running without `api_secret` is only allowed with explicit `dashboard.allow_open_mode: true` on loopback hosts. See [Authentication](#authentication) below.
-- **CORS:** Allows same-origin, `localhost` / `127.0.0.1` / `0.0.0.0`, and private network ranges (`10.x`, `172.16-31.x`, `192.168.x`) for Docker bridge and LAN access. All other origins are rejected.
+- **Auth:** By default, `dashboard.enabled: true` requires `dashboard.api_secret`. Browser clients unlock with `POST /api/auth/session` + HttpOnly cookie; non-browser clients can use `Authorization: Bearer <api_secret>`. Running without `api_secret` is only allowed with explicit `dashboard.allow_open_mode: true` on loopback hosts. Open mode disables all sideband authentication and is a local/demo posture only: the CORS allowlist above does not make it safe, since an unauthenticated loopback service is still reachable by a determined local attacker (for example via DNS rebinding). See [Authentication](#authentication) below.
+- **CORS:** Allows same-origin, `localhost` / `127.0.0.1` / `0.0.0.0`, and validated private-network IPv4 literals (`10.x`, `172.16-31.x`, `192.168.x`) for Docker bridge and LAN access. Origins are matched as real IP addresses, not by hostname prefix; every other origin, including hostnames, receives no CORS headers. (CORS is a browser-enforced control, not a server-side auth boundary.)
 - **Content type:** JSON for everything except `/api/audit/export` (JSON or CSV attachment) and `/api/events` (SSE stream).
 - **Non-200 errors:** Always JSON in the shape `{ "error": "<message>" }`. Unknown `/api/*` paths return `404` with this shape (never HTML).
 

--- a/packages/proxy/src/dashboard/api.test.ts
+++ b/packages/proxy/src/dashboard/api.test.ts
@@ -1631,3 +1631,114 @@ describe('unhandled errors', () => {
     expect(errSpy).not.toHaveBeenCalled()
   })
 })
+
+// ---------------------------------------------------------------------------
+// CORS origin validation
+// ---------------------------------------------------------------------------
+
+describe('CORS origin validation', () => {
+  // Origins that MUST be admitted: loopback plus genuine private-network IPv4
+  // literals (Docker bridge, LAN).
+  const allowed = [
+    'http://localhost:5173',
+    'http://127.0.0.1:3100',
+    'http://192.168.1.20',
+    'http://10.0.0.5',
+    'http://172.16.0.1',
+    'http://172.31.255.254',
+  ]
+
+  // Origins that MUST be rejected. The first four are the attack: public DNS
+  // names whose hostname merely starts with a private-range prefix. The rest
+  // are out-of-range or malformed addresses.
+  const rejected = [
+    'http://192.168.attacker.com',
+    'http://10.evil.io',
+    'http://172.16.pwn.example',
+    'http://192.168.1.1.nip.io',
+    'http://172.15.0.1',
+    'http://172.32.0.1',
+    'http://999.1.1.1',
+    'https://evil.example.com',
+  ]
+
+  for (const origin of allowed) {
+    it(`admits ${origin}`, async () => {
+      const { get } = setup()
+      const res = await get('/api/health', { origin })
+      expect(res.headers.get('access-control-allow-origin')).toBe(origin)
+    })
+  }
+
+  for (const origin of rejected) {
+    it(`rejects ${origin}`, async () => {
+      const { get } = setup()
+      const res = await get('/api/health', { origin })
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+  }
+})
+
+describe('CORS origin validation — secure mode', () => {
+  const SECRET = 'secure-mode-cors-secret'
+
+  it('admits a private origin via CORS but still 401s without a credential', async () => {
+    const { get } = setup({ apiSecret: SECRET })
+    const res = await get('/api/feed', { origin: 'http://192.168.1.20' })
+    expect(res.status).toBe(401)
+    // CORS admits the origin, but the auth layer is the real gate.
+    expect(res.headers.get('access-control-allow-origin')).toBe('http://192.168.1.20')
+    // No credentials header, so a browser fetch cannot attach cookies.
+    expect(res.headers.get('access-control-allow-credentials')).toBeNull()
+  })
+
+  it('rejects a spoofed origin and still 401s without a credential', async () => {
+    const { get } = setup({ apiSecret: SECRET })
+    const res = await get('/api/feed', { origin: 'http://192.168.attacker.com' })
+    expect(res.status).toBe(401)
+    expect(res.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  it('issues the session cookie with SameSite=Lax', async () => {
+    const { post } = setup({ apiSecret: SECRET })
+    const res = await post('/api/auth/session', { secret: SECRET })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('set-cookie') ?? '').toMatch(/SameSite=Lax/i)
+  })
+})
+
+describe('CORS origin validation — hostname normalization', () => {
+  // The URL parser normalizes these numeric/octal forms to private IPv4
+  // literals, so they are admitted. A browser only emits such an origin if the
+  // page was actually served from that address (not an attacker-controlled DNS
+  // name), so this is not a bypass — pinned here to keep the behavior stable.
+  const admittedByNormalization = [
+    'http://0x7f000001', // -> 127.0.0.1
+    'http://3232235521', // -> 192.168.0.1
+    'http://0300.0250.0.1', // -> 192.168.0.1
+    'http://192.168.1.1.', // trailing dot -> 192.168.1.1
+  ]
+
+  const rejectedForms = [
+    'http://192.168.1.1%2f@evil.com', // real host is evil.com
+    'http://xn--bcher-kva.example', // punycode hostname, not an IP
+    'http://[::1]', // IPv6 loopback is not in the allowlist
+    'http://010.0.0.1', // octal -> 8.0.0.1, a public address
+  ]
+
+  for (const origin of admittedByNormalization) {
+    it(`admits normalized private literal ${origin}`, async () => {
+      const { get } = setup()
+      const res = await get('/api/health', { origin })
+      expect(res.headers.get('access-control-allow-origin')).toBe(origin)
+    })
+  }
+
+  for (const origin of rejectedForms) {
+    it(`rejects ${origin}`, async () => {
+      const { get } = setup()
+      const res = await get('/api/health', { origin })
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+  }
+})

--- a/packages/proxy/src/dashboard/api.ts
+++ b/packages/proxy/src/dashboard/api.ts
@@ -190,6 +190,26 @@ function shouldSetSecureCookie(url: string, xForwardedProto: string | undefined)
   return new URL(url).protocol === 'https:'
 }
 
+/**
+ * Whether `host` is a private-network IPv4 literal (RFC 1918).
+ *
+ * Validates a real dotted-quad with in-range octets, NOT a string prefix. A
+ * prefix check would admit attacker-controlled DNS names such as
+ * `192.168.attacker.com` or `10.evil.io`, which resolve anywhere but are
+ * treated as private for CORS. Hostnames (any non-numeric label) fail the
+ * dotted-quad match and are rejected.
+ */
+function isPrivateIpv4(host: string): boolean {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
+  if (!match) return false
+  const a = Number(match[1])
+  const b = Number(match[2])
+  const c = Number(match[3])
+  const d = Number(match[4])
+  if (a > 255 || b > 255 || c > 255 || d > 255) return false
+  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168)
+}
+
 // ---------------------------------------------------------------------------
 // Dashboard API factory
 // ---------------------------------------------------------------------------
@@ -234,9 +254,9 @@ export function createDashboardAppWithLifecycle(
 
   // CORS — needed during development when React dev server (e.g. port 5173)
   // calls the dashboard API (port 3100). In production/Docker the SPA is served
-  // same-origin so CORS isn't triggered. Admits localhost plus hostnames with
-  // private-network prefixes (Docker bridge, LAN) — a prefix check, not IP
-  // validation; other origins get no CORS headers, which only browsers enforce.
+  // same-origin so CORS isn't triggered. Admits localhost plus validated
+  // private-network IPv4 literals (Docker bridge, LAN); every other origin,
+  // including hostnames, gets no CORS headers.
   app.use(
     '*',
     cors({
@@ -246,8 +266,7 @@ export function createDashboardAppWithLifecycle(
           const url = new URL(origin)
           const h = url.hostname
           if (h === 'localhost' || h === '127.0.0.1' || h === '0.0.0.0') return origin
-          // Allow private network IPs (Docker bridge, LAN access)
-          if (/^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(h)) return origin
+          if (isPrivateIpv4(h)) return origin
         } catch {
           // Invalid origin URL — reject
         }


### PR DESCRIPTION
Fixes the CORS origin-validation weakness tracked in GHSA-2c3r-q7gv-hp2m (private advisory; ships in 0.8.0).

The dashboard sideband matched CORS request origins against a private-network hostname *prefix*, so a public DNS name like `192.168.attacker.com` was admitted. In open mode (`dashboard.allow_open_mode: true`, no `api_secret`) a browser page on such an origin could read the sideband cross-origin. Secure mode (the default) was unaffected: cross-origin reads still require a credential the attacker page cannot supply (no `Access-Control-Allow-Credentials`, `SameSite=Lax` cookie).

The allowlist now validates a real dotted-quad private IPv4 literal (`isPrivateIpv4`) instead of prefix-matching the hostname, so DNS names no longer match. Numeric/octal origin forms normalize to private IP *literals* (not attacker-controlled hostnames), which a browser only emits when the page was actually served from that address, so they are not a bypass — pinned by tests to keep the behavior stable.

Includes:
- 25 CORS tests: allow/reject table, secure-mode regression (admitted origin still 401s without a credential; no credentials header; `SameSite=Lax`), and hostname-normalization edge cases.
- `docs/sideband-api.md`: describes IP-literal validation and states that open mode stays unauthenticated/demo-only even with the CORS allowlist (the fix does not close the DNS-rebinding class for an unauthenticated loopback service).
- CHANGELOG `Security` entry.