### PR TITLE
feat(sideband): record adapter liveness and surface GET /api/adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Added
+
+- **Adapter liveness on the dashboard: `GET /api/adapters` (#126).** The SDK
+  sideband now records, per adapter origin, when it was first and last seen
+  and the `adapter_version` it most recently reported on `POST /evaluate` —
+  the per-origin liveness the field was designed for. The dashboard sideband
+  serves it at `GET /api/adapters` (empty list when the SDK sideband is
+  disabled). State is in-memory, bounded by the existing 32-origin budget,
+  and version changes are logged to stderr escaped and capped per origin.
+
 ## [0.8.0] - 2026-07-03
 
 ### Added

--- a/docs/adapter-api.md
+++ b/docs/adapter-api.md
@@ -46,7 +46,7 @@ If you embed `GovernanceService` directly (instead of running `helio start`), wi
 // Request
 {
   "origin": "openclaw",                  // optional; default "sideband"; ^[a-z0-9_-]{1,64}$
-  "adapter_version": "0.1.0",            // optional, ≤64 chars; accepted but not yet recorded
+  "adapter_version": "0.1.0",            // optional, ≤64 chars; per-origin liveness (dashboard GET /api/adapters)
   "agent_id": "main",                    // optional
   "session_id": "oc-session-1",          // optional; required for evidence/dependency rules
   "tool": {

--- a/docs/sideband-api.md
+++ b/docs/sideband-api.md
@@ -44,9 +44,9 @@ Clients that need a page number compute it as `Math.floor(offset / limit) + 1`.
 
 Endpoints that return a computed view of in-memory state are not "resources" in the REST sense, and wrapping them in `{ data }` adds ceremony without signal. They return their computed view directly, with shapes specific to each endpoint.
 
-Endpoints in this category: `GET /api/health`, `GET /api/analytics`, `GET /api/limits`.
+Endpoints in this category: `GET /api/health`, `GET /api/analytics`, `GET /api/limits`, `GET /api/adapters`.
 
-Envelope category does not imply authentication policy: when dashboard auth is enabled, `GET /api/analytics` and `GET /api/limits` still require auth. `GET /api/health` remains the only intentionally unauthenticated probe endpoint.
+Envelope category does not imply authentication policy: when dashboard auth is enabled, `GET /api/analytics`, `GET /api/limits`, and `GET /api/adapters` still require auth. `GET /api/health` remains the only intentionally unauthenticated probe endpoint.
 
 `GET /api/health` in particular is preserved in this form so that container orchestrators (Kubernetes, Docker Compose, Nomad) can point healthcheck probes at it without a custom JSON parser: probes only evaluate the HTTP status code, and the flat `status`, `version`, and `uptime` keys stay easy to read for the humans and scripts that hit the same URL.
 
@@ -266,6 +266,31 @@ Current state of every active rate-limit and spend-limit bucket. Returns empty a
 - `rate_limits[].current` — calls consumed in the current window.
 - `rate_limits[].reset_at_ms` — epoch ms at which the oldest recorded call ages out of the sliding window and `current` drops. The bucket does not reset wholesale.
 - `spend_limits[].current_spend` — total spend in the current window in `currency`.
+
+**Raw-shape endpoint:** this is an RPC-style view.
+
+#### GET /api/adapters
+
+Per-origin liveness of the adapters driving the [SDK sideband's governance API](./adapter-api.md): when each origin was first and last seen, and the `adapter_version` it most recently reported on `POST /evaluate`. State is in-memory (reset on restart) and bounded by the sideband's 32-origin budget. Returns an empty list when the SDK sideband is disabled, so dashboards need no capability probe.
+
+**Response (200):**
+
+```json
+{
+  "adapters": [
+    {
+      "origin": "openclaw",
+      "adapter_version": "0.1.0",
+      "first_seen": "2026-07-04T12:00:00.000Z",
+      "last_seen": "2026-07-04T12:34:56.789Z"
+    }
+  ]
+}
+```
+
+- An entry is **created by the origin's first `POST /evaluate`** (the path that enforces the origin budget). `/install-scan` and `/audit` only refresh existing entries, so an origin whose sole traffic is install scans does not appear here.
+- `adapter_version` — the last value the origin supplied on `/evaluate`; `null` until one is supplied.
+- `last_seen` — the most recent `/evaluate`, `/install-scan`, or successfully finalized `/audit` from the origin. Entries are sorted most recently seen first.
 
 **Raw-shape endpoint:** this is an RPC-style view.
 

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -505,6 +505,9 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
         spendLimiter,
         evidenceStore,
         eventBus,
+        // Adapter liveness for GET /api/adapters (issue #126); undefined
+        // unless the SDK sideband is enabled → endpoint serves an empty list.
+        adapterLiveness: governanceService,
       },
       {
         apiSecret: config.dashboard.api_secret,

--- a/packages/proxy/src/dashboard/api.test.ts
+++ b/packages/proxy/src/dashboard/api.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createDashboardApp, createDashboardAppWithLifecycle } from './api.js'
+import type { DashboardAppDeps } from './api.js'
 import { DashboardEventBus } from './event-bus.js'
 import { AuditStore } from '../audit/store.js'
 import type { AuditRecord } from '../audit/types.js'
@@ -29,7 +30,10 @@ function at<T>(arr: readonly T[], index: number): T {
 // Setup helper
 // ---------------------------------------------------------------------------
 
-function setup(options?: { apiSecret?: string }) {
+function setup(options?: {
+  apiSecret?: string
+  adapterLiveness?: DashboardAppDeps['adapterLiveness']
+}) {
   const auditStore = new AuditStore({
     path: ':memory:',
     retention: '90d',
@@ -58,6 +62,7 @@ function setup(options?: { apiSecret?: string }) {
       spendLimiter,
       evidenceStore,
       eventBus,
+      adapterLiveness: options?.adapterLiveness,
     },
     { apiSecret: options?.apiSecret },
   )
@@ -746,6 +751,46 @@ describe('GET /api/limits', () => {
     }
     expect(body.spend_limits).toHaveLength(1)
     expect(at(body.spend_limits, 0).current_spend).toBe(100)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Adapters (issue #126)
+// ---------------------------------------------------------------------------
+
+describe('GET /api/adapters', () => {
+  it('returns an empty adapters list when the SDK sideband is not wired', async () => {
+    const { get } = setup()
+    const res = await get('/api/adapters')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ adapters: [] })
+  })
+
+  it('returns liveness entries from the registry in a raw envelope', async () => {
+    const entries = [
+      {
+        origin: 'openclaw',
+        adapter_version: '0.1.0',
+        first_seen: '2026-07-04T12:00:00.000Z',
+        last_seen: '2026-07-04T12:34:56.789Z',
+      },
+      {
+        origin: 'sideband',
+        adapter_version: null,
+        first_seen: '2026-07-04T11:00:00.000Z',
+        last_seen: '2026-07-04T11:00:00.000Z',
+      },
+    ]
+    const { get } = setup({ adapterLiveness: { listAdapters: () => entries } })
+    const res = await get('/api/adapters')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ adapters: entries })
+  })
+
+  it('requires auth like the other read endpoints when a secret is set', async () => {
+    const { get } = setup({ apiSecret: 'test-secret' })
+    const res = await get('/api/adapters')
+    expect(res.status).toBe(401)
   })
 })
 

--- a/packages/proxy/src/dashboard/api.ts
+++ b/packages/proxy/src/dashboard/api.ts
@@ -21,6 +21,7 @@ import { clampInt } from '../util/clamp.js'
 import { formatZodErrors } from '../util/format-zod-errors.js'
 import type { DashboardEventBus } from './event-bus.js'
 import { DashboardSessionStore } from './session.js'
+import type { AdapterLivenessEntry } from '../sideband/governance-service.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,6 +36,12 @@ export interface DashboardAppDeps {
   readonly spendLimiter: SpendLimiter
   readonly evidenceStore: EvidenceStore
   readonly eventBus: DashboardEventBus
+  /**
+   * Adapter liveness source for `GET /api/adapters` (issue #126) — a narrow
+   * view of the SDK sideband's GovernanceService. Absent when the SDK
+   * sideband is disabled; the endpoint then serves an empty list.
+   */
+  readonly adapterLiveness?: { listAdapters(): AdapterLivenessEntry[] }
 }
 
 /** Options for the dashboard API. */
@@ -233,6 +240,7 @@ export function createDashboardAppWithLifecycle(
     spendLimiter,
     evidenceStore,
     eventBus,
+    adapterLiveness,
   } = deps
   const apiSecret = options?.apiSecret
   const sessionStore = apiSecret
@@ -541,6 +549,12 @@ export function createDashboardAppWithLifecycle(
       rate_limits: rateLimiter.listKeyStates(),
       spend_limits: spendLimiter.listKeyStates(),
     })
+  })
+
+  // Adapter liveness (issue #126) — same raw envelope as /api/limits. Empty
+  // (not 404/503) without the SDK sideband, so dashboards need no probe.
+  app.get('/api/adapters', (c) => {
+    return c.json({ adapters: adapterLiveness?.listAdapters() ?? [] })
   })
 
   // -------------------------------------------------------------------------

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -44,6 +44,7 @@ export type {
   AuditInput,
   InstallScanInput,
   ResolveApprovalInput,
+  AdapterLivenessEntry,
 } from './sideband/governance-service.js'
 export { AuditStore, AuditWriter } from './audit/index.js'
 export type {

--- a/packages/proxy/src/sideband/governance-service.test.ts
+++ b/packages/proxy/src/sideband/governance-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { GovernanceService } from './governance-service.js'
 import type { EvaluateInput, AuditInput } from './governance-service.js'
 import { GovernanceConfigError } from './errors.js'
@@ -1148,5 +1148,269 @@ describe('audit evidence', () => {
     const h = makeService({ withEvidence: true })
     const { outcomes } = evalAudit(h, undefined)
     expect(outcomes).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// adapter liveness registry (issue #126)
+// ---------------------------------------------------------------------------
+
+describe('GovernanceService adapter liveness registry', () => {
+  const BASE = 1_000_000
+  const iso = (ms: number) => new Date(ms).toISOString()
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const installInput = (origin: string) => ({
+    origin,
+    agent_id: null,
+    session_id: null,
+    package: { name: 'left-pad' },
+    metadata: null,
+  })
+
+  it('evaluate records first_seen/last_seen with a null version when none is supplied', () => {
+    const { service } = makeService()
+    service.evaluate(evalInput())
+    expect(service.listAdapters()).toEqual([
+      {
+        origin: 'openclaw',
+        adapter_version: null,
+        first_seen: iso(BASE),
+        last_seen: iso(BASE),
+      },
+    ])
+  })
+
+  it('records the supplied version, updates last-write-wins, and keeps first_seen', () => {
+    const { service, advance } = makeService()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    service.evaluate(evalInput({ adapter_version: '0.1.0' }))
+    advance(5_000)
+    service.evaluate(evalInput({ adapter_version: '0.2.0' }))
+    expect(service.listAdapters()).toEqual([
+      {
+        origin: 'openclaw',
+        adapter_version: '0.2.0',
+        first_seen: iso(BASE),
+        last_seen: iso(BASE + 5_000),
+      },
+    ])
+  })
+
+  it('retains the last supplied version when a later evaluate omits it', () => {
+    const { service, advance } = makeService()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    service.evaluate(evalInput({ adapter_version: '0.1.0' }))
+    advance(1_000)
+    service.evaluate(evalInput())
+    expect(service.listAdapters()[0]).toMatchObject({
+      adapter_version: '0.1.0',
+      last_seen: iso(BASE + 1_000),
+    })
+  })
+
+  it('ignores an empty or over-64-char adapter_version (embedder path)', () => {
+    const { service } = makeService()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    service.evaluate(evalInput({ adapter_version: '' }))
+    expect(service.listAdapters()[0]?.adapter_version).toBeNull()
+    service.evaluate(evalInput({ adapter_version: 'v'.repeat(65) }))
+    expect(service.listAdapters()[0]?.adapter_version).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('escapes a caller-controlled origin in version log lines (embedder path)', () => {
+    const { service } = makeService()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const evil = 'x\n[helio] forged line'
+    service.evaluate(evalInput({ origin: evil, adapter_version: '1.0' }))
+    const line = String(spy.mock.calls[0]?.[0])
+    expect(line).not.toMatch(/\n/)
+    expect(line).toContain(JSON.stringify(evil))
+  })
+
+  it('does not refresh last_seen when the audit write throws (audit not finalized)', () => {
+    let time = BASE
+    const throwingWriter = {
+      push: () => {
+        throw new Error('disk full')
+      },
+      pushImmediate: () => {
+        throw new Error('disk full')
+      },
+    } as unknown as AuditWriter
+    const service = new GovernanceService({
+      policy: compile({ default: 'allow', rules: [] }),
+      auditWriter: throwingWriter,
+      ttlMs: 600_000,
+      now: () => time,
+      sweepIntervalMs: 0,
+    })
+    const ev = service.evaluate(evalInput())
+    const id = ev.body['evaluation_id'] as string
+    time += 5_000
+    expect(() => service.audit(auditInput(id), 'h')).toThrow()
+    expect(service.listAdapters()[0]?.last_seen).toBe(iso(BASE))
+  })
+
+  it('logs first sighting and version changes with the version JSON-escaped', () => {
+    const { service } = makeService()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    service.evaluate(evalInput({ adapter_version: '0.1.0' }))
+    service.evaluate(evalInput({ adapter_version: '0.2\n"evil' }))
+
+    const lines = spy.mock.calls.map((c) => String(c[0]))
+    expect(lines[0]).toBe('[helio] adapter origin "openclaw" reports version "0.1.0"')
+    expect(lines[1]).toBe(
+      `[helio] adapter origin "openclaw" version changed "0.1.0" -> ${JSON.stringify('0.2\n"evil')}`,
+    )
+    // The raw newline must not survive into the log line.
+    expect(lines[1]).not.toMatch(/\n/)
+  })
+
+  it('caps version log lines at 5 per origin per boot, then one suppression summary', () => {
+    const { service } = makeService()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    for (let i = 1; i <= 7; i++) {
+      service.evaluate(evalInput({ adapter_version: `0.${String(i)}.0` }))
+    }
+    const lines = spy.mock.calls.map((c) => String(c[0]))
+    const versionLines = lines.filter((l) => l.includes('version'))
+    const summaryLines = lines.filter((l) => l.includes('suppressing'))
+    expect(versionLines.filter((l) => !l.includes('suppressing'))).toHaveLength(5)
+    expect(summaryLines).toHaveLength(1)
+    // The 7th change added nothing beyond the summary already emitted at the 6th.
+    expect(lines).toHaveLength(6)
+  })
+
+  it('install-scan refreshes last_seen for a known origin but never creates one', () => {
+    const { service, advance } = makeService()
+    service.evaluate(evalInput())
+    advance(2_000)
+    service.installScan(installInput('openclaw'))
+    expect(service.listAdapters()[0]).toMatchObject({ last_seen: iso(BASE + 2_000) })
+
+    service.installScan(installInput('unseen-origin'))
+    expect(service.listAdapters().map((a) => a.origin)).toEqual(['openclaw'])
+  })
+
+  it('audit refreshes last_seen on the successful first finalize', () => {
+    const { service, advance } = makeService()
+    const ev = service.evaluate(evalInput())
+    const id = ev.body['evaluation_id'] as string
+    advance(3_000)
+    expect(service.audit(auditInput(id), 'h').status).toBe(201)
+    expect(service.listAdapters()[0]).toMatchObject({ last_seen: iso(BASE + 3_000) })
+  })
+
+  it('audit does not refresh on approval_unresolved, invalid_actual_amount, or no_spend_rule', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [{ name: 'ap', match: { tool: 'gated' }, action: 'require_approval' }],
+    })
+    const { service, advance } = makeService({ policy, withApprovals: true })
+
+    // approval_unresolved 409
+    const gated = service.evaluate(evalInput({ tool: { name: 'gated' } }))
+    const gatedId = gated.body['evaluation_id'] as string
+    advance(1_000)
+    expect(service.audit(auditInput(gatedId), 'h').status).toBe(409)
+    expect(service.listAdapters()[0]?.last_seen).toBe(iso(BASE))
+
+    // invalid_actual_amount / no_spend_rule 400s on a plain allow evaluation
+    const plain = service.evaluate(evalInput())
+    const plainId = plain.body['evaluation_id'] as string
+    advance(1_000)
+    expect(service.audit(auditInput(plainId, { actual_amount: -1 }), 'h').status).toBe(400)
+    expect(service.audit(auditInput(plainId, { actual_amount: 1 }), 'h').status).toBe(400)
+    expect(service.listAdapters()[0]?.last_seen).toBe(iso(BASE + 1_000))
+  })
+
+  it('audit does not refresh on evaluation_expired or on a tombstone replay', () => {
+    const { service, advance } = makeService({ ttlMs: 10_000 })
+
+    // Expired: never audited in time.
+    const ev = service.evaluate(evalInput())
+    const id = ev.body['evaluation_id'] as string
+    advance(10_000)
+    expect(service.audit(auditInput(id), 'h').status).toBe(404)
+    expect(service.listAdapters()[0]?.last_seen).toBe(iso(BASE))
+
+    // Replay: refresh happens at first finalize only.
+    const ev2 = service.evaluate(evalInput())
+    const id2 = ev2.body['evaluation_id'] as string
+    advance(1_000)
+    expect(service.audit(auditInput(id2), 'h').status).toBe(201)
+    advance(1_000)
+    expect(service.audit(auditInput(id2), 'h').status).toBe(200)
+    expect(service.listAdapters()[0]?.last_seen).toBe(iso(BASE + 11_000))
+  })
+
+  it('keeps last_seen monotonic when the clock moves backward', () => {
+    const { service, advance } = makeService()
+    service.evaluate(evalInput())
+    advance(-500_000)
+    service.evaluate(evalInput())
+    expect(service.listAdapters()[0]?.last_seen).toBe(iso(BASE))
+  })
+
+  it('a 33rd origin is refused by evaluate and leaves no registry entry', () => {
+    const { service } = makeService()
+    for (let i = 0; i < 32; i++) {
+      expect(service.evaluate(evalInput({ origin: `origin-${String(i)}` })).status).toBe(200)
+    }
+    const res = service.evaluate(evalInput({ origin: 'origin-32' }))
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ error: 'origin_limit_exceeded' })
+    expect(service.listAdapters()).toHaveLength(32)
+    expect(service.listAdapters().some((a) => a.origin === 'origin-32')).toBe(false)
+  })
+
+  it('listAdapters sorts by last_seen descending', () => {
+    const { service, advance } = makeService()
+    service.evaluate(evalInput({ origin: 'older' }))
+    advance(1_000)
+    service.evaluate(evalInput({ origin: 'newer' }))
+    expect(service.listAdapters().map((a) => a.origin)).toEqual(['newer', 'older'])
+  })
+
+  it('close() clears the registry', () => {
+    const { service } = makeService()
+    service.evaluate(evalInput())
+    service.close()
+    expect(service.listAdapters()).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// memory budget caps — per-origin tool baselines
+// (The 32-origin cap is pinned by the registry describe's 33rd-origin test.)
+// ---------------------------------------------------------------------------
+
+describe('GovernanceService tool baseline cap', () => {
+  it('refuses the 1,025th first-seen definition but keeps updating baselined tools', () => {
+    const { service } = makeService()
+    for (let i = 0; i < 1_024; i++) {
+      const res = service.evaluate(
+        evalInput({ tool: { name: `tool-${String(i)}`, description: 'd' } }),
+      )
+      expect(res.status).toBe(200)
+    }
+
+    // First-seen definition past the cap is refused fail-closed…
+    const over = service.evaluate(evalInput({ tool: { name: 'tool-1024', description: 'd' } }))
+    expect(over.status).toBe(400)
+    expect(over.body).toEqual({ error: 'tool_baseline_limit' })
+
+    // …while a definition UPDATE for an already-baselined tool still proceeds
+    // at cap: the evaluation runs (200, no error) and the changed definition
+    // is ingested — visible as a drift block under the default drift mode.
+    const update = service.evaluate(evalInput({ tool: { name: 'tool-0', description: 'changed' } }))
+    expect(update.status).toBe(200)
+    expect(update.body['error']).toBeUndefined()
+    expect(update.body['tool_drift']).toBeDefined()
   })
 })

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -54,6 +54,10 @@ const MAX_SENDER_KEYS = 50_000
 // without discarding the audit row for a call that already ran.
 const MAX_EVIDENCE_ENTRIES = 16
 const MAX_EVIDENCE_BYTES = 64 * 1_024
+// Version-sighting/change log lines per origin per boot (issue #126).
+// adapter_version is caller-controlled, so unbounded change-logging would be
+// a log-spam vector; after the cap one suppression summary is emitted.
+const MAX_VERSION_LOG_LINES_PER_ORIGIN = 5
 
 const SWEEP_INTERVAL_MS = 30_000
 
@@ -145,6 +149,18 @@ export interface ServiceResult {
   readonly body: Record<string, unknown>
 }
 
+/**
+ * Per-origin adapter liveness, wire-ready for the dashboard's
+ * `GET /api/adapters` (issue #126). ISO-8601 timestamps; `adapter_version`
+ * stays null until an /evaluate supplies one.
+ */
+export interface AdapterLivenessEntry {
+  readonly origin: string
+  readonly adapter_version: string | null
+  readonly first_seen: string
+  readonly last_seen: string
+}
+
 // ---------------------------------------------------------------------------
 // Internal registry types
 // ---------------------------------------------------------------------------
@@ -177,6 +193,15 @@ interface PendingEvaluation {
   readonly evaluationExpiresAtMs: number
   readonly ticketTimeoutAtMs: number | undefined
   readonly bytes: number
+}
+
+// adapterVersion/lastSeenMs/versionLogCount are mutated in place on every
+// sighting (recordAdapterSeen/touchAdapter); firstSeenMs is set once.
+interface AdapterLivenessState {
+  adapterVersion: string | null
+  readonly firstSeenMs: number
+  lastSeenMs: number
+  versionLogCount: number
 }
 
 type FinalizedBy = 'evaluate' | 'audit' | 'expired'
@@ -234,6 +259,13 @@ export class GovernanceService {
 
   /** Distinct sender_id limit keys with live state (reservation registry, issue #13). */
   private readonly senderKeys = new Set<string>()
+  /**
+   * Per-origin adapter liveness (issue #126). New origins are inserted ONLY on
+   * the /evaluate path, which sits behind the MAX_ORIGINS cache gate — every
+   * other path updates existing entries and skips unknown origins, so the
+   * registry shares the origin cap instead of adding a second growth vector.
+   */
+  private readonly adapters = new Map<string, AdapterLivenessState>()
   private readonly pending = new Map<string, PendingEvaluation>()
   private readonly tombstones = new Map<string, Tombstone>()
   private readonly caches = new Map<string, ToolAnnotationCache>()
@@ -308,6 +340,9 @@ export class GovernanceService {
     }
 
     const cache = this.cacheFor(req.origin)
+    // Liveness must not depend on the decision outcome, so record as soon as
+    // the origin has passed its budget gate (issue #126).
+    this.recordAdapterSeen(req.origin, req.adapter_version)
     const toolName = req.tool.name
 
     // Drift guard: merge the supplied definition into the per-origin
@@ -624,6 +659,12 @@ export class GovernanceService {
       expiresAtMs: this.now() + this.ttlMs,
     })
 
+    // Only a SUCCESSFULLY finalized audit counts as adapter liveness: the
+    // 409/400 exits above must not bump it, and neither may a write path that
+    // throws (500, evaluation still pending) — hence after the tombstone
+    // (issue #126).
+    this.touchAdapter(entry.origin)
+
     const body: Record<string, unknown> = { ok: true, audit_record_id: auditId }
     if (evidenceOutcomes) body['evidence'] = evidenceOutcomes
     return { status: 201, body }
@@ -699,6 +740,9 @@ export class GovernanceService {
     if (reserved) {
       return { status: 400, body: { error: 'reserved_metadata_key', key: reserved } }
     }
+    // Update-only: /install-scan has no origin budget gate, so it must never
+    // insert a registry entry (issue #126, see the adapters field note).
+    this.touchAdapter(req.origin)
     const evaluationId = randomUUID()
     const toolName = `install:${req.package.source ?? 'pkg'}:${req.package.name}`
 
@@ -773,6 +817,85 @@ export class GovernanceService {
       decision: install.defaultAction,
       reason: `No matching install rule; default ${install.defaultAction}`,
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Adapter liveness registry (issue #126)
+  // -------------------------------------------------------------------------
+
+  /** Wire-ready liveness entries, most recently seen first. */
+  listAdapters(): AdapterLivenessEntry[] {
+    return [...this.adapters.entries()]
+      .sort(([oa, a], [ob, b]) => b.lastSeenMs - a.lastSeenMs || oa.localeCompare(ob))
+      .map(([origin, state]) => ({
+        origin,
+        adapter_version: state.adapterVersion,
+        first_seen: new Date(state.firstSeenMs).toISOString(),
+        last_seen: new Date(state.lastSeenMs).toISOString(),
+      }))
+  }
+
+  /** Insert-or-refresh on the /evaluate path (the only insert site). */
+  private recordAdapterSeen(origin: string, version: string | undefined): void {
+    // Re-enforce the route schema's version bounds here so direct embedders
+    // are covered too (same rationale as reservedMetadataKey): an empty or
+    // over-64-char version is treated as absent, never stored or logged.
+    const normalized = version && version.length <= 64 ? version : undefined
+    const now = this.now()
+    const existing = this.adapters.get(origin)
+    if (!existing) {
+      const state: AdapterLivenessState = {
+        adapterVersion: normalized ?? null,
+        firstSeenMs: now,
+        lastSeenMs: now,
+        versionLogCount: 0,
+      }
+      this.adapters.set(origin, state)
+      if (normalized !== undefined) this.logVersionEvent(origin, state, null, normalized)
+      return
+    }
+    // The injectable clock is not guaranteed monotonic; last_seen must be.
+    existing.lastSeenMs = Math.max(existing.lastSeenMs, now)
+    if (normalized !== undefined && normalized !== existing.adapterVersion) {
+      this.logVersionEvent(origin, existing, existing.adapterVersion, normalized)
+      existing.adapterVersion = normalized
+    }
+  }
+
+  /** Refresh-only for paths without an origin budget gate (install-scan, audit). */
+  private touchAdapter(origin: string): void {
+    const existing = this.adapters.get(origin)
+    if (!existing) return
+    existing.lastSeenMs = Math.max(existing.lastSeenMs, this.now())
+  }
+
+  /**
+   * Log a version sighting/change, capped per origin per boot. Both origin and
+   * version are caller-controlled free text, so both are JSON-escaped — a
+   * newline or control character must not be able to forge extra log lines
+   * (the route's origin regex does not protect direct embedders).
+   */
+  private logVersionEvent(
+    origin: string,
+    state: AdapterLivenessState,
+    from: string | null,
+    to: string,
+  ): void {
+    if (state.versionLogCount > MAX_VERSION_LOG_LINES_PER_ORIGIN) return
+    state.versionLogCount += 1
+    if (state.versionLogCount > MAX_VERSION_LOG_LINES_PER_ORIGIN) {
+      // eslint-disable-next-line no-console -- Intentional operational warning
+      console.error(
+        `[helio] adapter origin ${JSON.stringify(origin)}: suppressing further version logs after ${String(MAX_VERSION_LOG_LINES_PER_ORIGIN)}`,
+      )
+      return
+    }
+    // eslint-disable-next-line no-console -- Intentional operational log
+    console.error(
+      from === null
+        ? `[helio] adapter origin ${JSON.stringify(origin)} reports version ${JSON.stringify(to)}`
+        : `[helio] adapter origin ${JSON.stringify(origin)} version changed ${JSON.stringify(from)} -> ${JSON.stringify(to)}`,
+    )
   }
 
   // -------------------------------------------------------------------------
@@ -894,6 +1017,7 @@ export class GovernanceService {
     this.tombstones.clear()
     this.caches.clear()
     this.senderKeys.clear()
+    this.adapters.clear()
     this.pendingBytes = 0
   }
 


### PR DESCRIPTION
Closes #126.

The SDK sideband now records per-origin adapter liveness and the dashboard serves it at GET /api/adapters, giving adapter_version the per-origin liveness role it was designed for (the docs called it out as accepted-but-unrecorded since #125).

What it does:

- GovernanceService tracks first_seen, last_seen, and the last reported adapter_version per origin. Entries are created only by /evaluate behind the existing 32-origin budget; /install-scan and a successfully finalized /audit refresh existing entries, so the registry cannot become a new growth vector. last_seen stays monotonic even if the clock steps backward.
- Version sightings and changes are logged to stderr with both origin and version JSON-escaped (a token-bearing caller cannot forge log lines), capped at five lines per origin per boot with one suppression summary. Empty or over-64-char versions are treated as absent at the service layer so direct embedders get the same contract as the HTTP route.
- GET /api/adapters returns a raw envelope like /api/limits, ISO timestamps, sorted most recently seen first, and an empty list when the SDK sideband is disabled, so dashboards need no capability probe. The dashboard app takes a narrow optional adapterLiveness dependency; AdapterLivenessEntry is exported for embedders.
- Rider: adds the previously missing tests for the origin (32) and per-origin tool-baseline (1,024) cardinality caps.

Live-verified end to end against a local build (evaluate/install-scan/audit refresh semantics, version-change logging, endpoint auth and empty-when-disabled posture). Docs (sideband-api.md, adapter-api.md) updated in the same commit.