### PR TITLE
docs(changelog): roll unreleased entries into 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Maintainer notes:
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-05
+
 ### Security
 
 - **Operator-provided sideband tokens are no longer echoed to stderr (#128).**
@@ -379,7 +381,9 @@ Helio's first public release.
 - Secret scanning is now part of the default quality gate (pre-commit + CI),
   designed to prevent accidental credential commits before merge.
 
-[Unreleased]: https://github.com/gethelio/helio/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/gethelio/helio/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/gethelio/helio/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/gethelio/helio/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/gethelio/helio/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/gethelio/helio/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/gethelio/helio/compare/v0.4.0...v0.5.0


### PR DESCRIPTION
## Summary

Rolls the accumulated Unreleased entries (#128 token echo, #126 adapter liveness, #131 export cap, #66 CSV columns) into a `[0.9.0] - 2026-07-05` section ahead of tagging v0.9.0.

Also fixes the footer compare links: the 0.8.0 roll (#122) missed adding the `[0.8.0]` link and left `[Unreleased]` pointing at `v0.7.0...HEAD`. This adds `[0.9.0]` and the missing `[0.8.0]`, and repoints `[Unreleased]` at `v0.9.0...HEAD`.