### PR TITLE
docs(changelog): roll unreleased entries into 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Maintainer notes:
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-03
+
 ### Added
 
 - **Audit records keep denial reasons and escalation history (#110).** Approval


### PR DESCRIPTION
Roll the accumulated `Unreleased` entries into a `0.8.0` section dated 2026-07-03, ahead of tagging `v0.8.0`.

0.8.0 batches:
- Added: audit records keep denial reasons and escalation history (#110)
- Changed: sidecar guide (#105), dashboard login copy (#94), Docker quickstart (#93)
- Fixed: sideband JSON 500s (#115), Docker demo approvals (#104)
- Security: harden dashboard CORS origin validation (GHSA-2c3r-q7gv-hp2m, #121)

Minor bump (not patch) because #110 adds a new audit field. No code changes in this PR.