### PR TITLE
fix(sideband): return rule feedback on require_approval and dry_run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sideband `/evaluate` returns configured rule feedback on gating decisions
+  (#78).** A `require_approval` or `dry_run` decision now carries the matched
+  rule's `feedback` block (`message`, optional `suggestion`) when the rule
+  configures one, so adapter-built approval prompts and shadow-mode reports
+  can show the operator's rationale instead of the internal rule-match
+  reason. Blocking decisions are unchanged and still always include
+  `feedback`; gating decisions without configured feedback omit it, and a
+  plain `allow` rule's feedback is never surfaced (a global dry-run that
+  shadows an allowed call stays feedback-free).
+
 ## [0.9.0] - 2026-07-05
 
 ### Security

--- a/docs/adapter-api.md
+++ b/docs/adapter-api.md
@@ -66,7 +66,7 @@ If you embed `GovernanceService` directly (instead of running `helio start`), wi
   "reason": "Matched \"allow-chat\" → allow",
   "matched_rule": "allow-chat",          // null when the default policy applied
   "matched_rule_index": 2,
-  "feedback": { "message": "…" },        // present on blocking decisions
+  "feedback": { "message": "…" },        // always on blocking decisions; on require_approval / dry_run when the gating rule configures feedback
   "approval": { "id": "…", "timeout_ms": 300000, "resolve_path": "/approval/…/resolve" }, // require_approval only
   "limits": { "rate": { } },             // present when a limit rule matched
   "dry_run": { "would_forward": true, "evidence_satisfied": true, "limits_ok": true }, // dry_run only

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,7 +209,7 @@ Each rule in the `rules` array has the following structure:
 | `requires`         | string[] | No       | Tool names that must have been called first in this session.                                                                                                                                     |
 | `requires_success` | boolean  | No       | Whether prerequisite tools in `requires` must have succeeded, not just been called. Defaults to `true`; set `false` to accept any prior call.                                                    |
 | `limits`           | object   | No       | Rate or spend limit configuration.                                                                                                                                                               |
