### PR TITLE
fix(audit): include record_kind, origin, and metadata in CSV exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ Maintainer notes:
   timestamp; the paginated `/api/audit` keeps its 1,000-row page cap.
   `helio export --limit` accepts integers up to 10,000 and rejects
   malformed values with an error instead of exporting a truncated result.
+- **CSV audit exports include every record field, matching JSON (#66).** CSV
+  exports gain `record_kind`, `origin`, and `metadata` columns, appended
+  after the existing columns so positions stay stable for consumers that
+  parse by index. Dashboard API exports serialize `metadata` as a JSON
+  string, like the other object-valued fields; `helio export -f csv` keeps
+  its lightweight serializer and leaves object-valued fields empty.
 
 ## [0.8.0] - 2026-07-03
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -235,15 +235,13 @@ The export response includes a `Content-Disposition` header for browser download
 
 ## CSV Format
 
-CSV exports include 24 of the record's 27 fields:
+CSV exports include all 27 of the record's fields:
 
-`id`, `timestamp`, `session_id`, `agent_id`, `tool_name`, `tool_input`, `policy_decision`, `block_reason`, `matched_rule`, `evidence_chain`, `approval_status`, `approved_by`, `upstream_response`, `upstream_error`, `upstream_http_status`, `upstream_latency_ms`, `total_duration_ms`, `approval_wait_ms`, `proxy_compute_ms`, `flagged_destructive`, `dry_run`, `created_at`, `environment`, `matched_rule_index`
+`id`, `timestamp`, `session_id`, `agent_id`, `tool_name`, `tool_input`, `policy_decision`, `block_reason`, `matched_rule`, `evidence_chain`, `approval_status`, `approved_by`, `upstream_response`, `upstream_error`, `upstream_http_status`, `upstream_latency_ms`, `total_duration_ms`, `approval_wait_ms`, `proxy_compute_ms`, `flagged_destructive`, `dry_run`, `created_at`, `environment`, `matched_rule_index`, `record_kind`, `origin`, `metadata`
 
-The `record_kind`, `origin`, and `metadata` fields are not yet included in CSV exports ([#66](https://github.com/gethelio/helio/issues/66)); use the JSON format if you need them.
+Dashboard API CSV exports (`GET /api/audit/export?format=csv`) serialize object fields (`tool_input`, `evidence_chain`, `upstream_response`, `metadata`) as JSON strings. Fields containing commas, newlines, or quotes are properly escaped per RFC 4180. Boolean values are exported as `true` or `false`. Null values are exported as empty strings.
 
-Dashboard API CSV exports (`GET /api/audit/export?format=csv`) serialize object fields (`tool_input`, `evidence_chain`, `upstream_response`) as JSON strings. Fields containing commas, newlines, or quotes are properly escaped per RFC 4180. Boolean values are exported as `true` or `false`. Null values are exported as empty strings.
-
-`helio export -f csv` currently uses a lightweight serializer: it prints the same CSV headers and scalar fields, but leaves object-valued fields empty.
+`helio export -f csv` currently uses a lightweight serializer: it prints the same CSV headers and scalar fields, including `record_kind` and `origin`, but leaves the object-valued fields (`tool_input`, `evidence_chain`, `upstream_response`, `metadata`) empty. Use the dashboard API export if you need `metadata` in CSV.
 
 **Formula injection defense.** Any cell that would otherwise begin with `=`, `+`, `-`, `@`, a tab, or a carriage return is prefixed with a single quote (`'`) before being quoted. This prevents CSV-opened spreadsheet applications from interpreting audit data as a formula (CWE-1236).
 

--- a/packages/proxy/src/audit/csv.test.ts
+++ b/packages/proxy/src/audit/csv.test.ts
@@ -176,18 +176,58 @@ describe('recordsToCsv', () => {
     expect(row).toContain('"tool,with,commas"')
   })
 
-  it('includes all 24 AuditRecord fields in headers', () => {
-    expect(CSV_HEADERS).toHaveLength(24)
-    expect(CSV_HEADERS).toContain('tool_input')
-    expect(CSV_HEADERS).toContain('block_reason')
-    expect(CSV_HEADERS).toContain('evidence_chain')
-    expect(CSV_HEADERS).toContain('upstream_response')
-    expect(CSV_HEADERS).toContain('upstream_http_status')
-    expect(CSV_HEADERS).toContain('total_duration_ms')
-    expect(CSV_HEADERS).toContain('approval_wait_ms')
-    expect(CSV_HEADERS).toContain('proxy_compute_ms')
-    expect(CSV_HEADERS).toContain('environment')
-    expect(CSV_HEADERS).toContain('matched_rule_index')
+  it('includes all 27 AuditRecord fields in headers, in a stable order', () => {
+    // Downstream consumers parse by column index, so new columns must only
+    // ever be appended, never inserted or reordered.
+    expect(CSV_HEADERS).toEqual([
+      'id',
+      'timestamp',
+      'session_id',
+      'agent_id',
+      'tool_name',
+      'tool_input',
+      'policy_decision',
+      'block_reason',
+      'matched_rule',
+      'evidence_chain',
+      'approval_status',
+      'approved_by',
+      'upstream_response',
+      'upstream_error',
+      'upstream_http_status',
+      'upstream_latency_ms',
+      'total_duration_ms',
+      'approval_wait_ms',
+      'proxy_compute_ms',
+      'flagged_destructive',
+      'dry_run',
+      'created_at',
+      'environment',
+      'matched_rule_index',
+      'record_kind',
+      'origin',
+      'metadata',
+    ])
+  })
+
+  it('serializes record_kind and origin as plain strings', () => {
+    const csv = recordsToCsv([makeRecord({ record_kind: 'install_scan', origin: 'openclaw' })])
+    const lines = csv.split('\n')
+    const headers = (lines[0] ?? '').split(',')
+    const cells = (lines[1] ?? '').split(',')
+    expect(cells[headers.indexOf('record_kind')]).toBe('install_scan')
+    expect(cells[headers.indexOf('origin')]).toBe('openclaw')
+  })
+
+  it('serializes metadata as a JSON string that round-trips', () => {
+    const csv = recordsToCsv([makeRecord({ metadata: { channel_id: 'C042' } })])
+    const lines = csv.split('\n')
+    const headers = (lines[0] ?? '').split(',')
+    const cells = (lines[1] ?? '').split(',')
+    const cell = cells[headers.indexOf('metadata')]
+    expect(cell).toBe('"{""channel_id"":""C042""}"')
+    const unescaped = (cell ?? '').slice(1, -1).replace(/""/g, '"')
+    expect(JSON.parse(unescaped)).toEqual({ channel_id: 'C042' })
   })
 
   it('serializes object fields as JSON strings', () => {

--- a/packages/proxy/src/audit/csv.ts
+++ b/packages/proxy/src/audit/csv.ts
@@ -30,6 +30,9 @@ export const CSV_HEADERS = [
   'created_at',
   'environment',
   'matched_rule_index',
+  'record_kind',
+  'origin',
+  'metadata',
 ] as const
 
 /**

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -1557,5 +1557,30 @@ audit:
         rmSync(dir, { recursive: true, force: true })
       }
     })
+
+    it('CSV includes record_kind and origin but leaves metadata empty', async () => {
+      const { dir, configPath } = setupExport([
+        makeRecord({ origin: 'openclaw', metadata: { channel_id: 'C042' } }),
+      ])
+
+      try {
+        const { code, stdout } = await runCli(['export', '-c', configPath, '-f', 'csv'])
+        expect(code).toBe(0)
+
+        const lines = stdout.trim().split('\n')
+        const headers = (lines[0] ?? '').split(',')
+        const cells = (lines[1] ?? '').split(',')
+        expect(cells[headers.indexOf('record_kind')]).toBe('tool_call')
+        expect(cells[headers.indexOf('origin')]).toBe('openclaw')
+
+        // The CLI serializer leaves object-valued fields empty; metadata is
+        // only populated in dashboard API CSV exports.
+        const metadataIdx = headers.indexOf('metadata')
+        expect(metadataIdx).toBeGreaterThan(-1)
+        expect(cells[metadataIdx]).toBe('')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
   })
 })

--- a/packages/proxy/src/dashboard/api.test.ts
+++ b/packages/proxy/src/dashboard/api.test.ts
@@ -463,6 +463,10 @@ describe('GET /api/audit/export', () => {
     const text = await res.text()
     expect(text).toContain('id,timestamp,session_id')
     expect(text).toContain('csv_tool')
+    const header = text.split('\n')[0] ?? ''
+    expect(header).toContain('record_kind')
+    expect(header).toContain('origin')
+    expect(header).toContain('metadata')
   })
 
   it('respects filters in export', async () => {


### PR DESCRIPTION
## Summary

The CSV audit export was missing the `origin`, `record_kind`, and `metadata` columns that the JSON export already carried, so a CSV export filtered by one of these fields had no column showing the value it was filtered on.

This appends `record_kind`, `origin`, and `metadata` to `CSV_HEADERS`, at the end so existing column positions stay stable for consumers that parse by index. Both export surfaces pick the columns up from the shared header list: the dashboard `GET /api/audit/export?format=csv` serializes `metadata` as a JSON string through the existing formula-injection guard, and `helio export -f csv` keeps its lightweight serializer, so `record_kind` and `origin` populate there while `metadata` stays empty. The CSV Format section of `docs/audit.md` now lists all 27 fields and states the CLI/dashboard split explicitly.

## Testing

- The serializer test now pins the full ordered 27-column header list, so future insertions or reorders fail loudly instead of silently shifting index-parsed columns. New tests cover `record_kind`/`origin` as plain strings and `metadata` round-tripping as a JSON string.
- A new CLI test pins the documented split against the built `dist/cli.js`: `record_kind` and `origin` populated, `metadata` empty.
- The dashboard export test asserts the new columns in the header.
- Verified live against a local build: dashboard CSV renders `metadata` as an escaped JSON string, `?format=csv&origin=openclaw` now shows the `origin` column it filters on, and CLI CSV leaves `metadata` empty.
- Full local gate green: format, lint, typecheck, tests (1675 proxy, 303 dashboard, 47 python-sdk), docs-drift check.

Closes #66