### PR TITLE
docs(adapter-api): correct API reference against the code

### DIFF
--- a/docs/adapter-api.md
+++ b/docs/adapter-api.md
@@ -15,7 +15,7 @@ The governance API lives on the **SDK sideband** — the local server on `127.0.
 
 Helio's headline guarantee is **structural** enforcement: an agent speaking MCP physically cannot reach a tool except through the proxy. Hook-based frameworks run their tools in-process, so there is nothing to proxy — the framework's hook dispatcher is the enforcement point, and Helio supplies the decision. This is the standard policy-decision-point / policy-enforcement-point split.
 
-Helio classifies every governed call by **enforcement grade**, surfaced via the audit `origin` column:
+Helio classifies every governed call by **enforcement grade**. The audit `origin` column separates host-enforced calls (the adapter's origin string) from proxy-path calls (`mcp`); whether an `mcp` record was structural or network is a property of the deployment's upstream transport, not something the record captures:
 
 | Grade           | Path                     | Guarantee                                                          |
 | --------------- | ------------------------ | ------------------------------------------------------------------ |
@@ -36,7 +36,7 @@ An adapter built on this API **MUST**:
 
 ## Authentication
 
-The governance routes require `Authorization: Bearer <HELIO_ADAPTER_TOKEN>`. This is a **separate token** from the SDK's `HELIO_SDK_TOKEN`: an SDK client cannot drive policy decisions, and an adapter cannot call the SDK's `POST /evidence`/`/context` routes. The adapter's evidence access is deliberately narrow: it may attach evidence to a call it is auditing, via the optional `evidence` field on `POST /audit` (success-only, bound to that evaluation's own session/tool, subject to the policy allowlist — see [Populating evidence](#populating-evidence)); it cannot write arbitrary evidence to arbitrary sessions. Both tokens are generated per boot (and printed to stderr) unless set in the environment. Requests carrying an `Origin` header are refused (browser-forgery guard), and bodies over 1 MiB are rejected with 413.
+The governance routes require `Authorization: Bearer <HELIO_ADAPTER_TOKEN>`. This is a **separate token** from the SDK's `HELIO_SDK_TOKEN`: an SDK client cannot drive policy decisions, and an adapter cannot call the SDK's `POST /evidence`/`/context` routes. The adapter's evidence access is deliberately narrow: it may attach evidence to a call it is auditing, via the optional `evidence` field on `POST /audit` (success-only, bound to that evaluation's own session/tool, subject to the policy allowlist — see [Populating evidence](#populating-evidence)); it cannot write arbitrary evidence to arbitrary sessions. Both tokens are generated per boot unless set in the environment, and are printed to stderr on start. Requests carrying an `Origin` header are refused (browser-forgery guard), and bodies over 1 MiB are rejected with 413.
 
 If you embed `GovernanceService` directly (instead of running `helio start`), wire an `ApprovalRouter` whenever the policy can emit `require_approval` (explicit rules, `flag_destructive: require_approval`, or `on_tool_drift: require_approval`), otherwise construction and hot-reload fail closed by throwing `GovernanceConfigError` (exported from `@gethelio/proxy`).
 
@@ -46,7 +46,7 @@ If you embed `GovernanceService` directly (instead of running `helio start`), wi
 // Request
 {
   "origin": "openclaw",                  // optional; default "sideband"; ^[a-z0-9_-]{1,64}$
-  "adapter_version": "0.1.0",            // optional, ≤64 chars (per-origin liveness)
+  "adapter_version": "0.1.0",            // optional, ≤64 chars; accepted but not yet recorded
   "agent_id": "main",                    // optional
   "session_id": "oc-session-1",          // optional; required for evidence/dependency rules
   "tool": {
@@ -69,7 +69,7 @@ If you embed `GovernanceService` directly (instead of running `helio start`), wi
   "feedback": { "message": "…" },        // present on blocking decisions
   "approval": { "id": "…", "timeout_ms": 300000, "resolve_path": "/approval/…/resolve" }, // require_approval only
   "limits": { "rate": { } },             // present when a limit rule matched
-  "dry_run": { "would_forward": true },  // dry_run only
+  "dry_run": { "would_forward": true, "evidence_satisfied": true, "limits_ok": true }, // dry_run only
   "tool_drift": { "changes": [ ] }       // present when the drift gate fired
 }
 ```
