### PR TITLE
fix(audit): honor the 10,000-record export cap end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,18 @@ Maintainer notes:
   disabled). State is in-memory, bounded by the existing 32-origin budget,
   and version changes are logged to stderr escaped and capped per origin.
 
+### Fixed
+
+- **Bulk audit exports honor the documented 10,000-record cap (#131).** The
+  dashboard export endpoint (`GET /api/audit/export`) and `helio export`
+  previously returned at most 1,000 records regardless of the requested
+  limit, because the bulk path shared the dashboard's page-query cap.
+  Exports now use a dedicated read path capped at 10,000 records,
+  oldest-first with a deterministic tiebreak for records sharing a
+  timestamp; the paginated `/api/audit` keeps its 1,000-row page cap.
+  `helio export --limit` accepts integers up to 10,000 and rejects
+  malformed values with an error instead of exporting a truncated result.
+
 ## [0.8.0] - 2026-07-03
 
 ### Added

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -155,17 +155,17 @@ helio export
 
 **Options:**
 
-| Flag                    | Type   | Default      | Description                                                                                                                                   |
-| ----------------------- | ------ | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-c, --config <path>`   | string | `helio.yaml` | Path to the config file (used to locate the database).                                                                                        |
-| `-f, --format <format>` | string | `json`       | Output format: `json` or `csv`.                                                                                                               |
-| `--tool <name>`         | string | —            | Filter by tool name.                                                                                                                          |
-| `--decision <decision>` | string | —            | Filter by policy decision.                                                                                                                    |
-| `--reason <reason>`     | string | —            | Filter by block reason.                                                                                                                       |
-| `--session <id>`        | string | —            | Filter by session ID.                                                                                                                         |
-| `--from <iso>`          | string | —            | Start time (ISO 8601).                                                                                                                        |
-| `--to <iso>`            | string | —            | End time (ISO 8601).                                                                                                                          |
-| `--limit <n>`           | number | `1000`       | Maximum number of records to export. Values above 1,000 are currently capped at 1,000 ([#131](https://github.com/gethelio/helio/issues/131)). |
+| Flag                    | Type   | Default      | Description                                            |
+| ----------------------- | ------ | ------------ | ------------------------------------------------------ |
+| `-c, --config <path>`   | string | `helio.yaml` | Path to the config file (used to locate the database). |
+| `-f, --format <format>` | string | `json`       | Output format: `json` or `csv`.                        |
+| `--tool <name>`         | string | —            | Filter by tool name.                                   |
+| `--decision <decision>` | string | —            | Filter by policy decision.                             |
+| `--reason <reason>`     | string | —            | Filter by block reason.                                |
+| `--session <id>`        | string | —            | Filter by session ID.                                  |
+| `--from <iso>`          | string | —            | Start time (ISO 8601).                                 |
+| `--to <iso>`            | string | —            | End time (ISO 8601).                                   |
+| `--limit <n>`           | number | `1000`       | Maximum number of records to export (up to 10,000).    |
 
 **Examples:**
 
@@ -195,27 +195,25 @@ GET /api/audit/export
 
 **Query parameters:**
 
-| Parameter             | Default | Description                                             |
-| --------------------- | ------- | ------------------------------------------------------- |
-| `format`              | `json`  | Output format: `json` or `csv`.                         |
-| `limit`               | `10000` | Maximum records (up to 10,000, but see the note below). |
-| `tool`                | —       | Filter by tool name.                                    |
-| `decision`            | —       | Filter by policy decision.                              |
-| `reason`              | —       | Filter by block reason.                                 |
-| `session`             | —       | Filter by session ID.                                   |
-| `agent`               | —       | Filter by agent ID.                                     |
-| `from`                | —       | Start time (ISO 8601).                                  |
-| `to`                  | —       | End time (ISO 8601).                                    |
-| `upstream_status_min` | —       | Minimum upstream HTTP status (inclusive).               |
-| `upstream_status_max` | —       | Maximum upstream HTTP status (inclusive).               |
-| `blocked`             | —       | Filter by blocked vs. allowed (`true`/`false`).         |
-| `dry_run`             | —       | Filter by dry-run mode (`true`/`false`).                |
-| `origin`              | —       | Filter by enforcement origin (substring match).         |
-| `record_kind`         | —       | Filter by record kind (exact match).                    |
-| `channel_id`          | —       | Filter by `metadata.channel_id` (substring match).      |
-| `sender_id`           | —       | Filter by `metadata.sender_id` (substring match).       |
-
-> **Known issue:** exports are currently capped at 1,000 records regardless of `limit` ([#131](https://github.com/gethelio/helio/issues/131)). Until that is fixed, use narrow time-range filters (`from`/`to`) and iterate in slices; each export request is still capped at 1,000 rows.
+| Parameter             | Default | Description                                        |
+| --------------------- | ------- | -------------------------------------------------- |
+| `format`              | `json`  | Output format: `json` or `csv`.                    |
+| `limit`               | `10000` | Maximum records (up to 10,000).                    |
+| `tool`                | —       | Filter by tool name.                               |
+| `decision`            | —       | Filter by policy decision.                         |
+| `reason`              | —       | Filter by block reason.                            |
+| `session`             | —       | Filter by session ID.                              |
+| `agent`               | —       | Filter by agent ID.                                |
+| `from`                | —       | Start time (ISO 8601).                             |
+| `to`                  | —       | End time (ISO 8601).                               |
+| `upstream_status_min` | —       | Minimum upstream HTTP status (inclusive).          |
+| `upstream_status_max` | —       | Maximum upstream HTTP status (inclusive).          |
+| `blocked`             | —       | Filter by blocked vs. allowed (`true`/`false`).    |
+| `dry_run`             | —       | Filter by dry-run mode (`true`/`false`).           |
+| `origin`              | —       | Filter by enforcement origin (substring match).    |
+| `record_kind`         | —       | Filter by record kind (exact match).               |
+| `channel_id`          | —       | Filter by `metadata.channel_id` (substring match). |
+| `sender_id`           | —       | Filter by `metadata.sender_id` (substring match).  |
 
 **Examples:**
 

--- a/packages/proxy/src/audit/index.ts
+++ b/packages/proxy/src/audit/index.ts
@@ -1,4 +1,4 @@
-export { AuditStore } from './store.js'
+export { AuditStore, EXPORT_MAX_RECORDS, LIST_MAX_PAGE_SIZE } from './store.js'
 export { AuditWriter } from './writer.js'
 export type { AuditWriterOptions } from './writer.js'
 export type {

--- a/packages/proxy/src/audit/store.test.ts
+++ b/packages/proxy/src/audit/store.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import Database from 'better-sqlite3'
-import { AuditStore } from './store.js'
+import { AuditStore, EXPORT_MAX_RECORDS } from './store.js'
 import type { AuditRecord } from './types.js'
 
 // ---------------------------------------------------------------------------
@@ -565,6 +565,100 @@ CREATE TABLE IF NOT EXISTS audit_records (
       const result = store.list({}, { limit: 3 })
       expect(result.records).toHaveLength(3)
       expect(result.total).toBe(10)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // List for export
+  // -------------------------------------------------------------------------
+
+  describe('listForExport', () => {
+    it('returns more than 1000 records in one call', () => {
+      const records = Array.from({ length: 1500 }, () => makeRecord())
+      store.insertBatch(records)
+      const result = store.listForExport({}, 1500)
+      expect(result.records).toHaveLength(1500)
+      expect(result.total).toBe(1500)
+    })
+
+    it('defaults to the export maximum', () => {
+      store.insert(makeRecord())
+      const result = store.listForExport()
+      expect(result.limit).toBe(EXPORT_MAX_RECORDS)
+    })
+
+    it('clamps limit to the export maximum', () => {
+      store.insert(makeRecord())
+      const result = store.listForExport({}, 20_000)
+      expect(result.limit).toBe(EXPORT_MAX_RECORDS)
+    })
+
+    it('clamps limit to a minimum of 1', () => {
+      store.insert(makeRecord())
+      store.insert(makeRecord())
+      const result = store.listForExport({}, 0)
+      expect(result.records).toHaveLength(1)
+      expect(result.limit).toBe(1)
+    })
+
+    it('returns records oldest-first', () => {
+      store.insert(makeRecord(), '2024-12-01T00:00:00.000Z')
+      store.insert(makeRecord(), '2024-01-01T00:00:00.000Z')
+      const result = store.listForExport()
+      expect(result.records[0]?.created_at).toBe('2024-01-01T00:00:00.000Z')
+      expect(result.records[1]?.created_at).toBe('2024-12-01T00:00:00.000Z')
+    })
+
+    // SQLite happens to return equal-created_at rows in rowid order on the
+    // query plans in use today; the explicit `rowid` tiebreaker in query()
+    // turns that planner accident into a contract. These tests pin the
+    // contract — insertion order within ties, in both sort directions, and
+    // under a filtered plan that goes through a secondary index — so a future
+    // query-plan or schema change cannot silently reorder ties or move the
+    // cut point of a capped export.
+    it('breaks created_at ties deterministically in insertion order', () => {
+      const ts = '2024-06-01T00:00:00.000Z'
+      store.insert(makeRecord({ tool_name: 'before' }), '2024-01-01T00:00:00.000Z')
+      for (const name of ['tie_a', 'tie_b', 'tie_c']) {
+        store.insert(makeRecord({ tool_name: name }), ts)
+      }
+      store.insert(makeRecord({ tool_name: 'after' }), '2024-12-01T00:00:00.000Z')
+
+      const expected = ['before', 'tie_a', 'tie_b', 'tie_c', 'after']
+      const first = store.listForExport()
+      const second = store.listForExport()
+      expect(first.records.map((r) => r.tool_name)).toEqual(expected)
+      expect(second.records.map((r) => r.tool_name)).toEqual(expected)
+    })
+
+    it('keeps tie order deterministic under a secondary-index filter plan', () => {
+      const ts = '2024-06-01T00:00:00.000Z'
+      for (const name of ['tie_a', 'tie_b', 'tie_c']) {
+        store.insert(makeRecord({ tool_name: name, policy_decision: 'deny' }), ts)
+        store.insert(makeRecord({ tool_name: `skip_${name}`, policy_decision: 'allow' }), ts)
+      }
+
+      const result = store.listForExport({ policy_decision: 'deny' })
+      expect(result.records.map((r) => r.tool_name)).toEqual(['tie_a', 'tie_b', 'tie_c'])
+    })
+
+    it('reverses tie order for descending list() reads', () => {
+      const ts = '2024-06-01T00:00:00.000Z'
+      for (const name of ['tie_a', 'tie_b', 'tie_c']) {
+        store.insert(makeRecord({ tool_name: name }), ts)
+      }
+
+      const result = store.list({}, { order: 'desc' })
+      expect(result.records.map((r) => r.tool_name)).toEqual(['tie_c', 'tie_b', 'tie_a'])
+    })
+
+    it('applies filters', () => {
+      store.insert(makeRecord({ policy_decision: 'deny', block_reason: 'policy_denied' }))
+      store.insert(makeRecord())
+      const result = store.listForExport({ policy_decision: 'deny' })
+      expect(result.records).toHaveLength(1)
+      expect(result.records[0]?.policy_decision).toBe('deny')
+      expect(result.total).toBe(1)
     })
   })
 

--- a/packages/proxy/src/audit/store.ts
+++ b/packages/proxy/src/audit/store.ts
@@ -21,6 +21,19 @@ import type {
 /** policy_decision values that describe upstream definition changes, not tool calls. */
 const DRIFT_EVENT_DECISIONS_SQL = "('tool_drift', 'tool_drift_reverted')"
 
+/**
+ * Maximum records a single bulk export may return. Shared by the dashboard
+ * export route schema and the CLI export command so the advertised cap and
+ * the store's actual cap cannot diverge.
+ */
+export const EXPORT_MAX_RECORDS = 10_000
+
+/**
+ * Maximum page size for paginated `list()` reads. Shared with the dashboard
+ * audit route schema for the same reason as {@link EXPORT_MAX_RECORDS}.
+ */
+export const LIST_MAX_PAGE_SIZE = 1_000
+
 // ---------------------------------------------------------------------------
 // Schema DDL
 // ---------------------------------------------------------------------------
@@ -447,20 +460,43 @@ export class AuditStore {
     return row ? deserializeRow(row) : undefined
   }
 
-  /** Query records with filters and pagination. */
+  /** Query records with filters and pagination. Capped at 1,000 per page. */
   list(filters: AuditQueryFilters = {}, pagination: AuditPaginationOptions = {}): AuditListResult {
-    const { clause, params } = buildWhereClause(filters)
-    const limit = clamp(pagination.limit ?? 50, 1, 1000)
+    const limit = clamp(pagination.limit ?? 50, 1, LIST_MAX_PAGE_SIZE)
     const offset = Math.max(pagination.offset ?? 0, 0)
     const order = pagination.order === 'asc' ? 'ASC' : 'DESC'
+    return this.query(filters, limit, offset, order)
+  }
+
+  /**
+   * Query records for bulk export. Unlike `list()`, which enforces the
+   * dashboard's 1,000-row page cap, this path allows up to
+   * {@link EXPORT_MAX_RECORDS} in a single call. Always oldest-first
+   * (ascending `created_at`), so a capped export keeps the earliest records.
+   */
+  listForExport(filters: AuditQueryFilters = {}, limit?: number): AuditListResult {
+    const clamped = clamp(limit ?? EXPORT_MAX_RECORDS, 1, EXPORT_MAX_RECORDS)
+    return this.query(filters, clamped, 0, 'ASC')
+  }
+
+  private query(
+    filters: AuditQueryFilters,
+    limit: number,
+    offset: number,
+    order: 'ASC' | 'DESC',
+  ): AuditListResult {
+    const { clause, params } = buildWhereClause(filters)
 
     const { total } = this.db
       .prepare(`SELECT COUNT(*) as total FROM audit_records ${clause}`)
       .get(...params) as { total: number }
 
+    // rowid tiebreaker: created_at has millisecond resolution and a batched
+    // flush stamps many rows identically, so without it the cut point of a
+    // capped export (and tie order across queries) would be nondeterministic.
     const rows = this.db
       .prepare(
-        `SELECT * FROM audit_records ${clause} ORDER BY created_at ${order} LIMIT ? OFFSET ?`,
+        `SELECT * FROM audit_records ${clause} ORDER BY created_at ${order}, rowid ${order} LIMIT ? OFFSET ?`,
       )
       .all(...params, limit, offset) as RawAuditRow[]
 

--- a/packages/proxy/src/audit/types.ts
+++ b/packages/proxy/src/audit/types.ts
@@ -122,7 +122,7 @@ export interface AuditQueryFilters {
 
 /** Pagination options for list queries. */
 export interface AuditPaginationOptions {
-  /** Maximum number of records to return (default: 50, max: 1000). */
+  /** Maximum number of records to return (default: 50, max: 1,000 — `LIST_MAX_PAGE_SIZE`). */
   readonly limit?: number
   /** Number of records to skip (default: 0). */
   readonly offset?: number

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -1321,8 +1321,9 @@ audit:
         cleanupIntervalMs: 0,
       })
 
-      for (const r of records) {
-        store.insert(r)
+      const inserted = store.insertBatch(records)
+      if (inserted !== records.length) {
+        throw new Error(`setupExport seeded ${String(inserted)}/${String(records.length)} records`)
       }
       store.close()
 
@@ -1359,6 +1360,48 @@ audit:
         const records = JSON.parse(stdout) as AuditRecord[]
         expect(records).toHaveLength(3)
         expect(records.map((r) => r.tool_name).sort()).toEqual(['tool_a', 'tool_b', 'tool_c'])
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('exports more than 1000 records when --limit allows it (#131)', async () => {
+      const { dir, configPath } = setupExport(Array.from({ length: 1100 }, () => makeRecord()))
+
+      try {
+        const { code, stdout, stderr } = await runCli([
+          'export',
+          '-c',
+          configPath,
+          '-f',
+          'json',
+          '--limit',
+          '2000',
+        ])
+        expect(code).toBe(0)
+        expect(stderr).toContain('Exported 1100 of 1100 records')
+
+        const records = JSON.parse(stdout) as AuditRecord[]
+        expect(records).toHaveLength(1100)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('rejects a malformed --limit instead of silently truncating', async () => {
+      const { dir, configPath } = setupExport([makeRecord()])
+
+      try {
+        for (const bad of ['5,000', 'abc', '50.7', '0']) {
+          const { code, stderr } = await runCli(['export', '-c', configPath, '--limit', bad])
+          expect(code).toBe(1)
+          expect(stderr).toContain('--limit must be an integer between 1 and 10000')
+        }
+
+        // '1e3' is a valid integer (1000) and must not be rejected or truncated.
+        const ok = await runCli(['export', '-c', configPath, '--limit', '1e3'])
+        expect(ok.code).toBe(0)
+        expect(ok.stderr).toContain('Exported 1 of 1 records')
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -12,7 +12,7 @@ import { createForwarderFromConfig } from './cli-forwarder.js'
 import { compilePolicies, PolicyParseError } from './policy/index.js'
 import { GovernedForwarder } from './policy/governed-forwarder.js'
 import type { AnnotationCachePrimeResult } from './policy/governed-forwarder.js'
-import { AuditStore, AuditWriter } from './audit/index.js'
+import { AuditStore, AuditWriter, EXPORT_MAX_RECORDS } from './audit/index.js'
 import { EvidenceStore, createSidebandApp } from './evidence/index.js'
 import { GovernanceService } from './sideband/governance-service.js'
 import {
@@ -721,6 +721,17 @@ interface ExportOptions {
 }
 
 async function exportCommand(opts: ExportOptions): Promise<void> {
+  // Strict validation: an audit-export tool must never silently truncate.
+  // parseInt-style leniency would turn "--limit 1e3" into 1 record.
+  const parsedLimit = Number(opts.limit)
+  if (!Number.isInteger(parsedLimit) || parsedLimit < 1) {
+    console.error(
+      `Error: --limit must be an integer between 1 and ${String(EXPORT_MAX_RECORDS)} (got "${opts.limit}")`,
+    )
+    process.exit(1)
+  }
+  const limit = Math.min(parsedLimit, EXPORT_MAX_RECORDS)
+
   let config
   try {
     config = await loadConfig(opts.config)
@@ -740,7 +751,7 @@ async function exportCommand(opts: ExportOptions): Promise<void> {
   })
 
   try {
-    const result = store.list(
+    const result = store.listForExport(
       {
         tool_name: opts.tool,
         policy_decision: opts.decision,
@@ -749,7 +760,7 @@ async function exportCommand(opts: ExportOptions): Promise<void> {
         from: opts.from,
         to: opts.to,
       },
-      { limit: Number(opts.limit), order: 'asc' },
+      limit,
     )
 
     if (opts.format === 'csv') {
@@ -887,7 +898,7 @@ program
   .option('--session <id>', 'Filter by session ID')
   .option('--from <iso>', 'Start time (ISO 8601)')
   .option('--to <iso>', 'End time (ISO 8601)')
-  .option('--limit <n>', 'Max records to export', '1000')
+  .option('--limit <n>', 'Max records to export (up to 10000)', '1000')
   .action((opts: ExportOptions) => exportCommand(opts))
 
 program.parse()

--- a/packages/proxy/src/dashboard/api.test.ts
+++ b/packages/proxy/src/dashboard/api.test.ts
@@ -500,6 +500,23 @@ describe('GET /api/audit/export', () => {
     expect(names).toContain('adapter_call')
     expect(names).not.toContain('mcp_call')
   })
+
+  it('exports more than 1000 records in one request (#131)', async () => {
+    const { get, auditStore } = setup()
+    cleanup.push(auditStore)
+    for (let i = 0; i < 1200; i++) {
+      insertAuditRecord(auditStore)
+    }
+
+    const full = await get('/api/audit/export?limit=10000')
+    expect(full.status).toBe(200)
+    const fullBody = (await full.json()) as AuditRecord[]
+    expect(fullBody).toHaveLength(1200)
+
+    const partial = await get('/api/audit/export?limit=1100')
+    const partialBody = (await partial.json()) as AuditRecord[]
+    expect(partialBody).toHaveLength(1100)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/proxy/src/dashboard/api.ts
+++ b/packages/proxy/src/dashboard/api.ts
@@ -10,6 +10,7 @@ import { serveStatic } from '@hono/node-server/serve-static'
 import { streamSSE } from 'hono/streaming'
 import { VERSION } from '../version.js'
 import type { AuditStore } from '../audit/store.js'
+import { EXPORT_MAX_RECORDS, LIST_MAX_PAGE_SIZE } from '../audit/store.js'
 import { recordsToCsv } from '../audit/csv.js'
 import type { ApprovalRouter } from '../approval/router.js'
 import type { ApprovalQueue } from '../approval/queue.js'
@@ -94,7 +95,7 @@ const feedQuerySchema = z.object({
 
 const auditExportQuerySchema = z.object({
   format: z.preprocess((value) => (value === 'csv' ? 'csv' : 'json'), z.enum(['json', 'csv'])),
-  limit: clampedQueryInt(10_000, 1, 10_000),
+  limit: clampedQueryInt(EXPORT_MAX_RECORDS, 1, EXPORT_MAX_RECORDS),
   tool: optionalQueryString,
   decision: optionalQueryString,
   reason: optionalQueryString,
@@ -113,7 +114,7 @@ const auditExportQuerySchema = z.object({
 })
 
 const auditQuerySchema = z.object({
-  limit: clampedQueryInt(50, 1, 1000),
+  limit: clampedQueryInt(50, 1, LIST_MAX_PAGE_SIZE),
   offset: clampedQueryInt(0, 0, Number.MAX_SAFE_INTEGER),
   tool: optionalQueryString,
   decision: optionalQueryString,
@@ -463,7 +464,7 @@ export function createDashboardAppWithLifecycle(
       sender_id: query.sender_id,
     }
 
-    const result = auditStore.list(filters, { limit, order: 'asc' })
+    const result = auditStore.listForExport(filters, limit)
 
     if (format === 'csv') {
       const csv = recordsToCsv(result.records)

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -46,7 +46,7 @@ export type {
   ResolveApprovalInput,
   AdapterLivenessEntry,
 } from './sideband/governance-service.js'
-export { AuditStore, AuditWriter } from './audit/index.js'
+export { AuditStore, AuditWriter, EXPORT_MAX_RECORDS, LIST_MAX_PAGE_SIZE } from './audit/index.js'
 export type {
   AuditRecord,
   AuditQueryFilters,


### PR DESCRIPTION
Closes #131

## Summary

Bulk audit exports were silently capped at 1,000 records: the export route's schema allowed 10,000, but the handler delegated to `AuditStore.list()`, whose 1,000-row clamp exists for the dashboard's paginated views. The two layers disagreed and the store silently won, on both `GET /api/audit/export` and `helio export`.

## What changed

- `AuditStore.listForExport()`: a dedicated bulk read path capped at 10,000 records, always oldest-first, sharing a private `query()` helper with `list()` so the two cannot drift.
- Both caps are now shared constants (`EXPORT_MAX_RECORDS`, `LIST_MAX_PAGE_SIZE`) referenced by the store clamps and the route schemas, closing the divergence class that caused the bug. Both are exported from the package root so embedders can read the caps.
- `helio export --limit` is strictly validated: malformed values (`5,000`, `abc`, `50.7`, `0`) fail with exit 1 and a clear message instead of reaching SQLite or exporting a truncated result. Integer-valued inputs like `1e3` keep working.
- The shared `ORDER BY` gains a `rowid` tiebreaker, so a capped export cuts at a deterministic point when many records share a `created_at` millisecond (routine under batched flushes).
- Regression tests above 1,000 rows at all three layers (store, HTTP endpoint, spawned CLI), plus malformed-limit rejection and tie-order contract tests in both sort directions and under a secondary-index filter plan.
- docs/audit.md drops the two known-issue notes added by #133; docs/sideband-api.md's existing "capped at 10k, oldest-first" description is now accurate unchanged. CHANGELOG entry under Unreleased.

## Review process

Lightweight process (as with #128/#130): TDD, an internal multi-angle review with per-finding verification, and one external round-trip on the diff (APPROVE-WITH-CHANGES; the required change strengthened the tie-order test coverage). The internal review caught and fixed a would-be regression in the first draft: routing `--limit` through the lenient query-param parser would have turned `--limit 1e3` into a silent single-record export.

Deferred as pre-existing and unchanged: the NaN passthrough in the shared `clamp()` (unreachable — both callers pre-sanitize), and the export path's discarded `COUNT(*)` (a later optimization can skip the count unless the fetch fills the limit).

## Verification

- `pnpm format:check`, `pnpm lint`, `pnpm -r typecheck`, `pnpm test` (proxy 1672 / dashboard 303 / python-sdk 47) all green; `scripts/check-docs-drift.sh` clean
- Verified live against a 1,219-row database: `--limit 2000` exports all 1,219 (previously 1,000), `--limit 20000` clamps to the 10k cap, `--limit abc` fails loudly