-| `feedback`         | object   | No       | Custom message and suggestion returned when the action is blocked.                                                                                                                               |
+| `feedback`         | object   | No       | Custom message and suggestion returned when the action is blocked, and on sideband `require_approval`/`dry_run` decisions. See [Feedback Messages](./policies.md#feedback-messages).             |
 
 `action: require_approval` without a rule-level `approval:` block is valid. Helio emits a config warning and uses runtime defaults (`channel: dashboard`, timeout from top-level `approval.timeout`).
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -37,7 +37,7 @@ rules:
     limits: # Rate or spend limit config
       max_calls: 100
       window: '1h'
-    feedback: # Custom message for blocked actions
+    feedback: # Custom message for blocked and gated actions
       message: 'This action is blocked.'
       suggestion: 'Try a different approach.'
 ```
@@ -502,6 +502,8 @@ When a tool call is blocked, the proxy returns structured feedback as a JSON-RPC
 ```
 
 The `feedback.message` appears as the error message. The `feedback.suggestion` is included in the error `data` for agents to use for self-correction. If no feedback is configured, the proxy generates a default message based on the block reason.
+
+On the [sideband adapter API](./adapter-api.md), `feedback` also accompanies `require_approval` and `dry_run` decisions when the gating rule configures it, so adapter-built approval prompts and shadow-mode reports can show the operator's rationale. Feedback on a plain `allow` rule is never surfaced.
 
 ## Flag Destructive
 

--- a/packages/proxy/src/sideband/governance-api.test.ts
+++ b/packages/proxy/src/sideband/governance-api.test.ts
@@ -3,6 +3,8 @@ import { createSidebandApp } from '../evidence/api.js'
 import { EvidenceStore } from '../evidence/store.js'
 import { GovernanceService } from './governance-service.js'
 import { compilePolicies } from '../policy/parser.js'
+import { ApprovalRouter } from '../approval/router.js'
+import { ApprovalQueue } from '../approval/queue.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -13,6 +15,7 @@ const ADAPTER_TOKEN = 'adapter-token-bbbbbbbbbbbb'
 
 function setup(opts?: {
   withGovernance?: boolean
+  withApprovals?: boolean
   tokens?: boolean
   policy?: Parameters<typeof compilePolicies>[0]
 }) {
@@ -25,12 +28,21 @@ function setup(opts?: {
     },
   ).policy
 
+  const approvalRouter = opts?.withApprovals
+    ? new ApprovalRouter({
+        defaultTimeoutMs: 300_000,
+        defaultOnTimeout: 'deny',
+        channels: new Map(),
+        queue: new ApprovalQueue({ cleanupIntervalMs: 0 }),
+      })
+    : undefined
+
   const governance =
     opts?.withGovernance === false
       ? undefined
       : // Wire the same EvidenceStore into the service, mirroring production
         // (cli.ts) so the /audit evidence path is exercised end-to-end.
-        new GovernanceService({ policy, sweepIntervalMs: 0, evidenceStore: store })
+        new GovernanceService({ policy, sweepIntervalMs: 0, evidenceStore: store, approvalRouter })
 
   const app = createSidebandApp(store, {
     token: opts?.tokens ? SDK_TOKEN : undefined,
@@ -104,6 +116,63 @@ describe('sideband governance routes', () => {
 
     const allowed = await ctx.post('/evaluate', evalBody({ metadata: { channel_id: 'C2' } }))
     expect(((await allowed.json()) as { decision: string }).decision).toBe('allow')
+  })
+
+  it('carries configured rule feedback on a dry_run decision end-to-end', async () => {
+    const ctx = setup({
+      policy: {
+        default: 'allow',
+        dry_run: false,
+        rules: [
+          {
+            name: 'shadow-send',
+            match: { tool: 'send' },
+            action: 'dry_run',
+            feedback: { message: 'Shadow mode: send would be governed' },
+          },
+        ],
+      },
+    })
+    store = ctx.store
+    governance = ctx.governance ?? null
+    const res = await ctx.post('/evaluate', evalBody())
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { decision: string; feedback?: { message: string } }
+    expect(json.decision).toBe('dry_run')
+    expect(json.feedback).toStrictEqual({ message: 'Shadow mode: send would be governed' })
+  })
+
+  it('carries configured rule feedback on a require_approval decision end-to-end', async () => {
+    const ctx = setup({
+      withApprovals: true,
+      policy: {
+        default: 'allow',
+        dry_run: false,
+        rules: [
+          {
+            name: 'approve-send',
+            match: { tool: 'send' },
+            action: 'require_approval',
+            feedback: { message: 'Manager sign-off required', suggestion: 'Ask in #ops' },
+          },
+        ],
+      },
+    })
+    store = ctx.store
+    governance = ctx.governance ?? null
+    const res = await ctx.post('/evaluate', evalBody())
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as {
+      decision: string
+      feedback?: { message: string; suggestion?: string }
+      approval?: { id: string }
+    }
+    expect(json.decision).toBe('require_approval')
+    expect(json.feedback).toStrictEqual({
+      message: 'Manager sign-off required',
+      suggestion: 'Ask in #ops',
+    })
+    expect(json.approval?.id).toBeTruthy()
   })
 
   it('denies a matching install through /install-scan end-to-end (deny_install)', async () => {

--- a/packages/proxy/src/sideband/governance-service.test.ts
+++ b/packages/proxy/src/sideband/governance-service.test.ts
@@ -307,6 +307,132 @@ describe('GovernanceService.evaluate', () => {
 })
 
 // ---------------------------------------------------------------------------
+// rule feedback on gating decisions (issue #78)
+// ---------------------------------------------------------------------------
+
+describe('GovernanceService.evaluate — rule feedback', () => {
+  it('returns configured feedback on require_approval', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [
+        {
+          name: 'ap',
+          match: { tool: 'send' },
+          action: 'require_approval',
+          feedback: { message: 'Needs a human sign-off', suggestion: 'Ask in #ops' },
+        },
+      ],
+    })
+    const { service } = makeService({ policy, withApprovals: true })
+    const res = service.evaluate(evalInput())
+    expect(res.body['decision']).toBe('require_approval')
+    expect(res.body['feedback']).toStrictEqual({
+      message: 'Needs a human sign-off',
+      suggestion: 'Ask in #ops',
+    })
+    expect(res.body['approval']).toBeTruthy()
+  })
+
+  it('omits feedback on require_approval when the rule configures none', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [{ name: 'ap', match: { tool: 'send' }, action: 'require_approval' }],
+    })
+    const { service } = makeService({ policy, withApprovals: true })
+    const res = service.evaluate(evalInput())
+    expect(res.body['decision']).toBe('require_approval')
+    expect(res.body).not.toHaveProperty('feedback')
+  })
+
+  it('returns configured feedback on a per-rule dry_run', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [
+        {
+          name: 'shadow',
+          match: { tool: 'send' },
+          action: 'dry_run',
+          feedback: { message: 'Would be blocked in enforce mode' },
+        },
+      ],
+    })
+    const { service } = makeService({ policy })
+    const res = service.evaluate(evalInput())
+    expect(res.body['decision']).toBe('dry_run')
+    expect(res.body['feedback']).toStrictEqual({ message: 'Would be blocked in enforce mode' })
+  })
+
+  it('returns the underlying matched rule feedback under global dry_run', () => {
+    const policy = compile({
+      default: 'allow',
+      dry_run: true,
+      rules: [
+        {
+          name: 'no-send',
+          match: { tool: 'send' },
+          action: 'deny',
+          feedback: { message: 'Sending is disabled' },
+        },
+      ],
+    })
+    const { service } = makeService({ policy })
+    const res = service.evaluate(evalInput())
+    expect(res.body['decision']).toBe('dry_run')
+    expect(res.body['feedback']).toStrictEqual({ message: 'Sending is disabled' })
+  })
+
+  it('omits feedback under global dry_run when no rule matched', () => {
+    const policy = compile({ default: 'allow', dry_run: true, rules: [] })
+    const { service } = makeService({ policy })
+    const res = service.evaluate(evalInput())
+    expect(res.body['decision']).toBe('dry_run')
+    expect(res.body).not.toHaveProperty('feedback')
+  })
+
+  it('omits feedback under global dry_run when the matched rule is a plain allow', () => {
+    const policy = compile({
+      default: 'deny',
+      dry_run: true,
+      rules: [
+        {
+          name: 'ok-send',
+          match: { tool: 'send' },
+          action: 'allow',
+          feedback: { message: 'Sending is fine' },
+        },
+      ],
+    })
+    const { service } = makeService({ policy })
+    const res = service.evaluate(evalInput())
+    expect(res.body['decision']).toBe('dry_run')
+    expect((res.body['dry_run'] as { would_forward: boolean }).would_forward).toBe(true)
+    expect(res.body).not.toHaveProperty('feedback')
+  })
+
+  it('omits feedback on require_approval escalated by flag_destructive (no matched rule)', () => {
+    const policy = compile({ default: 'allow', flag_destructive: 'require_approval', rules: [] })
+    const { service } = makeService({ policy, withApprovals: true })
+    const res = service.evaluate(
+      evalInput({ tool: { name: 'send', annotations: { destructiveHint: true } } }),
+    )
+    expect(res.body['decision']).toBe('require_approval')
+    expect(res.body['matched_rule']).toBeNull()
+    expect(res.body).not.toHaveProperty('feedback')
+  })
+
+  it('keeps the reason fallback on deny when the rule configures no feedback', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [{ name: 'no-send', match: { tool: 'send' }, action: 'deny' }],
+    })
+    const { service } = makeService({ policy })
+    const res = service.evaluate(evalInput())
+    expect(res.body['decision']).toBe('deny')
+    expect(res.body['feedback']).toStrictEqual({ message: 'Matched "no-send" → deny' })
+  })
+})
+
+// ---------------------------------------------------------------------------
 // audit
 // ---------------------------------------------------------------------------
 

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -418,7 +418,7 @@ export class GovernanceService {
       matched_rule: matchedRuleName,
       matched_rule_index: matchedRuleIndex,
     }