@@ -106,9 +106,9 @@ The `decision` is an **outcome**, not Helio's internal rule action: a `rate_limi
 }
 ```
 
-Counters are consumed here (not at `/evaluate`), and only when the call actually ran (`success`/`error`, not `not_executed`). `/audit` is **idempotent on `evaluation_id`**: an identical replay returns `200 { already_finalized: true }` with no double-consumption, so a network retry after a lost response is safe. A different payload under the same id is an adapter bug → `409 evaluation_conflict`.
+Counters are consumed here (not at `/evaluate`), and only when the call actually ran (`success`/`error`, not `not_executed`). `/audit` is **idempotent on `evaluation_id`**: an identical replay returns `200 { already_finalized: true }` with no double-consumption, so a network retry after a lost response is safe. Finalized ids are remembered for one `sdk.evaluation_ttl` after finalization; past that window a replay gets `404 evaluation_unknown`. A different payload under the same id is an adapter bug → `409 evaluation_conflict`.
 
-**Decision finalization.** `deny`, `rate_limited`, `spend_limited`, and `dry_run` are **terminal at `/evaluate`** — their audit record is written immediately, so completeness never depends on the adapter calling `/audit`. A later `/audit` for such an evaluation returns `200 { finalized_by: "evaluate" }` and accepts any payload, so adapters may audit unconditionally.
+**Decision finalization.** `deny`, `rate_limited`, `spend_limited`, and `dry_run` are **terminal at `/evaluate`** — their audit record is written immediately, so completeness never depends on the adapter calling `/audit`. A later `/audit` for such an evaluation returns `200 { finalized_by: "evaluate" }` and accepts any payload, so adapters may audit unconditionally (within the same one-TTL window).
 
 `actual_amount` must be finite and `>= 0` (`400 invalid_actual_amount` otherwise) and only applies to evaluations whose decision carried a spend rule (`400 no_spend_rule` if sent for any other evaluation).
 
@@ -120,7 +120,7 @@ Rules:
 
 - **Success-only.** Evidence is written only when `status: "success"`. On `error`/`not_executed` it is ignored (a failed tool must not ground later calls).
 - **First-finalize-only.** Evidence is written once, on the first `/audit`; idempotent replays never re-write (no TTL reset).
-- **Every per-entry failure is soft — never request-fatal.** The audit always finalizes `201`; per-entry outcomes are reported in the response `evidence` array as `{ evidence_key, stored, reason? }`. Reasons: `key_not_in_policy_allowlist` (the key is not named by any `evidence.requires` rule), `too_large` (`evidence_data` over 64 KiB), `too_many` (more than 16 entries — the excess is dropped), `no_session` (the evaluation had no `session_id`), `evidence_unavailable` (this deployment runs governance without an evidence store), `closed` (the store is shutting down). **A rejected key is silently not stored**, so a later grounded `/evaluate` will fail closed — make sure every key you populate is named by an `evidence.requires` rule.
+- **Every per-entry failure is soft — never request-fatal.** The audit always finalizes `201`; per-entry outcomes are reported in the response `evidence` array as `{ evidence_key, stored, reason? }`. Reasons: `key_not_in_policy_allowlist` (the key is not named by any `evidence.requires` rule), `too_large` (`evidence_data` over 64 KiB), `too_many` (more than 16 entries — the excess is dropped), `no_session` (the evaluation had no `session_id`), `evidence_unavailable` (this deployment runs governance without an evidence store), `closed` (the store is shutting down). **A rejected key still finalizes the audit with `201`** — the only signal is the per-entry outcome — and its evidence is not stored, so a later grounded `/evaluate` will fail closed. Make sure every key you populate is named by an `evidence.requires` rule.
 - **Idempotency.** Evidence is part of the `/audit` idempotency hash (order-independent): an identical retry replays cleanly, but the same `evaluation_id` with divergent evidence is `409 evaluation_conflict`.
 
 **Other responses:** `404 evaluation_unknown`, `404 evaluation_expired` (the decision aged out — see below), `409 approval_unresolved` (resolve the approval first; **retryable** with short backoff).
@@ -153,12 +153,12 @@ Evaluates a package/skill install against the operator's `policies.install` rule
 // Request
 { "origin": "openclaw", "package": { "name": "left-pad", "version": "1.3.0", "source": "npm" }, "metadata": { "sender_id": "U7" } }
 // Response 200 (allowed)
-{ "evaluation_id": "…", "decision": "allow", "reason": "no install-time rules defined", "matched_rule": null }
+{ "evaluation_id": "…", "decision": "allow", "reason": "no install-time rules defined", "matched_rule": null, "matched_rule_index": null }
 // Response 200 (denied by a deny_install rule)
-{ "evaluation_id": "…", "decision": "deny", "reason": "Matched \"block-evil\" → deny_install", "matched_rule": "block-evil", "feedback": { "message": "…" } }
+{ "evaluation_id": "…", "decision": "deny", "reason": "Matched \"block-evil\" → deny_install", "matched_rule": "block-evil", "matched_rule_index": 0, "feedback": { "message": "…" } }
 ```
 