-    if (isBlocking(wire)) {
+    if (shouldAttachFeedback(wire, decision)) {
       responseBody['feedback'] = buildFeedback(decision.matchedRule, decision.reason)
     }
     if (limitsBlock) responseBody['limits'] = limitsBlock
@@ -1332,6 +1332,21 @@ function buildFeedback(
 
 function isBlocking(wire: WireDecision): boolean {
   return wire === 'deny' || wire === 'rate_limited' || wire === 'spend_limited'
+}
+
+/**
+ * Blocking decisions always carry feedback (message falls back to the internal
+ * reason). The gating decisions — require_approval and dry_run — carry it only
+ * when the matched rule configures one and the underlying action gates: global
+ * dry-run can shadow a plain allow rule, whose feedback is never surfaced.
+ */
+function shouldAttachFeedback(
+  wire: WireDecision,
+  decision: { action: string; matchedRule?: { feedback?: unknown } },
+): boolean {
+  if (isBlocking(wire)) return true
+  const gating = wire === 'require_approval' || wire === 'dry_run'
+  return gating && decision.action !== 'allow' && decision.matchedRule?.feedback != null
 }
 
 function isTerminalAtEvaluate(wire: WireDecision): boolean {


### PR DESCRIPTION
Fixes the sideband `/evaluate` response dropping the matched rule's configured `feedback` block on `require_approval` and `dry_run` decisions. Feedback was only attached for `deny`/`rate_limited`/`spend_limited`, so approval surfaces built from the sideband envelope (e.g. the helio-openclaw approval card) could never show the operator's rationale and fell back to the internal rule-match reason.

Changes:

- `/evaluate` now attaches `feedback` on `require_approval` and `dry_run` when the matched rule configures one and the underlying action gates. A global dry-run that shadows a plain `allow` rule stays feedback-free, and gating decisions without configured feedback keep omitting the block, so absent feedback still means "fall back to reason" for adapters. Blocking decisions are unchanged.
- The attachment policy is consolidated in a `shouldAttachFeedback` helper next to the other wire-decision predicates.
- Docs synced in the same commit: adapter-api.md's "present on blocking decisions" comment, policies.md's Feedback Messages section, and configuration.md's rule-field table all described feedback as blocked-only.

Testing:

- New service-level tests cover both gating decisions with and without configured feedback, the global dry-run no-rule and allow-rule cases, the flag_destructive escalation boundary (no matched rule, so no feedback), and the deny reason fallback; route-level tests pin both decisions end to end.
- Full local gate green (format, lint, typecheck, 1685 proxy + 303 dashboard + 47 python tests, docs drift).
- Verified live: `npx @gethelio/proxy@0.9.0` reproduces the bug; a local build returns the configured message and suggestion on both decisions, with an unmatched-tool allow control unchanged.

Closes #78