-Install rules can match on the package `name` (glob), `source`, and `metadata.*` context (the same reserved keys). `metadata.agent_id` is rejected here too (see `/evaluate`).
+Install rules can match on the package `name` (glob), `source`, and `metadata.*` context (the same well-known keys). `metadata.agent_id` is rejected here too (see `/evaluate`).
 
 ## Approvals
 
@@ -168,12 +168,15 @@ A `require_approval` decision creates a **native ticket** (`channel_name: native
 // POST /approval/:id/resolve
 { "resolution": "approved" | "denied" | "timeout" | "cancelled",
   "resolved_by": "telegram:@oli",   // required for approved/denied
-  "reason": "…", "scope": "once" | "always" }
+  "reason": "…",                    // recorded for denials only (the audit record's denial reason)
+  "scope": "once" | "always" }      // reserved; accepted but currently ignored
 // Response 200
 { "ok": true }
 ```
 
 The resolution does **not** write the audit record; the subsequent `/audit` does, copying the approval status. A native ticket times out at `min(rule timeout, evaluation TTL)`; deadlines are enforced on access, so a late resolve deterministically returns `409 already_resolved`.
+
+**Errors:** `404 ticket_not_found`, `409 not_a_native_ticket` (an MCP-path ticket — resolve those from their approval channel), `409 already_resolved` (normally includes the ticket's terminal `status`; deadline-crossed resolves return this error, and a rare concurrent-resolve race may omit `status`), `400` when `resolved_by` is missing for `approved`/`denied`, `503 governance_unavailable`. The request-level errors from `/evaluate` (`400` validation / invalid JSON, `401`, `403`, `413`) apply here as everywhere on this server.
 
 ## Audit record additions
 
@@ -181,7 +184,7 @@ Sideband activity shares the audit schema with the MCP path, plus three columns 
 
 - `record_kind` — `tool_call` | `drift_event` | `install_scan` | `evaluation_expired`.
 - `origin` — `mcp` for the proxy path, or the adapter origin string.
-- `metadata` — the adapter-supplied context object (reserved keys `channel_id`, `sender_id`, `sender_name`, `conversation_id`). `agent_id` is **not** carried here — it has its own column and is rejected if placed in `metadata`.
+- `metadata` — the adapter-supplied context object, stored as sent (well-known match keys: `channel_id`, `sender_id`, `sender_name`, `conversation_id`). `agent_id` is **not** carried here — it has its own column and is rejected if placed in `metadata`.
 
 An install denied by a `deny_install` rule is recorded with `record_kind: install_scan`, `policy_decision: deny`, and `block_reason: install_denied`.
 


### PR DESCRIPTION
Accuracy pass on docs/adapter-api.md, verified claim by claim against the proxy source and live against the published 0.8.0 build (~30 endpoint checks, all matching the code).

Doc fixes:

- adapter_version is accepted but not recorded anywhere; say so instead of promising per-origin liveness.
- The resolve body's scope field is reserved and currently ignored, and reason is recorded for denials only.
- The enforcement-grade intro no longer claims the audit origin column distinguishes structural from network; it separates host-enforced from proxy-path records.
- The dry_run and install-scan examples now show the full response shapes (evidence_satisfied, limits_ok, matched_rule_index).
- The resolve endpoint gets an error list like the other endpoints, including the already_resolved nuance (its status field can be omitted in a rare concurrent-resolve race).
- The /audit replay and audit-unconditionally guarantees are bounded to one evaluation TTL, matching the tombstone lifetime.
- A rejected evidence key still finalizes the audit with 201; the per-entry outcome is the only signal.
- The four metadata match keys are well-known, not reserved (only agent_id is reserved), and both sideband tokens are printed to stderr whether generated or supplied via the environment.

Follow-up issues for the app-level gaps found during the review (adapter_version recording, scope semantics on native resolutions, env-token stderr echo) are being filed separately.