### PR TITLE
feat(budgets): named cross-tool budgets with deny enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Added
+
+- **Named budgets: cumulative cross-tool spend enforcement (#14).** A new
+  top-level `budgets:` section defines depleting spend pots independent of
+  policy rules: each budget aggregates spend across every tool its
+  `contributors` match (e.g. Stripe and PayPal into one cap, each with its own
+  amount field), scoped `global`, per `session`, or per adapter `sender_id`.
+  Windows are sliding durations or `session` (a pot that never replenishes on
+  a timer; idle pots are collected after `idle_ttl`, default 24h). The gate is
+  all-or-nothing on both doors: every matching budget is peeked before the
+  call proceeds, one breach denies it, and a denied call records nothing on
+  any budget — nor on rule-level rate/spend counters, which now also commit
+  only when the call actually forwards. Denials return structured feedback
+  with `reason: budget_exceeded` and a per-budget breakdown; the sideband
+  `/evaluate` gains the `budget_exceeded` decision (terminal, fail-closed for
+  adapters that treat unknown decisions as deny — now a normative adapter
+  requirement) and a `limits.budgets` block, with charges committed at
+  `/audit` only when the call executed. Budgets hot-reload by name identity:
+  contributor edits preserve accrued spend; `limit`/`currency`/`window`
+  changes reset it. `on_exceed: deny` is the only breach mode in this
+  release; break-glass approvals, persistence, and the dashboard Budgets view
+  land next in this release train. State is in-memory for now.
+
 ### Fixed
 
 - **Nameless `tools/call` requests are rejected and audited instead of
@@ -52,10 +75,10 @@ Maintainer notes:
   label no rule reads. Operator notes: bucket labels change in
   `GET /api/limits`, `limit_warning` events, and denial messages; accrued
   spend resets whenever a spend rule's position in the rules list changes;
-  and each sender-keyed `spend_limit` rule now holds its own slot in the
-  sideband's sender-key registry, so effective sender capacity is
-  `50,000 / (1 + sender-keyed spend rules)` instead of a flat 50,000. Rate
-  bucket keys are unchanged.
+  and the sideband's sender-key registry counts distinct live
+  sender-scoped KEYS (capped at 50,000), so a sender that exercises several
+  sender-keyed spend rules occupies one slot per exercised rule bucket
+  rather than one slot total. Rate bucket keys are unchanged.
 
 ### Changed
 

--- a/docs/adapter-api.md
+++ b/docs/adapter-api.md
@@ -33,6 +33,7 @@ An adapter built on this API **MUST**:
 2. **Resolve before auditing.** For a `require_approval` decision, call `/approval/:id/resolve` before `/audit` (see [Approvals](#approvals)).
 3. **Carry tool definitions where it can** (`tool.input_schema`, `tool.annotations`, …) so adapter-origin tools get the same rug-pull / drift guard as MCP tools.
 4. **Authenticate** with the adapter-scope bearer token (`HELIO_ADAPTER_TOKEN`), never the SDK token.
+5. **Treat any `decision` value you do not recognize as `deny`.** The decision vocabulary grows (this release adds `budget_exceeded`); an adapter that falls through an unknown value to "proceed" turns every future vocabulary addition into a governance bypass. Parsing the response against a closed enum and blocking on parse failure satisfies this.
 
 ## Authentication
 
@@ -47,10 +48,10 @@ If you embed `GovernanceService` directly (instead of running `helio start`), wi
 {
   "origin": "openclaw",                  // optional; default "sideband"; ^[a-z0-9_-]{1,64}$
   "adapter_version": "0.1.0",            // optional, ≤64 chars; per-origin liveness (dashboard GET /api/adapters)
-  "agent_id": "main",                    // optional
-  "session_id": "oc-session-1",          // optional; required for evidence/dependency rules
+  "agent_id": "main",                    // optional, ≤128 chars
+  "session_id": "oc-session-1",          // optional, ≤256 chars; required for evidence/dependency rules
   "tool": {
-    "name": "send_message",              // required
+    "name": "send_message",              // required, ≤256 chars
     "description": "…",                  // optional ┐ full definition enables the drift guard
     "input_schema": { },                 // optional ┤
     "annotations": { "destructiveHint": false } // optional ┘
@@ -62,19 +63,21 @@ If you embed `GovernanceService` directly (instead of running `helio start`), wi
 // Response 200
 {
   "evaluation_id": "5f2…",               // correlate with /audit; present even for terminal decisions
-  "decision": "allow",                   // allow | deny | require_approval | rate_limited | spend_limited | dry_run
+  "decision": "allow",                   // allow | deny | require_approval | rate_limited | spend_limited | budget_exceeded | dry_run
   "reason": "Matched \"allow-chat\" → allow",
   "matched_rule": "allow-chat",          // null when the default policy applied
   "matched_rule_index": 2,
   "feedback": { "message": "…" },        // always on blocking decisions; on require_approval / dry_run when the gating rule configures feedback
   "approval": { "id": "…", "timeout_ms": 300000, "resolve_path": "/approval/…/resolve" }, // require_approval only
-  "limits": { "rate": { } },             // present when a limit rule matched
+  "limits": { "rate": { } },             // present when a limit rule or a named budget matched (rate | spend | budgets)
   "dry_run": { "would_forward": true, "evidence_satisfied": true, "limits_ok": true }, // dry_run only
   "tool_drift": { "changes": [ ] }       // present when the drift gate fired
 }
 ```
 
 The `decision` is an **outcome**, not Helio's internal rule action: a `rate_limit` rule that still has headroom returns `"allow"` with a `limits.rate` block; only when the bucket is exhausted does it return `"rate_limited"`. There is no `modify` decision — argument rewriting has no engine support today.
+
+**Named budgets (issue #14).** When the call's tool matches a configured budget's contributors, the response carries a `limits.budgets` array — one block per matching budget with `name`, `limit`, `spent`, `remaining`, `attempted_amount`, `currency`, `window`, `on_exceed`, `allowed`, and `reset_at_ms` (epoch ms; `null` for `session` windows, which never replenish). A breach returns `decision: "budget_exceeded"` — **terminal at `/evaluate`**, like the other blocking decisions: the audit record is written immediately and nothing is recorded on any budget. A budget whose contributor cannot read a valid amount from the arguments fails closed the same way, with `reason: "invalid_amount"` inside its block. On an allowed call the budget charges commit at `/audit`, only when the call actually executed; `actual_amount`, when supplied, overrides every budget charge (a call has one true realized cost) as well as the spend-rule amount.
 
 **Errors:** `400` validation / invalid JSON, `401` wrong-or-missing adapter token, `403` Origin header, `413` oversized `metadata`/`tool_input`/body, `400 reserved_metadata_key` (a reserved column key — currently `agent_id` — was passed inside `metadata`; use the top-level field), `400 origin_limit_exceeded` / `400 tool_baseline_limit` / `503 evaluation_backlog_full` / `503 limit_capacity_exhausted` (memory/cardinality budgets — see below), `503 governance_unavailable` (sideband running without the service). Unhandled server faults return `500 { "error": "Internal server error" }`; adapters must fail closed on any 5xx.
 
@@ -108,9 +111,9 @@ The `decision` is an **outcome**, not Helio's internal rule action: a `rate_limi
 
 Counters are consumed here (not at `/evaluate`), and only when the call actually ran (`success`/`error`, not `not_executed`). `/audit` is **idempotent on `evaluation_id`**: an identical replay returns `200 { already_finalized: true }` with no double-consumption, so a network retry after a lost response is safe. Finalized ids are remembered for one `sdk.evaluation_ttl` after finalization; past that window a replay gets `404 evaluation_unknown`. A different payload under the same id is an adapter bug → `409 evaluation_conflict`.
 
-**Decision finalization.** `deny`, `rate_limited`, `spend_limited`, and `dry_run` are **terminal at `/evaluate`** — their audit record is written immediately, so completeness never depends on the adapter calling `/audit`. A later `/audit` for such an evaluation returns `200 { finalized_by: "evaluate" }` and accepts any payload, so adapters may audit unconditionally (within the same one-TTL window).
+**Decision finalization.** `deny`, `rate_limited`, `spend_limited`, `budget_exceeded`, and `dry_run` are **terminal at `/evaluate`** — their audit record is written immediately, so completeness never depends on the adapter calling `/audit`. A later `/audit` for such an evaluation returns `200 { finalized_by: "evaluate" }` and accepts any payload, so adapters may audit unconditionally (within the same one-TTL window).
 
-`actual_amount` must be finite and `>= 0` (`400 invalid_actual_amount` otherwise) and only applies to evaluations whose decision carried a spend rule (`400 no_spend_rule` if sent for any other evaluation).
+`actual_amount` must be finite and `>= 0` (`400 invalid_actual_amount` otherwise) and only applies to evaluations that track money — a spend rule or one or more matched budgets (`400 no_spend_rule` if sent for any other evaluation). It is the call's one true realized cost: it overrides the spend-rule amount AND every matched budget's charge.
 
 ### Populating evidence
 
@@ -143,7 +146,7 @@ A token-bearing adapter is in the threat model, so several caller-controlled gro
 | Pending evaluations             | 10,000 / 64 MiB | `503 evaluation_backlog_full`                                             |
 | Distinct `sender_id` limit keys | 50,000          | `503 limit_capacity_exhausted`                                            |
 
-The `sender_id` budget is a **reservation registry**: because `sender_id` is caller-minted, a new sender key is reserved at `/evaluate` (pre-execution, so it can fail closed) and released once its limiter bucket empties. It is scoped to `sender:*` keys only, so a flood of sender ids can never starve the structural MCP path's `tool`/`session` limits — the two doors share one limiter, but only the untrusted key family is capped.
+The `sender_id` budget is a **reservation registry**: because `sender_id` is caller-minted, a new sender key is reserved at `/evaluate` (pre-execution, so it can fail closed) and released once its limiter or budget bucket empties. It is scoped to sender-derived keys only — `sender:*` rule-limit keys and `budget:<name>:sender:*` budget buckets — so a flood of sender ids can never starve the structural MCP path's `tool`/`session` limits. A sender that exercises several sender-keyed rules or budgets holds one slot per exercised bucket.
 
 ## `POST /install-scan`
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -40,22 +40,24 @@ Each audit record contains the following fields:
 
 `block_reason` is the column to alert on: it is non-null exactly when Helio blocked the call. The vocabulary:
 
-| Reason                  | Set when                                                                                                                                                               |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `policy_denied`         | A `deny` rule (or the default deny) matched, or a session-required evidence gate had no session.                                                                       |
-| `evidence_missing`      | A required evidence key was never stored for the session.                                                                                                              |
-| `evidence_expired`      | A required evidence key was stored but its TTL lapsed.                                                                                                                 |
-| `dependency_missing`    | A `requires` / `requires_success` dependency was not satisfied.                                                                                                        |
-| `approval_denied`       | An approver denied the call.                                                                                                                                           |
-| `approval_timeout`      | The approval window elapsed (with `default_on_timeout: deny`).                                                                                                         |
-| `client_disconnected`   | The MCP client disconnected before request completion (while awaiting approval, or after approval resolved but before completion).                                     |
-| `shutdown_cancelled`    | Proxy shutdown cancelled a pending approval.                                                                                                                           |
-| `cancelled`             | A sideband-resolved ticket was cancelled by the adapter.                                                                                                               |
-| `rate_limited`          | A `rate_limit` rule's window was exhausted.                                                                                                                            |
-| `spend_limited`         | A `spend_limit` rule's window budget was exhausted (or the amount was invalid).                                                                                        |
-| `tool_definition_drift` | The call hit a drifted tool under `on_tool_drift: block`.                                                                                                              |
-| `install_denied`        | An install scan matched a `deny_install` rule.                                                                                                                         |
-| `missing_tool_name`     | A `tools/call` carried no usable tool name (missing, non-string, or empty `params.name`) and was rejected (see [Nameless Call Rejections](#nameless-call-rejections)). |
+| Reason                       | Set when                                                                                                                                                               |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `policy_denied`              | A `deny` rule (or the default deny) matched, or a session-required evidence gate had no session.                                                                       |
+| `evidence_missing`           | A required evidence key was never stored for the session.                                                                                                              |
+| `evidence_expired`           | A required evidence key was stored but its TTL lapsed.                                                                                                                 |
+| `dependency_missing`         | A `requires` / `requires_success` dependency was not satisfied.                                                                                                        |
+| `approval_denied`            | An approver denied the call.                                                                                                                                           |
+| `approval_timeout`           | The approval window elapsed (with `default_on_timeout: deny`).                                                                                                         |
+| `client_disconnected`        | The MCP client disconnected before request completion (while awaiting approval, or after approval resolved but before completion).                                     |
+| `shutdown_cancelled`         | Proxy shutdown cancelled a pending approval.                                                                                                                           |
+| `cancelled`                  | A sideband-resolved ticket was cancelled by the adapter.                                                                                                               |
+| `rate_limited`               | A `rate_limit` rule's window was exhausted.                                                                                                                            |
+| `spend_limited`              | A `spend_limit` rule's window budget was exhausted (or the amount was invalid).                                                                                        |
+| `budget_exceeded`            | A named budget denied the call — the policy decision itself may be `allow`; the budget gate blocked it. `evidence_chain.budgets` carries the per-budget snapshots.     |
+| `budget_ledger_write_failed` | The budget ledger's durable write failed, so the call was blocked without consuming any counters. The failure detail is in `evidence_chain.budgets`.                   |
+| `tool_definition_drift`      | The call hit a drifted tool under `on_tool_drift: block`.                                                                                                              |
+| `install_denied`             | An install scan matched a `deny_install` rule.                                                                                                                         |
+| `missing_tool_name`          | A `tools/call` carried no usable tool name (missing, non-string, or empty `params.name`) and was rejected (see [Nameless Call Rejections](#nameless-call-rejections)). |
 
 `evaluation_expired` records keep `block_reason` null: an expired evaluation is a reporting failure, not an enforcement block. One caveat for library embedders: when Helio's forwarder is embedded without an approval router or rate/spend limiter, a rule requiring the missing handler blocks with the free-text policy reason instead of a fixed value. This cannot happen under `helio start`, which always wires all three.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,6 +220,40 @@ Limiter actions are startup-fatal when incomplete:
 - `action: rate_limit` must include both `limits.max_calls` and `limits.window`.
 - `action: spend_limit` must include `limits.max_spend`.
 
+### budgets
+
+Named cross-tool spend budgets — a first-class layer independent of policy rules. One call depletes every budget whose contributors match, all-or-nothing: the call proceeds only if every matching budget allows it, a breach denies it, and rejected calls never consume budget anywhere. Budgets are enforced deterministically at the MCP gate; on the host-enforced adapter tier they inherit the documented [TOCTOU caveat](./adapter-api.md#the-crash-ttl-and-toctou-caveats).
+
+```yaml
+budgets:
+  - name: daily-cap # unique; letters, digits, "_", "-" only
+    limit: 50
+    currency: USD # single currency per budget, the operator's assertion
+    window: 24h # a duration, or "session" (a depleting pot per session key)
+    key: global # global | session | sender_id (default: global)
+    on_exceed: deny # deny is the only mode in this release
+    contributors:
+      - tool: 'stripe_*' # picomatch glob, same engine as match.tool
+        field: '$.amount' # dot-path into the tool arguments
+      - tool: 'paypal_*'
+        field: '$.total'
+```
+
+| Field          | Type     | Required | Default  | Description                                                                                            |
+| -------------- | -------- | -------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| `name`         | string   | Yes      | —        | Unique budget identity; preserves accrued spend across config edits. Charset: `[A-Za-z0-9_-]`, ≤64.    |
+| `limit`        | number   | Yes      | —        | Maximum cumulative spend within the window. Must be positive.                                          |
+| `currency`     | string   | Yes      | —        | Display/validation currency. Whether tools actually charge in it is the operator's assertion.          |
+| `window`       | string   | Yes      | —        | A [duration](#duration-strings) (sliding window) or `session` (never replenishes on a timer).          |
+| `key`          | string   | No       | `global` | Bucket scope: one shared pot (`global`), per session, or per adapter-supplied sender.                  |
+| `on_exceed`    | string   | No       | `deny`   | What a breach does. Only `deny` ships in this release; break-glass approval is planned.                |
+| `idle_ttl`     | duration | No       | `24h`    | Session windows only: idle time before an inactive session pot is collected.                           |
+| `contributors` | list     | Yes      | —        | Non-empty. Which tools feed the budget and which argument field carries the amount (first match wins). |
+
+Validation: budget names must be unique; `window: session` requires `key: session` or `key: sender_id`; `idle_ttl` is only valid with `window: session`; `key: sender_id` requires `sdk.enabled: true`. A matched contributor whose amount field is missing, non-numeric, negative, or non-finite fails closed — the call is denied.
+
+Budget state lives in buckets keyed `budget:<name>:<scope>` — visible in audit records' `evidence_chain.budgets`. Budgets hot-reload by name identity: edits to `contributors` preserve accrued spend (they do not change what was already spent), while a change to `limit`, `currency`, `window`, or `key` resets the budget's buckets (a different pool or scope structure). Budget state is in-memory in this release; persistence and a spend ledger are planned.
+
 ### approval
 
 Configuration for human-in-the-loop approval workflows. See [Approval Workflows](./approvals.md) for full documentation.
@@ -437,11 +471,12 @@ The CLI flag takes precedence over the config file. When disabled, Helio logs:
 
 ### Reload boundary
 
-Only compiled policy behavior is hot-reloadable. Startup-bound sections still require restart.
+Compiled policy behavior and named budgets are hot-reloadable. Startup-bound sections still require restart.
 
 | Config path                 | Reloads on save? | Notes                                                                                     |
 | --------------------------- | ---------------- | ----------------------------------------------------------------------------------------- |
 | `policies.rules`            | Yes              | Recompiled and swapped atomically.                                                        |
+| `budgets`                   | Yes              | Reconciled by name identity — see [budgets](#budgets) for what survives an edit.          |
 | `policies.default`          | Yes              | Takes effect immediately on the next request.                                             |
 | `policies.flag_destructive` | Yes              | Takes effect immediately on the next request.                                             |
 | `policies.on_tool_drift`    | Yes              | Takes effect immediately on the next request.                                             |

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -419,6 +419,29 @@ Spend limits track cumulative monetary amounts extracted from tool call argument
     suggestion: 'Wait for the current window to reset or escalate to a human.'
 ```
 
+## Named Budgets (cross-tool)
+
+`spend_limit` rules cap what one rule's matched tools spend. **Named budgets** are the cross-tool layer: a first-class `budgets:` section, independent of rules, where one depleting pot aggregates spend across every tool its contributors match — Stripe and PayPal into one cap, each exposing the amount under its own field name.
+
+```yaml
+budgets:
+  - name: daily-cap
+    limit: 50
+    currency: USD
+    window: 24h
+    contributors:
+      - tool: 'stripe_*'
+        field: '$.amount'
+      - tool: 'paypal_*'
+        field: '$.total'
+```
+
+The ordering differs per door because only one of them can sequence gates in time. On the **MCP door** a call flows: policy decision → approval resolution (rule-level, if required) → budget gate → forward — a human can approve a call that the budget gate then checks with fresh numbers. The **sideband door** decides everything in one `/evaluate` round-trip, so budgets are checked at evaluate time: a budget breach is terminal there and preempts any approval ticket (the money gate forbids what the approver would have been asked to allow), while an allowed call's budget charges commit at `/audit` once the call actually executed. On both doors a deny rule denies before budgets are consulted, and dry-run peeks budgets without ever recording. The budget gate is all-or-nothing: every matching budget is peeked first, the call forwards only if all allow, and a denied call records nothing on any budget — including the rule-level rate/spend counters, which are only consumed when the call actually forwards. A denial returns structured feedback with `reason: budget_exceeded` and a `budgets` array listing every breached budget (name, `spent`, `remaining`, `reset_at`).
+
+`window: session` makes the pot deplete for the lifetime of a session key and never replenish on a timer; idle pots are collected after `idle_ttl` (default 24h), because neither door has an authoritative session-end signal. See the [configuration reference](./configuration.md#budgets) for the full schema and validation rules.
+
+`action: spend_limit` keeps working as the per-rule quick path; budgets are the cross-tool layer on top.
+
 ## Evidence Requirements
 
 Evidence grounding lets you require that certain information has been gathered before a tool call is allowed. Evidence is submitted by the [Python SDK](../packages/python-sdk/) via the sideband API.

--- a/packages/dashboard/src/components/AuditFilterBar.tsx
+++ b/packages/dashboard/src/components/AuditFilterBar.tsx
@@ -71,6 +71,7 @@ const BLOCK_REASON_FILTERS: ReadonlyArray<{ label: string; value: string | null 
   { label: 'Missing Tool Name', value: 'missing_tool_name' },
   { label: 'Rate Limited', value: 'rate_limited' },
   { label: 'Spend Limited', value: 'spend_limited' },
+  { label: 'Budget Exceeded', value: 'budget_exceeded' },
 ]
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/components/PolicyBadge.tsx
+++ b/packages/dashboard/src/components/PolicyBadge.tsx
@@ -19,6 +19,7 @@ const COLORS: Record<string, string> = {
   shutdown_cancelled: 'bg-slate-100 text-slate-700 ring-slate-500/20',
   rate_limited: 'bg-orange-50 text-orange-700 ring-orange-600/20',
   spend_limited: 'bg-purple-50 text-purple-700 ring-purple-600/20',
+  budget_exceeded: 'bg-fuchsia-50 text-fuchsia-700 ring-fuchsia-600/20',
   dry_run: 'bg-blue-50 text-blue-700 ring-blue-600/20',
 }
 

--- a/packages/dashboard/src/constants.ts
+++ b/packages/dashboard/src/constants.ts
@@ -16,6 +16,7 @@ export const DECISION_FILTERS: ReadonlyArray<{ label: string; value: OutcomeFilt
     { label: 'Shutdown Cancelled', value: 'shutdown_cancelled' },
     { label: 'Rate Limited', value: 'rate_limited' },
     { label: 'Spend Limited', value: 'spend_limited' },
+    { label: 'Budget Exceeded', value: 'budget_exceeded' },
     { label: 'Dry Run', value: 'dry_run' },
   ]
 

--- a/packages/dashboard/src/outcome.test.ts
+++ b/packages/dashboard/src/outcome.test.ts
@@ -5,6 +5,7 @@ import {
   outcomeFilterToAuditParams,
   formatDisplayOutcome,
 } from './outcome'
+import { DECISION_FILTERS } from './constants'
 
 describe('outcome helpers', () => {
   it('derives allow for non-blocked rate/spend/approval actions', () => {
@@ -85,5 +86,32 @@ describe('outcome helpers', () => {
     })
     expect(outcomeFilterToAuditParams('dry_run')).toEqual({ dry_run: true })
     expect(outcomeFilterToAuditParams('rejected')).toEqual({ decision: 'rejected' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// budget_exceeded (issue #14)
+// ---------------------------------------------------------------------------
+
+describe('budget_exceeded outcome', () => {
+  it('renders a budget denial as Budget Exceeded, never Allow', () => {
+    // A budget denial rides policy_decision "allow" (the rule allowed; the
+    // budget gate blocked) — the block_reason must win over the fallthrough.
+    const outcome = deriveDisplayOutcome({
+      policy_decision: 'allow',
+      block_reason: 'budget_exceeded',
+    })
+    expect(outcome).toBe('budget_exceeded')
+    expect(formatDisplayOutcome(outcome)).toBe('Budget Exceeded')
+  })
+
+  it('maps the budget_exceeded filter to the block-reason query param', () => {
+    expect(outcomeFilterToAuditParams('budget_exceeded')).toEqual({
+      reason: 'budget_exceeded',
+    })
+  })
+
+  it('offers Budget Exceeded in the decision filter list', () => {
+    expect(DECISION_FILTERS.some((f) => f.value === 'budget_exceeded')).toBe(true)
   })
 })

--- a/packages/dashboard/src/outcome.ts
+++ b/packages/dashboard/src/outcome.ts
@@ -12,6 +12,7 @@ export type DisplayOutcome =
   | 'shutdown_cancelled'
   | 'rate_limited'
   | 'spend_limited'
+  | 'budget_exceeded'
   | 'dry_run'
 
 export type OutcomeFilterValue = Exclude<DisplayOutcome, never>
@@ -39,6 +40,12 @@ export function deriveDisplayOutcome(record: DecisionLike): DisplayOutcome {
       return 'rate_limited'
     case 'spend_limited':
       return 'spend_limited'
+    case 'budget_exceeded':
+      // A named-budget denial (issue #14). It usually rides
+      // policy_decision "allow" — the rule allowed, the budget gate blocked —
+      // so it must be pinned before the policy_decision fallthrough or the
+      // dashboard would render a blocked call as Allow.
+      return 'budget_exceeded'
     case 'approval_denied':
       return 'approval_denied'
     case 'approval_timeout':
@@ -87,6 +94,8 @@ export function formatDisplayOutcome(outcome: DisplayOutcome): string {
       return 'Rate Limited'
     case 'spend_limited':
       return 'Spend Limited'
+    case 'budget_exceeded':
+      return 'Budget Exceeded'
     case 'dry_run':
       return 'Dry Run'
   }
@@ -138,6 +147,8 @@ export function outcomeFilterToAuditParams(filter: OutcomeFilterValue | null): A
       return { reason: 'rate_limited' }
     case 'spend_limited':
       return { reason: 'spend_limited' }
+    case 'budget_exceeded':
+      return { reason: 'budget_exceeded' }
     case 'dry_run':
       return { dry_run: true }
     default:

--- a/packages/proxy/src/__tests__/e2e-full.test.ts
+++ b/packages/proxy/src/__tests__/e2e-full.test.ts
@@ -23,6 +23,8 @@ import { EvidenceStore, createSidebandApp } from '../evidence/index.js'
 import { ApprovalQueue, ApprovalRouter, createChannels } from '../approval/index.js'
 import { RateLimiter } from '../policy/index.js'
 import { SpendLimiter } from '../policy/index.js'
+import { BudgetEngine } from '../budget/engine.js'
+import { compileBudgets } from '../budget/parser.js'
 import { createDashboardApp, DashboardEventBus } from '../dashboard/index.js'
 import type { DashboardEventType, DashboardEvents } from '../dashboard/index.js'
 
@@ -45,6 +47,7 @@ let approvalQueue: ApprovalQueue
 let approvalRouter: ApprovalRouter
 let rateLimiter: RateLimiter
 let spendLimiter: SpendLimiter
+let budgetEngine: BudgetEngine
 let evidenceStore: EvidenceStore
 let eventBus: DashboardEventBus
 let unsubscribeEvents: () => void
@@ -85,6 +88,13 @@ const policiesConfig: PoliciesConfig = {
     {
       name: 'allow-lookup',
       match: { tool: 'lookup_order' },
+      action: 'allow' as const,
+    },
+    // 3b: Allowed probe tool for the named-budget flow (issue #14) — the
+    // budget gate, not the rule, is what constrains it.
+    {
+      name: 'allow-budgeted-probe',
+      match: { tool: 'budgeted_*' },
       action: 'allow' as const,
     },
     // 4: Spend-limited payment (amount >= 1000 — must be before evidence-gated payment)
@@ -223,8 +233,22 @@ beforeAll(async () => {
     },
   })
 
-  // 7. Compile policies + create governed forwarder
+  // 7. Compile policies + create governed forwarder (budgets: issue #14)
   const { policy } = compilePolicies(policiesConfig)
+  budgetEngine = new BudgetEngine({
+    budgets: compileBudgets([
+      {
+        name: 'e2e-cap',
+        limit: 100,
+        currency: 'USD',
+        window: '24h',
+        key: 'global',
+        on_exceed: 'deny',
+        contributors: [{ tool: 'budgeted_*', field: '$.amount' }],
+      },
+    ]),
+    cleanupIntervalMs: 0,
+  })
   const rawForwarder = new StreamableHttpForwarder({ url: upstreamUrl })
   const governed = new GovernedForwarder(rawForwarder, policy, {
     auditWriter,
@@ -232,6 +256,7 @@ beforeAll(async () => {
     approvalRouter,
     rateLimiter,
     spendLimiter,
+    budgetEngine,
   })
 
   // 8. Build config for createApp
@@ -277,6 +302,7 @@ afterAll(async () => {
   approvalQueue.close()
   rateLimiter.close()
   spendLimiter.close()
+  budgetEngine.close()
   evidenceStore.close()
   auditWriter.close() // also closes auditStore internally
   await dashboardManaged.close()
@@ -793,5 +819,49 @@ describe('E2E: full MVP integration', () => {
       expect(rec.proxy_compute_ms).toBeGreaterThanOrEqual(0)
       expect(rec.created_at).toBeDefined()
     }
+  })
+
+  // --- Named budgets (issue #14) ---
+
+  it('depletes the cross-tool budget over HTTP and then denies with feedback', async () => {
+    // First call consumes 60 of the 100 pot.
+    const first = await sendMcpRequest(
+      proxyUrl,
+      'tools/call',
+      { name: 'budgeted_probe', arguments: { amount: 60 } },
+      70,
+    )
+    expect((first.body as { error?: unknown }).error).toBeUndefined()
+
+    // Second call would exceed: denied with budget feedback, nothing recorded.
+    const denied = await sendMcpRequest(
+      proxyUrl,
+      'tools/call',
+      { name: 'budgeted_probe', arguments: { amount: 50 } },
+      71,
+    )
+    const data = getErrorData(denied.body)
+    expect(data['reason']).toBe('budget_exceeded')
+    const budgets = data['budgets'] as Array<Record<string, unknown>>
+    expect(budgets[0]?.['name']).toBe('e2e-cap')
+    expect(budgets[0]?.['remaining']).toBe(40)
+
+    // A call within the remainder still forwards.
+    const third = await sendMcpRequest(
+      proxyUrl,
+      'tools/call',
+      { name: 'budgeted_probe', arguments: { amount: 40 } },
+      72,
+    )
+    expect((third.body as { error?: unknown }).error).toBeUndefined()
+
+    // The denial is on the audit trail with the budget chain.
+    auditWriter.flush()
+    const rec = auditStore
+      .list({ tool_name: 'budgeted_probe' })
+      .records.find((r) => r.block_reason === 'budget_exceeded')
+    expect(rec).toBeDefined()
+    const chain = rec?.evidence_chain as Record<string, unknown>
+    expect((chain['budgets'] as Array<Record<string, unknown>>)[0]?.['name']).toBe('e2e-cap')
   })
 })

--- a/packages/proxy/src/__tests__/sideband-shared-limiter.test.ts
+++ b/packages/proxy/src/__tests__/sideband-shared-limiter.test.ts
@@ -3,6 +3,8 @@ import { GovernanceService } from '../sideband/governance-service.js'
 import { GovernedForwarder } from '../policy/governed-forwarder.js'
 import { compilePolicies } from '../policy/parser.js'
 import { RateLimiter } from '../policy/rate-limiter.js'
+import { BudgetEngine } from '../budget/engine.js'
+import { compileBudgets } from '../budget/parser.js'
 import type { McpForwarder, McpRequest, ForwardResult } from '../mcp/types.js'
 
 // ---------------------------------------------------------------------------
@@ -116,6 +118,74 @@ describe('sideband ↔ MCP shared rate limiter', () => {
     expect(rateLimiter.getKeyState('sender:U2')?.current).toBe(1)
 
     rateLimiter.close()
+    service.close()
+  })
+})
+
+describe('sideband ↔ MCP shared budget engine (issue #14)', () => {
+  it('pools budget spend across both doors — one pot', async () => {
+    const policy = compilePolicies({ default: 'allow', dry_run: false, rules: [] }).policy
+    const budgetEngine = new BudgetEngine({
+      budgets: compileBudgets([
+        {
+          name: 'cap',
+          limit: 100,
+          currency: 'USD',
+          window: '24h',
+          key: 'global',
+          on_exceed: 'deny',
+          contributors: [{ tool: 'send', field: '$.amount' }],
+        },
+      ]),
+      cleanupIntervalMs: 0,
+    })
+    const service = new GovernanceService({ policy, budgetEngine, sweepIntervalMs: 0 })
+    const forwarder = new GovernedForwarder(mockForwarder(), policy, { budgetEngine })
+
+    // 1) Sideband evaluate + audit commits 60 of the 100 pot.
+    const ev = service.evaluate({
+      origin: 'openclaw',
+      agent_id: null,
+      session_id: null,
+      tool: { name: 'send' },
+      arguments: { amount: 60 },
+      metadata: null,
+    })
+    expect(ev.body['decision']).toBe('allow')
+    service.audit({ evaluation_id: ev.body['evaluation_id'] as string, status: 'success' }, 'h')
+    expect(budgetEngine.listStates()[0]?.buckets[0]?.spent).toBe(60)
+
+    // 2) An MCP call sees the sideband's spend: 50 more would exceed.
+    const mcpDenied = await forwarder.forward({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'send', arguments: { amount: 50 } },
+    })
+    expect(isBlocked(mcpDenied)).toBe(true)
+
+    // 3) An MCP call within the remainder records into the same pot...
+    const mcpAllowed = await forwarder.forward({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'send', arguments: { amount: 40 } },
+    })
+    expect(isBlocked(mcpAllowed)).toBe(false)
+    expect(budgetEngine.listStates()[0]?.buckets[0]?.spent).toBe(100)
+
+    // 4) ...and the sideband now sees a depleted pot.
+    const evDenied = service.evaluate({
+      origin: 'openclaw',
+      agent_id: null,
+      session_id: null,
+      tool: { name: 'send' },
+      arguments: { amount: 1 },
+      metadata: null,
+    })
+    expect(evDenied.body['decision']).toBe('budget_exceeded')
+
+    budgetEngine.close()
     service.close()
   })
 })

--- a/packages/proxy/src/budget/engine.test.ts
+++ b/packages/proxy/src/budget/engine.test.ts
@@ -1,0 +1,676 @@
+import { describe, it, expect, vi } from 'vitest'
+import { BudgetEngine } from './engine.js'
+import type { BudgetCommitEvent, BudgetLedgerSink } from './engine.js'
+import { compileBudgets } from './parser.js'
+import type { BudgetConfig } from '../config/schema.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function budgetConfig(overrides: Partial<BudgetConfig> = {}): BudgetConfig {
+  return {
+    name: 'daily-cap',
+    limit: 100,
+    currency: 'USD',
+    window: '24h',
+    key: 'global',
+    on_exceed: 'deny',
+    contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+    ...overrides,
+  }
+}
+
+function createEngine(
+  configs: BudgetConfig[],
+  options: {
+    ledger?: BudgetLedgerSink
+    onCommit?: (event: BudgetCommitEvent) => void
+  } = {},
+) {
+  let time = 1_000_000
+  const advance = (ms: number) => {
+    time += ms
+  }
+  const engine = new BudgetEngine({
+    budgets: compileBudgets(configs),
+    now: () => time,
+    cleanupIntervalMs: 0,
+    ...options,
+  })
+  return { engine, advance }
+}
+
+const COMMIT_META = {
+  kind: 'spend' as const,
+  auditRecordId: 'audit-1',
+  origin: 'mcp',
+  toolName: 'stripe_charge',
+  timestampIso: '2026-07-09T12:00:00.000Z',
+}
+
+function chargeCtx(toolName: string, args: Record<string, unknown>, sessionId?: string) {
+  return {
+    toolName,
+    toolArguments: args,
+    sessionId: sessionId ?? null,
+    senderId: null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resolveCharges
+// ---------------------------------------------------------------------------
+
+describe('BudgetEngine.resolveCharges', () => {
+  it('resolves a matching contributor into a charge with the extracted amount', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const { charges, failures } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 25 }))
+
+    expect(failures).toEqual([])
+    expect(charges).toHaveLength(1)
+    expect(charges[0]?.amount).toBe(25)
+    expect(charges[0]?.bucketKey).toBe('budget:daily-cap:global')
+  })
+
+  it('returns no charges for tools no contributor matches', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const { charges, failures } = engine.resolveCharges(chargeCtx('send_email', { amount: 25 }))
+
+    expect(charges).toEqual([])
+    expect(failures).toEqual([])
+  })
+
+  it('resolves every matching budget for one call', () => {
+    const { engine } = createEngine([
+      budgetConfig({ name: 'cap-a' }),
+      budgetConfig({ name: 'cap-b', contributors: [{ tool: 'stripe_*', field: '$.amount' }] }),
+    ])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 10 }))
+    expect(charges.map((c) => c.budget.name)).toEqual(['cap-a', 'cap-b'])
+  })
+
+  it('uses the first matching contributor when globs overlap', () => {
+    const { engine } = createEngine([
+      budgetConfig({
+        contributors: [
+          { tool: 'stripe_*', field: '$.amount' },
+          { tool: 'stripe_charge', field: '$.total' },
+        ],
+      }),
+    ])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 5, total: 999 }))
+    expect(charges[0]?.amount).toBe(5)
+  })
+
+  it('fails closed when the amount field is missing', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const { charges, failures } = engine.resolveCharges(chargeCtx('stripe_charge', { other: 1 }))
+
+    expect(charges).toEqual([])
+    expect(failures).toHaveLength(1)
+    expect(failures[0]?.reason).toBe('invalid_amount')
+  })
+
+  it.each([
+    ['NaN', NaN],
+    ['negative', -5],
+    ['Infinity', Infinity],
+    ['string', '5' as unknown],
+  ])('fails closed on a %s amount', (_label, amount) => {
+    const { engine } = createEngine([budgetConfig()])
+    const { charges, failures } = engine.resolveCharges(chargeCtx('stripe_charge', { amount }))
+    expect(charges).toEqual([])
+    expect(failures).toHaveLength(1)
+  })
+
+  it('builds session bucket keys with the session id and pools unknowns', () => {
+    const { engine } = createEngine([
+      budgetConfig({ name: 'sc', window: 'session', key: 'session' }),
+    ])
+    const withSession = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }, 's1'))
+    const withoutSession = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }))
+
+    expect(withSession.charges[0]?.bucketKey).toBe('budget:sc:session:s1')
+    expect(withoutSession.charges[0]?.bucketKey).toBe('budget:sc:session:unknown')
+  })
+
+  it('builds sender bucket keys from senderId', () => {
+    const { engine } = createEngine([budgetConfig({ name: 'sb', key: 'sender_id' })])
+    const { charges } = engine.resolveCharges({
+      toolName: 'stripe_charge',
+      toolArguments: { amount: 1 },
+      sessionId: null,
+      senderId: 'U7',
+    })
+    expect(charges[0]?.bucketKey).toBe('budget:sb:sender:U7')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// peekAll / recordAll
+// ---------------------------------------------------------------------------
+
+describe('BudgetEngine peek and record', () => {
+  it('peek allows under the limit and never mutates', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 }))
+
+    const first = engine.peekAll(charges)
+    const second = engine.peekAll(charges)
+
+    expect(first.allowed).toBe(true)
+    expect(first.entries[0]?.spent).toBe(0)
+    expect(first.entries[0]?.remaining).toBe(100)
+    expect(second.entries[0]?.spent).toBe(0)
+  })
+
+  it('record accumulates and a later peek that would exceed is denied', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const spend = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 }))
+    engine.recordAll(spend.charges, COMMIT_META)
+
+    const next = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 50 }))
+    const peek = engine.peekAll(next.charges)
+
+    expect(peek.allowed).toBe(false)
+    expect(peek.entries[0]?.spent).toBe(60)
+    expect(peek.entries[0]?.remaining).toBe(40)
+  })
+
+  it('peekAll is all-or-nothing: one denying budget flips allowed', () => {
+    const { engine } = createEngine([
+      budgetConfig({ name: 'big', limit: 1000 }),
+      budgetConfig({ name: 'small', limit: 10 }),
+    ])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 50 }))
+    const peek = engine.peekAll(charges)
+
+    expect(peek.allowed).toBe(false)
+    expect(peek.entries.find((e) => e.budget.name === 'big')?.allowed).toBe(true)
+    expect(peek.entries.find((e) => e.budget.name === 'small')?.allowed).toBe(false)
+  })
+
+  it('recordAll records on every matched budget together', () => {
+    const { engine } = createEngine([budgetConfig({ name: 'a' }), budgetConfig({ name: 'b' })])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 }))
+    engine.recordAll(charges, COMMIT_META)
+
+    const next = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }))
+    const peek = engine.peekAll(next.charges)
+    expect(peek.entries.map((e) => e.spent)).toEqual([30, 30])
+  })
+
+  it('recordAll can push past the limit (approved overage semantics)', () => {
+    const { engine } = createEngine([budgetConfig({ limit: 50 })])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 80 }))
+    const snapshots = engine.recordAll(charges, COMMIT_META)
+
+    expect(snapshots[0]?.spent).toBe(80)
+    expect(snapshots[0]?.remaining).toBe(0)
+  })
+
+  it('duration windows replenish after the window slides', () => {
+    const { engine, advance } = createEngine([budgetConfig({ window: '1h' })])
+    const spend = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 100 }))
+    engine.recordAll(spend.charges, COMMIT_META)
+
+    advance(3_600_001)
+
+    const next = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 100 }))
+    expect(engine.peekAll(next.charges).allowed).toBe(true)
+  })
+
+  it('session pots never replenish on a timer', () => {
+    const { engine, advance } = createEngine([
+      budgetConfig({ name: 'sc', window: 'session', key: 'session' }),
+    ])
+    const spend = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 100 }, 's1'))
+    engine.recordAll(spend.charges, { ...COMMIT_META })
+
+    advance(3_600_000 * 20) // well past any duration window, within idle TTL
+
+    const next = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }, 's1'))
+    expect(engine.peekAll(next.charges).allowed).toBe(false)
+  })
+
+  it('reports reset_at_ms for duration windows and null for session pots', () => {
+    const { engine } = createEngine([
+      budgetConfig({ name: 'd', window: '1h' }),
+      budgetConfig({ name: 's', window: 'session', key: 'session' }),
+    ])
+    const spend = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 10 }, 's1'))
+    const snapshots = engine.recordAll(spend.charges, COMMIT_META)
+
+    expect(snapshots.find((e) => e.budget.name === 'd')?.resetAtMs).toBe(1_000_000 + 3_600_000)
+    expect(snapshots.find((e) => e.budget.name === 's')?.resetAtMs).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Ledger sink atomicity
+// ---------------------------------------------------------------------------
+
+describe('BudgetEngine ledger sink', () => {
+  it('applies no in-memory state when the sink throws', () => {
+    const throwingSink: BudgetLedgerSink = {
+      commitAll: () => {
+        throw new Error('disk full')
+      },
+    }
+    const { engine } = createEngine([budgetConfig()], { ledger: throwingSink })
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 }))
+
+    expect(() => engine.recordAll(charges, COMMIT_META)).toThrow('disk full')
+
+    const peek = engine.peekAll(charges)
+    expect(peek.entries[0]?.spent).toBe(0)
+  })
+
+  it('hands the sink one row per charge with the call metadata', () => {
+    const rows: unknown[] = []
+    const sink: BudgetLedgerSink = {
+      commitAll: (batch) => {
+        rows.push(...batch)
+      },
+    }
+    const { engine } = createEngine([budgetConfig({ name: 'a' }), budgetConfig({ name: 'b' })], {
+      ledger: sink,
+    })
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 }))
+    engine.recordAll(charges, COMMIT_META)
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      budget_name: 'a',
+      bucket_key: 'budget:a:global',
+      kind: 'spend',
+      amount: 30,
+      currency: 'USD',
+      tool_name: 'stripe_charge',
+      origin: 'mcp',
+      audit_record_id: 'audit-1',
+      timestamp: '2026-07-09T12:00:00.000Z',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Commit events
+// ---------------------------------------------------------------------------
+
+describe('BudgetEngine commit events', () => {
+  it('fires onCommit per charge with post-record numbers', () => {
+    const onCommit = vi.fn()
+    const { engine } = createEngine([budgetConfig()], { onCommit })
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 40 }))
+    engine.recordAll(charges, COMMIT_META)
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(onCommit.mock.calls[0]?.[0]).toMatchObject({
+      name: 'daily-cap',
+      bucket_key: 'budget:daily-cap:global',
+      kind: 'spend',
+      amount: 40,
+      spent: 40,
+      remaining: 60,
+      limit: 100,
+      currency: 'USD',
+      utilization: 0.4,
+    })
+  })
+})
+
+describe('BudgetEngine commit robustness (review round)', () => {
+  it('mutates every bucket before emitting callbacks, and isolates callback throws', () => {
+    const seen: string[] = []
+    const onCommit = (event: BudgetCommitEvent) => {
+      seen.push(event.name)
+      if (event.name === 'a') throw new Error('subscriber bug')
+    }
+    const { engine } = createEngine([budgetConfig({ name: 'a' }), budgetConfig({ name: 'b' })], {
+      onCommit,
+    })
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 }))
+
+    // A throwing subscriber must not abort the commit nor leave memory
+    // partially updated relative to the (already-written) ledger.
+    expect(() => engine.recordAll(charges, COMMIT_META)).not.toThrow()
+    expect(seen).toEqual(['a', 'b'])
+    expect(engine.listStates().map((s2) => s2.buckets[0]?.spent)).toEqual([30, 30])
+  })
+
+  it('ledgers a stale-generation charge without repopulating the reset pot', () => {
+    const rows: Array<Record<string, unknown>> = []
+    const { engine } = createEngine([budgetConfig({ limit: 100 })], {
+      ledger: { commitAll: (batch) => rows.push(...(batch as never[])) },
+    })
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 }))
+
+    // Tuple change between peek and commit (sideband /evaluate → reload →
+    // /audit, or an MCP approval wait): the call EXECUTED, so the money must
+    // stay on the ledger/audit trail — under the evaluate-time generation —
+    // but the frozen charge must not repopulate the reset pot.
+    engine.reconcile(compileBudgets([budgetConfig({ limit: 500 })]))
+
+    const snapshots = engine.recordAll(charges, COMMIT_META)
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0]?.stale).toBe(true)
+    expect(snapshots[0]?.amount).toBe(30)
+    // Honest numbers: the CURRENT pot (untouched by the stale charge), and a
+    // duration reset is never null — that is reserved for session pots.
+    expect(snapshots[0]?.spent).toBe(0)
+    expect(snapshots[0]?.remaining).toBe(500)
+    expect(snapshots[0]?.resetAtMs).not.toBeNull()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.['generation']).toBe(1)
+    expect(rows[0]?.['amount']).toBe(30)
+    // The reset pot itself stays untouched.
+    expect(engine.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+  })
+
+  it('bumps the generation when a budget is removed (no hidden state revival)', () => {
+    const rows: Array<Record<string, unknown>> = []
+    const { engine } = createEngine([budgetConfig()], {
+      ledger: { commitAll: (batch) => rows.push(...(batch as never[])) },
+    })
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 }))
+
+    // evaluate → budget removed → audit: the executed spend still ledgers,
+    // but no bucket state may be recreated for a budget that no longer exists.
+    engine.reconcile([])
+
+    const snapshots = engine.recordAll(charges, COMMIT_META)
+    expect(snapshots[0]?.stale).toBe(true)
+    expect(rows).toHaveLength(1)
+    expect(engine.listStates()).toEqual([])
+    expect(engine.hasBucket('budget:daily-cap:global')).toBe(false)
+  })
+
+  it('commits charges whose generation is still current after a benign reconcile', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 }))
+
+    // Contributor-only edit: same tuple, same generation — the in-flight
+    // charge stays valid.
+    engine.reconcile(
+      compileBudgets([
+        budgetConfig({
+          contributors: [
+            { tool: 'stripe_*', field: '$.amount' },
+            { tool: 'paypal_*', field: '$.total' },
+          ],
+        }),
+      ]),
+    )
+
+    const snapshots = engine.recordAll(charges, COMMIT_META)
+    expect(snapshots).toHaveLength(1)
+    expect(engine.listStates()[0]?.buckets[0]?.spent).toBe(30)
+  })
+})
+
+describe('BudgetEngine invalid-amount snapshots (review round 2)', () => {
+  it('reports a future reset for duration budgets even with an empty bucket', () => {
+    // The wire contract reserves a null reset for session pots; an empty
+    // duration bucket resets one window from now.
+    const { engine } = createEngine([budgetConfig({ window: '1h' })])
+    const { failures } = engine.resolveCharges(chargeCtx('stripe_charge', { note: 'no amount' }))
+    expect(failures[0]?.resetAtMs).toBe(1_000_000 + 3_600_000)
+  })
+
+  it('keeps a null reset for session pots on invalid amounts', () => {
+    const { engine } = createEngine([
+      budgetConfig({ name: 'sc', window: 'session', key: 'session' }),
+    ])
+    const { failures } = engine.resolveCharges(chargeCtx('stripe_charge', { note: 'x' }, 's1'))
+    expect(failures[0]?.resetAtMs).toBeNull()
+  })
+})
+
+describe('BudgetEngine lazy expiry (review round)', () => {
+  it('reports a live reset_at_ms after entries expire, not a past one', () => {
+    const { engine, advance } = createEngine([budgetConfig({ window: '1h' })])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 10 })).charges,
+      COMMIT_META,
+    )
+    advance(3_600_001) // the only entry expired; no gc() has run
+
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 10 }))
+    const peek = engine.peekAll(charges)
+    expect(peek.entries[0]?.spent).toBe(0)
+    // A stale first-entry timestamp would report a reset in the past.
+    expect(peek.entries[0]?.resetAtMs).toBeGreaterThan(1_000_000 + 3_600_001)
+  })
+
+  it('drops fully-expired duration buckets from listStates and hasBucket without gc', () => {
+    const { engine, advance } = createEngine([budgetConfig({ window: '1h' })])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 10 })).charges,
+      COMMIT_META,
+    )
+    advance(3_600_001)
+
+    expect(engine.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+    // Liveness drives sender-capacity slot pruning — an all-expired bucket
+    // must not pin a slot until the periodic sweep.
+    expect(engine.hasBucket('budget:daily-cap:global')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reconcile — name identity
+// ---------------------------------------------------------------------------
+
+describe('BudgetEngine.reconcile', () => {
+  it('preserves accrued spend across a contributor edit', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const spend = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 }))
+    engine.recordAll(spend.charges, COMMIT_META)
+
+    engine.reconcile(
+      compileBudgets([
+        budgetConfig({
+          contributors: [
+            { tool: 'stripe_*', field: '$.amount' },
+            { tool: 'paypal_*', field: '$.total' },
+          ],
+        }),
+      ]),
+    )
+
+    const viaNewContributor = engine.resolveCharges(chargeCtx('paypal_send', { total: 50 }))
+    expect(engine.peekAll(viaNewContributor.charges).allowed).toBe(false)
+  })
+
+  it('resets state when the limit changes', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const spend = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 }))
+    engine.recordAll(spend.charges, COMMIT_META)
+
+    engine.reconcile(compileBudgets([budgetConfig({ limit: 200 })]))
+
+    const next = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }))
+    expect(engine.peekAll(next.charges).entries[0]?.spent).toBe(0)
+  })
+
+  it('resets state when the currency changes', () => {
+    const { engine } = createEngine([budgetConfig()])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 })).charges,
+      COMMIT_META,
+    )
+
+    engine.reconcile(compileBudgets([budgetConfig({ currency: 'EUR' })]))
+
+    const next = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }))
+    expect(engine.peekAll(next.charges).entries[0]?.spent).toBe(0)
+  })
+
+  it('resets state when the key scope changes', () => {
+    const { engine } = createEngine([budgetConfig()])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 })).charges,
+      COMMIT_META,
+    )
+
+    // global → session is a different pool structure: the old global bucket
+    // must not strand (still displayed, never read) while session pots start
+    // at zero — the scope change resets the budget like any tuple change.
+    // The window stays identical so ONLY the key differs.
+    engine.reconcile(compileBudgets([budgetConfig({ key: 'session' })]))
+
+    expect(engine.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+    expect(engine.hasBucket('budget:daily-cap:global')).toBe(false)
+  })
+
+  it('marks in-flight charges stale across a key-scope change', () => {
+    const rows: Array<Record<string, unknown>> = []
+    const { engine } = createEngine([budgetConfig()], {
+      ledger: { commitAll: (batch) => rows.push(...(batch as never[])) },
+    })
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 }))
+
+    engine.reconcile(compileBudgets([budgetConfig({ key: 'session' })]))
+
+    const snapshots = engine.recordAll(charges, COMMIT_META)
+    expect(snapshots[0]?.stale).toBe(true)
+    expect(rows).toHaveLength(1)
+    expect(engine.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+  })
+
+  it('resets state when the window changes', () => {
+    const { engine } = createEngine([budgetConfig()])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 })).charges,
+      COMMIT_META,
+    )
+
+    engine.reconcile(compileBudgets([budgetConfig({ window: '1h' })]))
+
+    const next = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }))
+    expect(engine.peekAll(next.charges).entries[0]?.spent).toBe(0)
+  })
+
+  it('drops state for removed budgets and starts fresh for new names', () => {
+    const { engine } = createEngine([budgetConfig({ name: 'old' })])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 })).charges,
+      COMMIT_META,
+    )
+
+    engine.reconcile(compileBudgets([budgetConfig({ name: 'new' })]))
+
+    expect(engine.listStates().map((s) => s.name)).toEqual(['new'])
+    const next = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }))
+    expect(next.charges[0]?.budget.name).toBe('new')
+    expect(engine.peekAll(next.charges).entries[0]?.spent).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Idle-TTL GC (session windows)
+// ---------------------------------------------------------------------------
+
+describe('BudgetEngine.gc', () => {
+  it('collects session pots idle past their TTL and keeps active ones', () => {
+    const { engine, advance } = createEngine([
+      budgetConfig({ name: 'sc', window: 'session', key: 'session', idle_ttl: '1h' }),
+    ])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 100 }, 'stale')).charges,
+      COMMIT_META,
+    )
+    advance(1_800_000)
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 10 }, 'active')).charges,
+      COMMIT_META,
+    )
+    advance(1_800_001) // stale pot now idle > 1h; active pot idle 30min
+
+    engine.gc()
+
+    const keys = engine
+      .listStates()
+      .flatMap((s) => s.buckets)
+      .map((b) => b.bucket_key)
+    expect(keys).toEqual(['budget:sc:session:active'])
+
+    // The collected pot starts fresh if the session reappears.
+    const revived = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }, 'stale'))
+    expect(engine.peekAll(revived.charges).allowed).toBe(true)
+  })
+
+  it('evicts expired duration entries on gc', () => {
+    const { engine, advance } = createEngine([budgetConfig({ window: '1h' })])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 100 })).charges,
+      COMMIT_META,
+    )
+    advance(3_600_001)
+
+    engine.gc()
+
+    expect(engine.listStates().flatMap((s) => s.buckets)).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// listStates / hasBucket / close
+// ---------------------------------------------------------------------------
+
+describe('BudgetEngine read surface', () => {
+  it('lists configured budgets even with zero live buckets', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const states = engine.listStates()
+
+    expect(states).toHaveLength(1)
+    expect(states[0]).toMatchObject({
+      name: 'daily-cap',
+      limit: 100,
+      currency: 'USD',
+      window: '24h',
+      key: 'global',
+      on_exceed: 'deny',
+      buckets: [],
+    })
+  })
+
+  it('reports live bucket state with wire field names', () => {
+    const { engine } = createEngine([budgetConfig({ window: '1h' })])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    const bucket = engine.listStates()[0]?.buckets[0]
+    expect(bucket).toEqual({
+      bucket_key: 'budget:daily-cap:global',
+      spent: 30,
+      remaining: 70,
+      reset_at_ms: 1_000_000 + 3_600_000,
+      last_activity_ms: 1_000_000,
+    })
+  })
+
+  it('hasBucket reports live buckets by key', () => {
+    const { engine } = createEngine([budgetConfig()])
+    expect(engine.hasBucket('budget:daily-cap:global')).toBe(false)
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 })).charges,
+      COMMIT_META,
+    )
+    expect(engine.hasBucket('budget:daily-cap:global')).toBe(true)
+  })
+
+  it('close clears all state', () => {
+    const { engine } = createEngine([budgetConfig()])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 })).charges,
+      COMMIT_META,
+    )
+    engine.close()
+    expect(engine.listStates().flatMap((s) => s.buckets)).toEqual([])
+  })
+})

--- a/packages/proxy/src/budget/engine.ts
+++ b/packages/proxy/src/budget/engine.ts
@@ -1,0 +1,580 @@
+// ---------------------------------------------------------------------------
+// BudgetEngine — in-memory state for named cross-tool budgets (issue #14).
+//
+// One engine instance is shared by both doors (MCP forwarder and sideband
+// governance service): one pot, both doors. The gate sequence is the caller's
+// job — resolveCharges → peekAll (all matching budgets, all-or-nothing) →
+// recordAll only when the call actually proceeds. peekAll never mutates;
+// recordAll writes the ledger sink first (one atomic batch) and applies
+// in-memory state only after the sink commits, so a failed durable write can
+// never leave memory and ledger disagreeing about money.
+//
+// Mirrors the SpendLimiter pattern: injectable clock, cleanup timer, close().
+// ---------------------------------------------------------------------------
+
+import { resolvePath } from '../policy/matchers.js'
+import type { CompiledBudget } from './types.js'
+
+/** Everything the engine needs about one tool call to resolve its charges. */
+export interface BudgetChargeContext {
+  readonly toolName: string
+  readonly toolArguments: Record<string, unknown> | undefined
+  readonly sessionId: string | null
+  /** Adapter-supplied sender id (sideband only); null on the MCP path. */
+  readonly senderId: string | null
+}
+
+/** One budget's share of a call: which bucket, how much. */
+export interface BudgetCharge {
+  readonly budget: CompiledBudget
+  readonly bucketKey: string
+  readonly amount: number
+  /**
+   * The budget's config generation at peek time. A tuple-changing reload
+   * bumps the generation and resets the pot; a charge frozen before the bump
+   * (sideband /evaluate → /audit, or an MCP approval wait) is stale and MUST
+   * NOT repopulate the new pot with old-config spend — recordAll skips it.
+   */
+  readonly generation: number
+}
+
+/** A budget whose contributor matched but whose amount was unusable. */
+export interface BudgetChargeFailure {
+  readonly budget: CompiledBudget
+  readonly bucketKey: string
+  readonly reason: 'invalid_amount'
+  /** REAL accrued spend on the bucket the charge would have hit. */
+  readonly spent: number
+  readonly remaining: number
+  /** Epoch ms when the oldest entry ages out (duration); null for session pots. */
+  readonly resetAtMs: number | null
+}
+
+/** Snapshot of one budget's state relative to a charge. */
+export interface BudgetPeekEntry {
+  readonly budget: CompiledBudget
+  readonly bucketKey: string
+  readonly amount: number
+  readonly allowed: boolean
+  /** Spend accrued before this charge. */
+  readonly spent: number
+  /** Headroom before this charge: max(0, limit - spent). */
+  readonly remaining: number
+  /** Epoch ms when the oldest entry ages out (duration); null for session pots. */
+  readonly resetAtMs: number | null
+  /**
+   * Set on recordAll snapshots for charges frozen before a tuple-changing
+   * reload: the executed spend was ledgered under its evaluate-time
+   * generation, but the reset pot was not touched.
+   */
+  readonly stale?: true
+}
+
+/** Metadata recorded with every committed charge of one call. */
+export interface BudgetCommitMeta {
+  readonly kind: 'spend' | 'approved_overage'
+  readonly auditRecordId: string
+  readonly origin: string
+  readonly toolName: string
+  readonly timestampIso: string
+}
+
+/**
+ * One durable ledger row. DTO: snake_case, matching the `budget_events`
+ * table columns the persistence layer writes.
+ */
+export interface BudgetLedgerRow {
+  readonly budget_name: string
+  readonly bucket_key: string
+  readonly kind: 'spend' | 'approved_overage'
+  readonly amount: number
+  readonly currency: string
+  readonly tool_name: string
+  readonly origin: string
+  readonly audit_record_id: string
+  readonly timestamp: string
+  readonly timestamp_ms: number
+  /**
+   * The charge's config generation at evaluate time. Rows from a stale
+   * generation are historical accounting for money that really moved; live
+   * replay only ever reads the current generation (the epoch of PR 2).
+   */
+  readonly generation: number
+}
+
+/**
+ * Durable sink for committed charges. `commitAll` MUST be transactional:
+ * either every row of the batch persists or none does (a throw means none).
+ * The in-memory default is a no-op; the SQLite ledger implements this.
+ */
+export interface BudgetLedgerSink {
+  commitAll(rows: readonly BudgetLedgerRow[]): void
+}
+
+/** Payload for the per-charge commit callback (dashboard event bus). */
+export interface BudgetCommitEvent {
+  readonly name: string
+  readonly bucket_key: string
+  readonly kind: 'spend' | 'approved_overage'
+  readonly amount: number
+  readonly spent: number
+  readonly remaining: number
+  readonly limit: number
+  readonly currency: string
+  readonly utilization: number
+}
+
+/** Wire-ready bucket state for `GET /api/budgets` (snake_case DTO). */
+export interface BudgetBucketState {
+  readonly bucket_key: string
+  readonly spent: number
+  readonly remaining: number
+  readonly reset_at_ms: number | null
+  readonly last_activity_ms: number
+}
+
+/** Wire-ready budget state for `GET /api/budgets` (snake_case DTO). */
+export interface BudgetState {
+  readonly name: string
+  readonly limit: number
+  readonly currency: string
+  readonly window: string
+  readonly key: 'global' | 'session' | 'sender_id'
+  readonly on_exceed: 'deny' | 'require_approval'
+  readonly buckets: readonly BudgetBucketState[]
+}
+
+export interface BudgetEngineOptions {
+  readonly budgets?: readonly CompiledBudget[]
+  /** Clock function for testable time. Defaults to `Date.now`. */
+  readonly now?: () => number
+  /** Interval (ms) between GC sweeps. 0 disables the timer. Default: 60000. */
+  readonly cleanupIntervalMs?: number
+  /** Durable sink; defaults to a no-op (state resets on restart). */
+  readonly ledger?: BudgetLedgerSink
+  /** Fired once per committed charge with post-record numbers. */
+  readonly onCommit?: (event: BudgetCommitEvent) => void
+}
+
+interface BudgetBucket {
+  /** Sliding-window entries (duration windows). */
+  entries: Array<{ timestampMs: number; amount: number }>
+  /** Running total (session windows). */
+  total: number
+  lastActivityMs: number
+}
+
+const NOOP_LEDGER: BudgetLedgerSink = { commitAll: () => {} }
+
+export class BudgetEngine {
+  private budgets = new Map<string, CompiledBudget>()
+  /** budget name → bucket key → bucket. */
+  private readonly state = new Map<string, Map<string, BudgetBucket>>()
+  /** budget name → config generation; bumped whenever the pot resets. */
+  private readonly generations = new Map<string, number>()
+  private readonly now: () => number
+  private readonly ledger: BudgetLedgerSink
+  private readonly onCommit: ((event: BudgetCommitEvent) => void) | undefined
+  private timer: ReturnType<typeof setInterval> | null = null
+  private closed = false
+
+  constructor(options: BudgetEngineOptions = {}) {
+    this.now = options.now ?? Date.now
+    this.ledger = options.ledger ?? NOOP_LEDGER
+    this.onCommit = options.onCommit
+    for (const budget of options.budgets ?? []) {
+      this.budgets.set(budget.name, budget)
+      this.generations.set(budget.name, 1)
+    }
+
+    const intervalMs = options.cleanupIntervalMs ?? 60_000
+    if (intervalMs > 0) {
+      this.timer = setInterval(() => {
+        this.gc()
+      }, intervalMs)
+      this.timer.unref()
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Gate operations
+  // -------------------------------------------------------------------------
+
+  /**
+   * Resolve which budgets a call feeds and how much it charges each.
+   *
+   * A budget participates when any contributor glob matches the tool name;
+   * the FIRST matching contributor (config order) supplies the amount field.
+   * A missing, non-numeric, negative, or non-finite amount fails closed as a
+   * `failures` entry — the caller must deny the call.
+   */
+  resolveCharges(ctx: BudgetChargeContext): {
+    charges: BudgetCharge[]
+    failures: BudgetChargeFailure[]
+  } {
+    const charges: BudgetCharge[] = []
+    const failures: BudgetChargeFailure[] = []
+
+    for (const budget of this.budgets.values()) {
+      const contributor = budget.contributors.find((c) => c.tool.test(ctx.toolName))
+      if (!contributor) continue
+
+      const raw = resolvePath(contributor.field, ctx.toolArguments ?? {})
+      if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0) {
+        // Fail closed with the REAL bucket snapshot — feedback must not
+        // fabricate zero spend for a pot that has accrued state.
+        const bucketKey = this.bucketKey(budget, ctx)
+        const nowMs = this.now()
+        const bucket = this.liveBucket(budget, bucketKey, nowMs)
+        const spent = bucket ? this.spentOf(budget, bucket, nowMs) : 0
+        failures.push({
+          budget,
+          bucketKey,
+          reason: 'invalid_amount',
+          spent,
+          remaining: Math.max(0, budget.limit - spent),
+          // null is reserved for session pots on the wire; an empty duration
+          // bucket resets one window from now.
+          resetAtMs:
+            budget.window.kind === 'duration'
+              ? bucket && bucket.entries.length > 0
+                ? (bucket.entries[0]?.timestampMs ?? nowMs) + budget.window.windowMs
+                : nowMs + budget.window.windowMs
+              : null,
+        })
+        continue
+      }
+
+      charges.push({
+        budget,
+        bucketKey: this.bucketKey(budget, ctx),
+        amount: raw,
+        generation: this.generations.get(budget.name) ?? 0,
+      })
+    }
+
+    return { charges, failures }
+  }
+
+  /** Check every charge without mutating. All-or-nothing: one deny flips `allowed`. */
+  peekAll(charges: readonly BudgetCharge[]): { allowed: boolean; entries: BudgetPeekEntry[] } {
+    const entries = charges.map((charge) => this.snapshot(charge))
+    return { allowed: entries.every((entry) => entry.allowed), entries }
+  }
+
+  /**
+   * Commit every charge of one call: ledger first (one atomic batch), then
+   * in-memory state, then the commit events. A sink throw propagates and
+   * leaves ALL in-memory buckets untouched — no partial commit, ever.
+   * Recording is unconditional past the sink (an approved overage
+   * legitimately pushes a bucket past its limit).
+   */
+  recordAll(charges: readonly BudgetCharge[], meta: BudgetCommitMeta): BudgetPeekEntry[] {
+    const nowMs = this.now()
+
+    // Stale-generation charges were frozen before a tuple-changing reload (or
+    // a removal) reset the pot. The call EXECUTED, so the money stays on the
+    // ledger — under its evaluate-time generation — but it must not mutate
+    // the reset pot's live state.
+    const current: BudgetCharge[] = []
+    const stale: BudgetCharge[] = []
+    for (const charge of charges) {
+      if (this.generations.get(charge.budget.name) === charge.generation) {
+        current.push(charge)
+      } else {
+        stale.push(charge)
+        // eslint-disable-next-line no-console -- Intentional operational warning
+        console.error(
+          `[helio] Budget "${charge.budget.name}": an in-flight charge outlived a config ` +
+            `change; its amount is ledgered under the old generation but does not count ` +
+            `against the current pot`,
+        )
+      }
+    }
+
+    this.ledger.commitAll(
+      charges.map((charge) => ({
+        budget_name: charge.budget.name,
+        bucket_key: charge.bucketKey,
+        kind: meta.kind,
+        amount: charge.amount,
+        currency: charge.budget.currency,
+        tool_name: meta.toolName,
+        origin: meta.origin,
+        audit_record_id: meta.auditRecordId,
+        timestamp: meta.timestampIso,
+        timestamp_ms: nowMs,
+        generation: charge.generation,
+      })),
+    )
+
+    // Mutate EVERY bucket before emitting any callback: a throwing subscriber
+    // must not leave memory partially updated relative to the ledger batch
+    // that already committed above.
+    const snapshots: BudgetPeekEntry[] = []
+    for (const charge of current) {
+      const bucket = this.bucketFor(charge.budget.name, charge.bucketKey)
+      if (charge.budget.window.kind === 'duration') {
+        this.evictExpired(bucket, charge.budget.window.windowMs, nowMs)
+        bucket.entries.push({ timestampMs: nowMs, amount: charge.amount })
+      } else {
+        bucket.total += charge.amount
+      }
+      bucket.lastActivityMs = nowMs
+      snapshots.push(this.snapshot(charge, { postRecord: true }))
+    }
+    for (const charge of stale) {
+      // An honest snapshot: the CURRENT pot's real numbers (which this charge
+      // deliberately did not touch) plus the stale marker — so use the live
+      // config where the name still exists (the frozen charge carries the
+      // pre-reload one). snapshot() keeps the reset contract: null stays
+      // session-only.
+      const liveBudget = this.budgets.get(charge.budget.name) ?? charge.budget
+      snapshots.push({ ...this.snapshot({ ...charge, budget: liveBudget }), stale: true })
+    }
+
+    for (let i = 0; i < current.length; i++) {
+      const charge = current[i]
+      const snapshot = snapshots[i]
+      if (!charge || !snapshot || !this.onCommit) continue
+      try {
+        this.onCommit({
+          name: charge.budget.name,
+          bucket_key: charge.bucketKey,
+          kind: meta.kind,
+          amount: charge.amount,
+          spent: snapshot.spent,
+          remaining: snapshot.remaining,
+          limit: charge.budget.limit,
+          currency: charge.budget.currency,
+          utilization: snapshot.spent / charge.budget.limit,
+        })
+      } catch (err) {
+        // eslint-disable-next-line no-console -- Subscriber bugs must not corrupt money state
+        console.error('[helio] budget onCommit subscriber threw:', err)
+      }
+    }
+    return snapshots
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Swap budget configs on hot-reload. Identity is the NAME: removed names
+   * drop their live buckets; a changed `{limit, currency, window, key}` tuple
+   * resets the budget's buckets (a different pool or scope structure);
+   * everything else — contributors, on_exceed — applies to the accrued state
+   * as-is, because those edits do not change what was already spent.
+   */
+  reconcile(next: readonly CompiledBudget[]): void {
+    const nextByName = new Map(next.map((budget) => [budget.name, budget]))
+
+    for (const [name, budget] of nextByName) {
+      const current = this.budgets.get(name)
+      if (!current || tupleChanged(current, budget)) {
+        // New name or a different pool: reset state and invalidate any
+        // in-flight charges frozen under the old generation.
+        this.state.delete(name)
+        this.generations.set(name, (this.generations.get(name) ?? 0) + 1)
+      }
+    }
+    for (const name of [...this.budgets.keys()]) {
+      if (nextByName.has(name)) continue
+      this.state.delete(name)
+      // A removed budget's generation bumps too: an in-flight charge frozen
+      // before the removal must go stale, or its commit would recreate
+      // hidden bucket state for a budget that no longer exists. Generations
+      // for removed names are kept (not deleted) so a later re-add keeps
+      // counting up instead of colliding with older in-flight charges.
+      this.generations.set(name, (this.generations.get(name) ?? 0) + 1)
+    }
+
+    this.budgets = nextByName
+  }
+
+  /** Sweep: collect idle session pots, evict expired duration entries. */
+  gc(): void {
+    const nowMs = this.now()
+    for (const [name, buckets] of this.state) {
+      const budget = this.budgets.get(name)
+      if (!budget) {
+        this.state.delete(name)
+        continue
+      }
+      for (const [key, bucket] of buckets) {
+        if (budget.window.kind === 'session') {
+          if (nowMs - bucket.lastActivityMs > budget.window.idleTtlMs) buckets.delete(key)
+        } else {
+          this.evictExpired(bucket, budget.window.windowMs, nowMs)
+          if (bucket.entries.length === 0) buckets.delete(key)
+        }
+      }
+      if (buckets.size === 0) this.state.delete(name)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Read surface
+  // -------------------------------------------------------------------------
+
+  /**
+   * Wire-ready state for `GET /api/budgets`. Configured budgets appear even
+   * with zero live buckets, so the dashboard shows every pot at headroom.
+   */
+  listStates(): BudgetState[] {
+    const nowMs = this.now()
+    return [...this.budgets.values()].map((budget) => {
+      const buckets: BudgetBucketState[] = []
+      for (const key of [...(this.state.get(budget.name)?.keys() ?? [])]) {
+        const bucket = this.liveBucket(budget, key, nowMs)
+        if (!bucket) continue
+        const spent = this.spentOf(budget, bucket, nowMs)
+        buckets.push({
+          bucket_key: key,
+          spent,
+          remaining: Math.max(0, budget.limit - spent),
+          reset_at_ms:
+            budget.window.kind === 'duration'
+              ? (bucket.entries[0]?.timestampMs ?? nowMs) + budget.window.windowMs
+              : null,
+          last_activity_ms: bucket.lastActivityMs,
+        })
+      }
+      return {
+        name: budget.name,
+        limit: budget.limit,
+        currency: budget.currency,
+        window: budget.windowRaw,
+        key: budget.key,
+        on_exceed: budget.onExceed,
+        buckets,
+      }
+    })
+  }
+
+  /** Whether any budget holds a live bucket under `key` (cardinality probes). */
+  hasBucket(key: string): boolean {
+    const nowMs = this.now()
+    for (const name of [...this.state.keys()]) {
+      const budget = this.budgets.get(name)
+      if (!budget) continue
+      if (this.liveBucket(budget, key, nowMs)) return true
+    }
+    return false
+  }
+
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    this.state.clear()
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private bucketKey(budget: CompiledBudget, ctx: BudgetChargeContext): string {
+    switch (budget.key) {
+      case 'session':
+        return `budget:${budget.name}:session:${ctx.sessionId ?? 'unknown'}`
+      case 'sender_id':
+        return `budget:${budget.name}:sender:${ctx.senderId ?? 'unknown'}`
+      case 'global':
+        return `budget:${budget.name}:global`
+    }
+  }
+
+  private bucketFor(name: string, key: string): BudgetBucket {
+    let buckets = this.state.get(name)
+    if (!buckets) {
+      buckets = new Map()
+      this.state.set(name, buckets)
+    }
+    let bucket = buckets.get(key)
+    if (!bucket) {
+      bucket = { entries: [], total: 0, lastActivityMs: this.now() }
+      buckets.set(key, bucket)
+    }
+    return bucket
+  }
+
+  private evictExpired(bucket: BudgetBucket, windowMs: number, nowMs: number): void {
+    const windowStart = nowMs - windowMs
+    bucket.entries = bucket.entries.filter((entry) => entry.timestampMs > windowStart)
+  }
+
+  /**
+   * Fetch a bucket for reading, evicting expired duration entries first and
+   * pruning the bucket if nothing is left. Reads must never see (or keep
+   * alive, via `hasBucket`-driven capacity slots) state the window has
+   * already expired — expiry is lazy on read, not just on the sweep timer.
+   */
+  private liveBucket(budget: CompiledBudget, key: string, nowMs: number): BudgetBucket | undefined {
+    const buckets = this.state.get(budget.name)
+    const bucket = buckets?.get(key)
+    if (!bucket || !buckets) return undefined
+    if (budget.window.kind === 'duration') {
+      this.evictExpired(bucket, budget.window.windowMs, nowMs)
+      if (bucket.entries.length === 0) {
+        buckets.delete(key)
+        if (buckets.size === 0) this.state.delete(budget.name)
+        return undefined
+      }
+    }
+    return bucket
+  }
+
+  private spentOf(budget: CompiledBudget, bucket: BudgetBucket, nowMs: number): number {
+    if (budget.window.kind === 'session') return bucket.total
+    const windowStart = nowMs - budget.window.windowMs
+    return bucket.entries.reduce(
+      (sum, entry) => (entry.timestampMs > windowStart ? sum + entry.amount : sum),
+      0,
+    )
+  }
+
+  private snapshot(charge: BudgetCharge, options: { postRecord?: boolean } = {}): BudgetPeekEntry {
+    const nowMs = this.now()
+    const bucket = this.liveBucket(charge.budget, charge.bucketKey, nowMs)
+    const accrued = bucket ? this.spentOf(charge.budget, bucket, nowMs) : 0
+    // Pre-record: `spent` is the accrued state the charge is checked against.
+    // Post-record: the charge is already inside the bucket.
+    const spent = accrued
+    const checkedAgainst = options.postRecord ? accrued - charge.amount : accrued
+    const resetAtMs =
+      charge.budget.window.kind === 'duration'
+        ? bucket && bucket.entries.length > 0
+          ? (bucket.entries[0]?.timestampMs ?? nowMs) + charge.budget.window.windowMs
+          : nowMs + charge.budget.window.windowMs
+        : null
+
+    return {
+      budget: charge.budget,
+      bucketKey: charge.bucketKey,
+      amount: charge.amount,
+      allowed: checkedAgainst + charge.amount <= charge.budget.limit,
+      spent,
+      remaining: Math.max(0, charge.budget.limit - spent),
+      resetAtMs,
+    }
+  }
+}
+
+function tupleChanged(a: CompiledBudget, b: CompiledBudget): boolean {
+  // `key` is part of the reset tuple: a scope change (e.g. global → session)
+  // restructures bucket identity, and preserving the old scope's buckets
+  // would strand them — displayed but never read — while new keys start at
+  // zero.
+  return (
+    a.limit !== b.limit ||
+    a.currency !== b.currency ||
+    a.windowRaw !== b.windowRaw ||
+    a.key !== b.key
+  )
+}

--- a/packages/proxy/src/budget/index.ts
+++ b/packages/proxy/src/budget/index.ts
@@ -1,0 +1,16 @@
+export { compileBudgets, BudgetParseError } from './parser.js'
+export { BudgetEngine } from './engine.js'
+export type {
+  BudgetChargeContext,
+  BudgetCharge,
+  BudgetChargeFailure,
+  BudgetPeekEntry,
+  BudgetCommitMeta,
+  BudgetLedgerRow,
+  BudgetLedgerSink,
+  BudgetCommitEvent,
+  BudgetBucketState,
+  BudgetState,
+  BudgetEngineOptions,
+} from './engine.js'
+export type { CompiledBudget, CompiledBudgetContributor, CompiledBudgetWindow } from './types.js'

--- a/packages/proxy/src/budget/parser.test.ts
+++ b/packages/proxy/src/budget/parser.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { compileBudgets, BudgetParseError } from './parser.js'
+import type { BudgetConfig } from '../config/schema.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function budgetConfig(overrides: Partial<BudgetConfig> = {}): BudgetConfig {
+  return {
+    name: 'daily-cap',
+    limit: 50,
+    currency: 'USD',
+    window: '24h',
+    key: 'global',
+    on_exceed: 'deny',
+    contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// compileBudgets
+// ---------------------------------------------------------------------------
+
+describe('compileBudgets', () => {
+  it('compiles a duration window to milliseconds', () => {
+    const [budget] = compileBudgets([budgetConfig({ window: '1h' })])
+    expect(budget?.window).toEqual({ kind: 'duration', windowMs: 3_600_000 })
+    expect(budget?.windowRaw).toBe('1h')
+  })
+
+  it('compiles a session window with the default 24h idle TTL', () => {
+    const [budget] = compileBudgets([budgetConfig({ window: 'session', key: 'session' })])
+    expect(budget?.window).toEqual({ kind: 'session', idleTtlMs: 86_400_000 })
+  })
+
+  it('honors an explicit idle_ttl on session windows', () => {
+    const [budget] = compileBudgets([
+      budgetConfig({ window: 'session', key: 'session', idle_ttl: '12h' }),
+    ])
+    expect(budget?.window).toEqual({ kind: 'session', idleTtlMs: 43_200_000 })
+  })
+
+  it('carries name, limit, currency, key, and on_exceed through', () => {
+    const [budget] = compileBudgets([budgetConfig()])
+    expect(budget?.name).toBe('daily-cap')
+    expect(budget?.limit).toBe(50)
+    expect(budget?.currency).toBe('USD')
+    expect(budget?.key).toBe('global')
+    expect(budget?.onExceed).toBe('deny')
+  })
+
+  it('compiles contributor globs with the policy matcher semantics', () => {
+    const [budget] = compileBudgets([
+      budgetConfig({
+        contributors: [
+          { tool: 'stripe_*', field: '$.amount' },
+          { tool: 'paypal_*', field: '$.total' },
+        ],
+      }),
+    ])
+    expect(budget?.contributors).toHaveLength(2)
+    expect(budget?.contributors[0]?.tool.test('stripe_charge')).toBe(true)
+    expect(budget?.contributors[0]?.tool.test('paypal_send')).toBe(false)
+    expect(budget?.contributors[0]?.field).toBe('$.amount')
+    expect(budget?.contributors[1]?.tool.pattern).toBe('paypal_*')
+  })
+
+  it('compiles exotic patterns to matchers rather than throwing (picomatch is total)', () => {
+    const [budget] = compileBudgets([budgetConfig({ contributors: [{ tool: '[', field: '$.x' }] })])
+    expect(budget?.contributors[0]?.tool.test('anything')).toBe(false)
+  })
+
+  it('BudgetParseError names the offending budget', () => {
+    const err = new BudgetParseError('invalid contributor glob "x": boom', 'daily-cap')
+    expect(err.message).toContain('daily-cap')
+    expect(err.budgetName).toBe('daily-cap')
+  })
+
+  it('compiles an empty list to an empty list', () => {
+    expect(compileBudgets([])).toEqual([])
+  })
+})

--- a/packages/proxy/src/budget/parser.ts
+++ b/packages/proxy/src/budget/parser.ts
@@ -1,0 +1,63 @@
+import picomatch from 'picomatch'
+import { parseDuration } from '../config/schema.js'
+import type { BudgetConfig } from '../config/schema.js'
+import type { CompiledBudget, CompiledBudgetContributor } from './types.js'
+
+/** Default idle TTL for `window: session` pots when `idle_ttl` is omitted. */
+const DEFAULT_IDLE_TTL_MS = 86_400_000 // 24h
+
+/** A budget failed to compile (invalid contributor glob). */
+export class BudgetParseError extends Error {
+  readonly budgetName: string
+
+  constructor(message: string, budgetName: string) {
+    super(`Budget "${budgetName}": ${message}`)
+    this.name = 'BudgetParseError'
+    this.budgetName = budgetName
+  }
+}
+
+/**
+ * Compile validated budget configs into engine-ready form.
+ *
+ * Contributor globs use the same picomatch engine as `match.tool` so a
+ * pattern behaves identically whether it gates a rule or feeds a budget.
+ *
+ * @throws {BudgetParseError} On an invalid contributor glob.
+ */
+export function compileBudgets(budgets: readonly BudgetConfig[]): CompiledBudget[] {
+  return budgets.map((budget) => ({
+    name: budget.name,
+    limit: budget.limit,
+    currency: budget.currency,
+    window:
+      budget.window === 'session'
+        ? {
+            kind: 'session' as const,
+            idleTtlMs: budget.idle_ttl ? parseDuration(budget.idle_ttl) : DEFAULT_IDLE_TTL_MS,
+          }
+        : { kind: 'duration' as const, windowMs: parseDuration(budget.window) },
+    windowRaw: budget.window,
+    key: budget.key,
+    onExceed: budget.on_exceed,
+    contributors: budget.contributors.map((contributor) =>
+      compileContributor(contributor, budget.name),
+    ),
+  }))
+}
+
+function compileContributor(
+  contributor: { tool: string; field: string },
+  budgetName: string,
+): CompiledBudgetContributor {
+  try {
+    const test = picomatch(contributor.tool, { dot: true })
+    return { tool: { pattern: contributor.tool, test }, field: contributor.field }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new BudgetParseError(
+      `invalid contributor glob "${contributor.tool}": ${message}`,
+      budgetName,
+    )
+  }
+}

--- a/packages/proxy/src/budget/types.ts
+++ b/packages/proxy/src/budget/types.ts
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------
+// Compiled budget types — engine-ready form of the `budgets:` config section
+// (issue #14). Mirrors the policy split: config types (config/schema.ts) carry
+// raw strings validated by Zod; compiled types carry pre-built matchers and
+// pre-parsed millisecond durations for zero-overhead evaluation.
+// ---------------------------------------------------------------------------
+
+import type { ToolMatcher } from '../policy/types.js'
+
+/** One compiled contributor: which tools feed the budget, and from which field. */
+export interface CompiledBudgetContributor {
+  readonly tool: ToolMatcher
+  /** Dot-path into the tool arguments (e.g. "$.amount"), resolved per call. */
+  readonly field: string
+}
+
+/**
+ * A budget's replenishment semantics.
+ *
+ * - `duration`: sliding window; spend ages out after `windowMs`.
+ * - `session`: a depleting pot per session key that never replenishes on a
+ *   timer; idle pots are garbage-collected after `idleTtlMs` because neither
+ *   door has an authoritative session-end signal.
+ */
+export type CompiledBudgetWindow =
+  | { readonly kind: 'duration'; readonly windowMs: number }
+  | { readonly kind: 'session'; readonly idleTtlMs: number }
+
+/** A fully compiled named budget, ready for the engine. */
+export interface CompiledBudget {
+  readonly name: string
+  readonly limit: number
+  readonly currency: string
+  readonly window: CompiledBudgetWindow
+  /** The raw config window string ("1h" | "session") for wire/docs surfaces. */
+  readonly windowRaw: string
+  readonly key: 'global' | 'session' | 'sender_id'
+  /**
+   * `require_approval` (break-glass) arrives later in this release train; the
+   * compiled union is forward-shaped so the engine's exhaustive handling is
+   * already in place, but the config schema only admits `deny` today.
+   */
+  readonly onExceed: 'deny' | 'require_approval'
+  readonly contributors: readonly CompiledBudgetContributor[]
+}

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -23,6 +23,7 @@ import {
 } from './approval/index.js'
 import { RateLimiter } from './policy/index.js'
 import { SpendLimiter } from './policy/index.js'
+import { BudgetEngine, compileBudgets } from './budget/index.js'
 import { parseDuration } from './config/schema.js'
 import { createDashboardAppWithLifecycle, DashboardEventBus } from './dashboard/index.js'
 import type { AuditRecord } from './audit/index.js'
@@ -314,6 +315,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     const label = w.ruleName ? `rule "${w.ruleName}"` : `rule ${String(w.ruleIndex)}`
     console.error(`Warning: policy ${label}: ${w.message}`)
   }
+  const budgets = compileBudgets(config.budgets)
 
   // Create dashboard event bus (used by all components for real-time events)
   const eventBus = new DashboardEventBus()
@@ -413,6 +415,11 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     },
   })
 
+  // One budget engine shared by both doors — one pot, MCP and sideband alike.
+  // Constructed even with zero budgets configured so a hot-reload can
+  // introduce budgets without a restart; the gate short-circuits when empty.
+  const budgetEngine = new BudgetEngine({ budgets })
+
   const governedForwarder = new GovernedForwarder(forwarder, policy, {
     environment: config.environment,
     auditWriter,
@@ -420,6 +427,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     approvalRouter,
     rateLimiter,
     spendLimiter,
+    budgetEngine,
   })
 
   const annotationPrime = await startAnnotationPrimeLoop(governedForwarder)
@@ -483,6 +491,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
       approvalRouter,
       rateLimiter,
       spendLimiter,
+      budgetEngine,
       auditWriter,
       approvalTimeoutMs: parseDuration(config.approval.timeout),
       ttlMs: parseDuration(config.sdk.evaluation_ttl),
@@ -575,6 +584,10 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   )
   console.error(`Rate limits: enabled`)
   console.error(`Spend limits: enabled`)
+  const budgetCount = budgets.length
+  console.error(
+    `Budgets: ${String(budgetCount)} configured${budgetCount > 0 ? ` (${budgets.map((b) => b.name).join(', ')})` : ''}`,
+  )
   if (policy.dryRun) {
     console.error(`Dry-run: ENABLED (no requests will be forwarded to upstream)`)
   }
@@ -591,9 +604,14 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     configWatcher = new ConfigWatcher({
       configPath,
       initialConfig: config,
-      onPolicyReload: (newPolicy, reloadWarnings, restartRequiredPaths) => {
+      onPolicyReload: (newPolicy, reloadWarnings, restartRequiredPaths, newBudgets) => {
         governedForwarder.updatePolicy(newPolicy)
         governanceService?.updatePolicy(newPolicy)
+        budgetEngine.reconcile(newBudgets)
+        const budgetTotal = newBudgets.length
+        console.error(
+          `[helio] Budgets reloaded: ${String(budgetTotal)} budget${budgetTotal !== 1 ? 's' : ''}`,
+        )
         const count = newPolicy.rules.length
         console.error(
           `[helio] Policy reloaded: ${String(count)} rule${count !== 1 ? 's' : ''} (default: ${newPolicy.defaultAction})`,
@@ -637,6 +655,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     approvalQueue,
     rateLimiter,
     spendLimiter,
+    budgetEngine,
     closeDashboardApp,
     dashboardHandle,
     eventBus,
@@ -666,12 +685,14 @@ async function validateCommand(configPath: string): Promise<void> {
   try {
     const config = await loadConfig(configPath)
 
-    // Also compile policies to catch invalid globs, regex patterns, etc.
+    // Also compile policies and budgets to catch invalid globs, regex
+    // patterns, etc.
     const { warnings } = compilePolicies(config.policies)
     for (const w of warnings) {
       const label = w.ruleName ? `rule "${w.ruleName}"` : `rule ${String(w.ruleIndex)}`
       console.error(`Warning: policy ${label}: ${w.message}`)
     }
+    compileBudgets(config.budgets)
 
     if (config.dashboard.enabled && !getBundledDashboardDistPath()) {
       console.error(
@@ -807,6 +828,7 @@ function registerShutdown(
   approvalQueue?: ApprovalQueue,
   rateLimiter?: RateLimiter,
   spendLimiter?: SpendLimiter,
+  budgetEngine?: BudgetEngine,
   closeDashboardApp?: () => void,
   dashboardHandle?: ServerHandle,
   eventBus?: DashboardEventBus,
@@ -831,6 +853,7 @@ function registerShutdown(
       if (governanceService) governanceService.close()
       if (rateLimiter) rateLimiter.close()
       if (spendLimiter) spendLimiter.close()
+      if (budgetEngine) budgetEngine.close()
       if (approvalRouter) approvalRouter.close()
       if (approvalQueue) approvalQueue.close()
       if (dashboardHandle) await dashboardHandle.close()

--- a/packages/proxy/src/config/reload-boundary.test.ts
+++ b/packages/proxy/src/config/reload-boundary.test.ts
@@ -24,6 +24,24 @@ function minimalConfig(overrides: Record<string, unknown> = {}): HelioConfig {
 // ---------------------------------------------------------------------------
 
 describe('diffReloadBoundary', () => {
+  it('does not require restart when budgets change (they hot-reload)', () => {
+    const previous = minimalConfig()
+    const next = minimalConfig({
+      budgets: [
+        {
+          name: 'cap',
+          limit: 50,
+          currency: 'USD',
+          window: '24h',
+          contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+        },
+      ],
+    })
+
+    const diff = diffReloadBoundary(previous, next)
+    expect(diff.restartRequiredPaths).toEqual([])
+  })
+
   it('does not require restart when only policy rules change', () => {
     const previous = minimalConfig()
     const next = minimalConfig({

--- a/packages/proxy/src/config/reload-boundary.ts
+++ b/packages/proxy/src/config/reload-boundary.ts
@@ -14,8 +14,9 @@ export interface ReloadBoundaryDiff {
 /**
  * Compare two validated configs and report changed paths that do not hot-reload.
  *
- * Hot-reload only applies `policies.default`, `policies.flag_destructive`,
- * `policies.dry_run`, and `policies.rules` by swapping the compiled policy.
+ * Hot-reload applies `policies.default`, `policies.flag_destructive`,
+ * `policies.dry_run`, and `policies.rules` by swapping the compiled policy,
+ * and `budgets` by reconciling the budget engine on name identity.
  * Everything else is startup-bound (listeners, upstream, dashboard, etc.) and
  * requires process restart.
  */
@@ -43,6 +44,10 @@ export function diffReloadBoundary(previous: HelioConfig, next: HelioConfig): Re
   if (!isDeepStrictEqual(previous.sdk, next.sdk)) {
     restartRequiredPaths.push('sdk')
   }
+
+  // `budgets` is deliberately NOT in this list: budgets hot-reload (the
+  // watcher recompiles them and the engine reconciles by name, issue #14).
+  // Do not cargo-cult it in when adding the next top-level field.
 
   // `policies.hot_reload` only affects whether the watcher exists at startup.
   const previousHotReload = previous.policies.hot_reload ?? true

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -1030,4 +1030,162 @@ describe('helioConfigSchema', () => {
       expect(result.success).toBe(true)
     })
   })
+
+  describe('budgets (issue #14)', () => {
+    const validBudget = {
+      name: 'daily-cap',
+      limit: 50,
+      currency: 'USD',
+      window: '24h',
+      contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+    }
+
+    function withBudgets(budgets: unknown[], extra: Record<string, unknown> = {}) {
+      return minimalConfig({ budgets, ...extra })
+    }
+
+    it('defaults to an empty list when absent', () => {
+      const result = helioConfigSchema.safeParse(minimalConfig())
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(result.data.budgets).toEqual([])
+    })
+
+    it('parses a duration-window budget and applies defaults', () => {
+      const result = helioConfigSchema.safeParse(withBudgets([validBudget]))
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      const budget = result.data.budgets[0]
+      expect(budget?.key).toBe('global')
+      expect(budget?.on_exceed).toBe('deny')
+    })
+
+    it('accepts window: session with key: session', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, window: 'session', key: 'session' }]),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts window: session with key: sender_id when the sideband is enabled', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, window: 'session', key: 'sender_id' }], {
+          sdk: { enabled: true },
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects window: session with key: global (explicit)', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, window: 'session', key: 'global' }]),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects window: session with the default key', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, window: 'session' }]),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts idle_ttl on session windows', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, window: 'session', key: 'session', idle_ttl: '12h' }]),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects idle_ttl on duration windows', () => {
+      const result = helioConfigSchema.safeParse(withBudgets([{ ...validBudget, idle_ttl: '12h' }]))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects key: sender_id when the sideband is disabled', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, key: 'sender_id' }]),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('budgets.0.key')
+    })
+
+    it('rejects duplicate budget names', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([validBudget, { ...validBudget, window: '1h' }]),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects an empty contributors list', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, contributors: [] }]),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects unknown budget fields (strict)', () => {
+      const result = helioConfigSchema.safeParse(withBudgets([{ ...validBudget, surprise: true }]))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects unknown contributor fields (strict)', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([
+          { ...validBudget, contributors: [{ tool: 'a_*', field: '$.x', currency: 'USD' }] },
+        ]),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects on_exceed: require_approval (ships in a later change)', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, on_exceed: 'require_approval' }]),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts on_exceed: deny explicitly', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, on_exceed: 'deny' }]),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects an approval block (only meaningful with require_approval)', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, approval: { channel: 'dashboard' } }]),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a non-positive limit', () => {
+      const zero = helioConfigSchema.safeParse(withBudgets([{ ...validBudget, limit: 0 }]))
+      const negative = helioConfigSchema.safeParse(withBudgets([{ ...validBudget, limit: -5 }]))
+      expect(zero.success).toBe(false)
+      expect(negative.success).toBe(false)
+    })
+
+    it('rejects a window that is neither a duration nor "session"', () => {
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, window: 'monthly' }]),
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects an empty budget name', () => {
+      const result = helioConfigSchema.safeParse(withBudgets([{ ...validBudget, name: '' }]))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects budget names with delimiter characters', () => {
+      // Names are embedded in bucket keys; a ":" could forge scope segments.
+      const result = helioConfigSchema.safeParse(
+        withBudgets([{ ...validBudget, name: 'evil:sender:x' }]),
+      )
+      expect(result.success).toBe(false)
+    })
+  })
 })

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -309,6 +309,67 @@ const policiesSchema = z
   .strict()
 
 // ---------------------------------------------------------------------------
+// Budgets (issue #14) — named cross-tool spend budgets, independent of rules
+// ---------------------------------------------------------------------------
+
+const budgetContributorSchema = z
+  .object({
+    tool: z.string().min(1), // picomatch glob, same engine as match.tool
+    field: z.string().min(1), // dot-path into tool arguments, e.g. "$.amount"
+  })
+  .strict()
+
+const budgetSchema = z
+  .object({
+    // The name is embedded in bucket keys (`budget:<name>:<scope>`) and, later,
+    // ledger rows — constrain it so keys stay parseable and scope classification
+    // (e.g. the sender-key cardinality guard) cannot be confused by delimiters.
+    name: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(/^[a-zA-Z0-9_-]+$/, {
+        message: 'Budget names may only contain letters, digits, "_" and "-"',
+      }),
+    limit: z.number().positive(),
+    currency: z.string().min(1),
+    /** A sliding duration ("1h", "7d") or "session" (a depleting pot per session key). */
+    window: z.union([durationSchema, z.literal('session')]),
+    key: z.enum(['global', 'session', 'sender_id']).default('global'),
+    /**
+     * Break-glass (`require_approval`) ships later in this release train;
+     * until then the schema accepts only the default so the config surface
+     * never promises behavior that does not exist yet.
+     */
+    on_exceed: z.literal('deny').default('deny'),
+    /** Session windows only: idle time before a session pot is collected. Default 24h. */
+    idle_ttl: durationSchema.optional(),
+    contributors: z.array(budgetContributorSchema).min(1),
+  })
+  .strict()
+  .superRefine((budget, ctx) => {
+    if (budget.window === 'session' && budget.key === 'global') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['key'],
+        message:
+          'window: "session" requires key: "session" or "sender_id" — a global bucket with ' +
+          'session lifetime never replenishes and never ends. Pick a per-session or ' +
+          'per-sender scope, or use a duration window.',
+      })
+    }
+    if (budget.window !== 'session' && budget.idle_ttl !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['idle_ttl'],
+        message:
+          'idle_ttl only applies to window: "session" budgets. Duration windows expire ' +
+          'entries on their own; remove idle_ttl.',
+      })
+    }
+  })
+
+// ---------------------------------------------------------------------------
 // Approval channels (discriminated union)
 // ---------------------------------------------------------------------------
 
@@ -387,6 +448,9 @@ const helioConfigBaseSchema = z.object({
   dashboard: dashboardSchema.prefault({}),
   environment: z.string().optional(),
   policies: policiesSchema.prefault({}),
+  // Budgets sit beside policies deliberately: they are the second half of the
+  // governance declaration (policy decision → budget gate), not plumbing.
+  budgets: z.array(budgetSchema).default([]),
   approval: approvalSchema.prefault({}),
   audit: auditSchema.prefault({}),
   sdk: sdkSchema.prefault({}),
@@ -442,6 +506,33 @@ export const helioConfigSchema = helioConfigBaseSchema.superRefine((cfg, ctx) =>
         'dashboard.host must be a loopback address (127.0.0.1, localhost, or ::1) ' +
         'when dashboard.allow_open_mode is true and dashboard.api_secret is unset.',
     })
+  }
+
+  // Budgets (issue #14): names are the identity for hot-reload state
+  // preservation and persistence, so they must be unique; sender_id scoping
+  // mirrors the rule-limits sideband guard above.
+  const seenBudgetNames = new Set<string>()
+  for (const [budgetIndex, budget] of cfg.budgets.entries()) {
+    if (seenBudgetNames.has(budget.name)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['budgets', budgetIndex, 'name'],
+        message:
+          `Duplicate budget name "${budget.name}". Budget names are the identity that ` +
+          'preserves accrued spend across config edits — each budget needs its own.',
+      })
+    }
+    seenBudgetNames.add(budget.name)
+
+    if (!cfg.sdk.enabled && budget.key === 'sender_id') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['budgets', budgetIndex, 'key'],
+        message:
+          'budget key "sender_id" requires the SDK sideband (sdk.enabled: true) — ' +
+          'sender_id is supplied by hook adapters and is absent on the MCP path.',
+      })
+    }
   }
 
   const hasWebhookChannel = cfg.approval.channels.some((channel) => channel.type === 'webhook')
@@ -569,3 +660,9 @@ export type PoliciesConfig = z.infer<typeof policiesSchema>
 
 /** The audit section of the config. */
 export type AuditConfig = z.infer<typeof auditSchema>
+
+/** A single named budget from the `budgets` array (issue #14). */
+export type BudgetConfig = z.infer<typeof budgetSchema>
+
+/** The `budgets` section of the config. */
+export type BudgetsConfig = readonly BudgetConfig[]

--- a/packages/proxy/src/config/watcher.test.ts
+++ b/packages/proxy/src/config/watcher.test.ts
@@ -9,6 +9,8 @@ import { GovernedForwarder } from '../policy/governed-forwarder.js'
 import { RateLimiter } from '../policy/rate-limiter.js'
 import { SpendLimiter } from '../policy/spend-limiter.js'
 import { compilePolicies } from '../policy/parser.js'
+import { BudgetEngine } from '../budget/engine.js'
+import { compileBudgets } from '../budget/parser.js'
 import type { McpForwarder, McpRequest, ForwardResult, McpResponse } from '../mcp/types.js'
 
 // ---------------------------------------------------------------------------
@@ -104,6 +106,222 @@ describe('ConfigWatcher', () => {
     expect(reloads[0]?.policy.rules[0]?.name).toBe('block-delete')
     expect(reloads[0]?.policy.rules[0]?.action).toBe('deny')
     expect(restartRequiredPaths).toEqual([[]])
+  })
+
+  it('passes compiled budgets to the reload callback', async () => {
+    await writeFile(configPath, validConfig())
+
+    const budgetReloads: unknown[][] = []
+
+    watcher = new ConfigWatcher({
+      configPath,
+      onPolicyReload: (_policy, _warnings, _paths, budgets) => {
+        budgetReloads.push([...budgets])
+      },
+      onError: () => {},
+      debounceMs: 50,
+    })
+    watcher.start()
+    await wait(100)
+
+    await writeFile(
+      configPath,
+      `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+dashboard:
+  enabled: false
+policies:
+  default: allow
+  rules: []
+budgets:
+  - name: daily-cap
+    limit: 50
+    currency: USD
+    window: 24h
+    contributors:
+      - tool: "stripe_*"
+        field: "$.amount"
+`,
+    )
+    await wait(500)
+
+    expect(budgetReloads).toHaveLength(1)
+    const budget = budgetReloads[0]?.[0] as { name: string; limit: number } | undefined
+    expect(budget?.name).toBe('daily-cap')
+    expect(budget?.limit).toBe(50)
+  })
+
+  it('reconciles the budget engine across hot-reloads by name identity', async () => {
+    const budgetYaml = (limit: number, extraContributor = '') => `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+dashboard:
+  enabled: false
+policies:
+  default: allow
+  rules: []
+budgets:
+  - name: daily-cap
+    limit: ${String(limit)}
+    currency: USD
+    window: 24h
+    contributors:
+      - tool: "stripe_*"
+        field: "$.amount"
+${extraContributor}
+`
+    await writeFile(configPath, budgetYaml(100))
+
+    const engine = new BudgetEngine({
+      budgets: compileBudgets([
+        {
+          name: 'daily-cap',
+          limit: 100,
+          currency: 'USD',
+          window: '24h',
+          key: 'global',
+          on_exceed: 'deny',
+          contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+        },
+      ]),
+      cleanupIntervalMs: 0,
+    })
+
+    watcher = new ConfigWatcher({
+      configPath,
+      onPolicyReload: (_policy, _warnings, _paths, budgets) => {
+        engine.reconcile(budgets)
+      },
+      onError: () => {},
+      debounceMs: 50,
+    })
+    watcher.start()
+    await wait(100)
+
+    // Accrue 60 of the 100 pot.
+    const { charges } = engine.resolveCharges({
+      toolName: 'stripe_charge',
+      toolArguments: { amount: 60 },
+      sessionId: null,
+      senderId: null,
+    })
+    engine.recordAll(charges, {
+      kind: 'spend',
+      auditRecordId: 'a1',
+      origin: 'mcp',
+      toolName: 'stripe_charge',
+      timestampIso: new Date().toISOString(),
+    })
+
+    // Contributor-only edit — accrued spend must survive.
+    await writeFile(
+      configPath,
+      budgetYaml(100, '      - tool: "paypal_*"\n        field: "$.total"'),
+    )
+    await wait(500)
+    expect(engine.listStates()[0]?.buckets[0]?.spent).toBe(60)
+
+    // Limit change — a different pool; the pot resets.
+    await writeFile(configPath, budgetYaml(500))
+    await wait(500)
+    expect(engine.listStates().flatMap((s) => s.buckets)).toEqual([])
+
+    engine.close()
+  })
+
+  it('keeps budgets and accrued state when a reload fails budget validation', async () => {
+    const validYaml = `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+dashboard:
+  enabled: false
+policies:
+  default: allow
+  rules: []
+budgets:
+  - name: daily-cap
+    limit: 100
+    currency: USD
+    window: 24h
+    contributors:
+      - tool: "stripe_*"
+        field: "$.amount"
+`
+    // Duplicate budget names fail the schema refinement at load time.
+    const invalidYaml = validYaml.replace(
+      'budgets:',
+      `budgets:
+  - name: daily-cap
+    limit: 999
+    currency: USD
+    window: 1h
+    contributors:
+      - tool: "other_*"
+        field: "$.x"`,
+    )
+    await writeFile(configPath, validYaml)
+
+    const engine = new BudgetEngine({
+      budgets: compileBudgets([
+        {
+          name: 'daily-cap',
+          limit: 100,
+          currency: 'USD',
+          window: '24h',
+          key: 'global',
+          on_exceed: 'deny',
+          contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+        },
+      ]),
+      cleanupIntervalMs: 0,
+    })
+    const errors: Error[] = []
+
+    watcher = new ConfigWatcher({
+      configPath,
+      onPolicyReload: (_policy, _warnings, _paths, budgets) => {
+        engine.reconcile(budgets)
+      },
+      onError: (err) => errors.push(err),
+      debounceMs: 50,
+    })
+    watcher.start()
+    await wait(100)
+
+    const { charges } = engine.resolveCharges({
+      toolName: 'stripe_charge',
+      toolArguments: { amount: 60 },
+      sessionId: null,
+      senderId: null,
+    })
+    engine.recordAll(charges, {
+      kind: 'spend',
+      auditRecordId: 'a1',
+      origin: 'mcp',
+      toolName: 'stripe_charge',
+      timestampIso: new Date().toISOString(),
+    })
+
+    await writeFile(configPath, invalidYaml)
+    await wait(500)
+
+    // The bad config was refused wholesale; accrued spend is untouched and
+    // in-flight charges from before the failed reload are still current.
+    expect(errors).toHaveLength(1)
+    expect(engine.listStates()[0]?.buckets[0]?.spent).toBe(60)
+    const post = engine.resolveCharges({
+      toolName: 'stripe_charge',
+      toolArguments: { amount: 50 },
+      sessionId: null,
+      senderId: null,
+    })
+    expect(engine.peekAll(post.charges).allowed).toBe(false)
+
+    engine.close()
   })
 
   it('reloads with updated flag_destructive setting', async () => {

--- a/packages/proxy/src/config/watcher.ts
+++ b/packages/proxy/src/config/watcher.ts
@@ -5,6 +5,8 @@ import type { HelioConfig } from './schema.js'
 import { diffReloadBoundary } from './reload-boundary.js'
 import { compilePolicies } from '../policy/parser.js'
 import type { CompiledPolicy, PolicyParseWarning } from '../policy/types.js'
+import { compileBudgets } from '../budget/parser.js'
+import type { CompiledBudget } from '../budget/types.js'
 
 // ---------------------------------------------------------------------------
 // ConfigWatcher — hot-reload policy rules on helio.yaml changes.
@@ -14,11 +16,12 @@ import type { CompiledPolicy, PolicyParseWarning } from '../policy/types.js'
 export interface ConfigWatcherOptions {
   /** Absolute or relative path to helio.yaml. */
   readonly configPath: string
-  /** Called with the new compiled policy on successful reload. */
+  /** Called with the new compiled policy and budgets on successful reload. */
   readonly onPolicyReload: (
     policy: CompiledPolicy,
     warnings: readonly PolicyParseWarning[],
     restartRequiredPaths: readonly string[],
+    budgets: readonly CompiledBudget[],
   ) => void
   /** Called when a reload attempt fails (parse, validation, or compile error). */
   readonly onError: (error: Error) => void
@@ -98,11 +101,12 @@ export class ConfigWatcher {
     try {
       const config = await loadConfig(this.configPath, this.env)
       const { policy, warnings } = compilePolicies(config.policies)
+      const budgets = compileBudgets(config.budgets)
       const restartRequiredPaths =
         this.initialConfig !== undefined
           ? diffReloadBoundary(this.initialConfig, config).restartRequiredPaths
           : []
-      this.onPolicyReload(policy, warnings, restartRequiredPaths)
+      this.onPolicyReload(policy, warnings, restartRequiredPaths, budgets)
     } catch (err) {
       if (err instanceof Error) {
         this.onError(err)

--- a/packages/proxy/src/dashboard/api.test.ts
+++ b/packages/proxy/src/dashboard/api.test.ts
@@ -752,6 +752,20 @@ describe('GET /api/limits', () => {
     expect(body.spend_limits).toEqual([])
   })
 
+  it('labels spend buckets with the rule-discriminated key', async () => {
+    const { get, spendLimiter } = setup()
+    spendLimiter.check({
+      key: 'session:abc:rule:2',
+      amount: 5,
+      limit: 20,
+      windowMs: 60_000,
+    })
+    const res = await get('/api/limits')
+    const body = (await res.json()) as { spend_limits: Array<{ key: string }> }
+    expect(body.spend_limits).toHaveLength(1)
+    expect(body.spend_limits[0]?.key).toBe('session:abc:rule:2')
+  })
+
   it('returns rate limit state after checks', async () => {
     const { get, rateLimiter } = setup()
     rateLimiter.check({ key: 'tool:send_email', maxCalls: 10, windowMs: 60_000 })

--- a/packages/proxy/src/feedback/self-repair.test.ts
+++ b/packages/proxy/src/feedback/self-repair.test.ts
@@ -11,6 +11,7 @@ import {
   buildRateLimitedFeedback,
   buildSpendLimitedFeedback,
   buildToolDriftFeedback,
+  buildBudgetExceededFeedback,
 } from './self-repair.js'
 import type { PolicyDecision } from '../policy/engine.js'
 import type { EvidenceCheckResult, DependencyCheckResult } from '../evidence/index.js'
@@ -841,6 +842,52 @@ describe('rule_index dual-key window (issue #109)', () => {
     const feedback = buildPolicyDeniedFeedback(defaultDenyDecision())
     expect(feedback).toHaveProperty('rule_index', null)
     expect(feedback).toHaveProperty('ruleIndex', null)
+  })
+
+  it('budget_exceeded is not retryable when a session breach rides with an invalid amount', () => {
+    const sessionBudget = {
+      name: 'sc',
+      limit: 100,
+      currency: 'USD',
+      window: { kind: 'session' as const, idleTtlMs: 1 },
+      windowRaw: 'session',
+      key: 'session' as const,
+      onExceed: 'deny' as const,
+      contributors: [],
+    }
+    const invalidBudget = {
+      ...sessionBudget,
+      name: 'iv',
+      window: { kind: 'duration' as const, windowMs: 1000 },
+      windowRaw: '1s',
+    }
+    const feedback = buildBudgetExceededFeedback(
+      denyDecision(),
+      [
+        {
+          budget: sessionBudget,
+          bucketKey: 'budget:sc:session:s1',
+          amount: 5,
+          allowed: false,
+          spent: 100,
+          remaining: 0,
+          resetAtMs: null,
+        },
+      ],
+      [
+        {
+          budget: invalidBudget,
+          bucketKey: 'budget:iv:global',
+          reason: 'invalid_amount',
+          spent: 0,
+          remaining: 100,
+          resetAtMs: 1_000,
+        },
+      ],
+    )
+    // The session pot never replenishes: fixing the invalid amount cannot
+    // make the breached call succeed, so the denial is not retryable.
+    expect(feedback.retry_allowed).toBe(false)
   })
 
   it('buildToolDriftFeedback emits null under both keys', () => {

--- a/packages/proxy/src/feedback/self-repair.ts
+++ b/packages/proxy/src/feedback/self-repair.ts
@@ -4,6 +4,7 @@ import type { EvidenceCheckResult, DependencyCheckResult } from '../evidence/gro
 import type { RateLimitResult } from '../policy/rate-limiter.js'
 import type { SpendLimitResult } from '../policy/spend-limiter.js'
 import type { ToolDriftEvent } from '../policy/annotation-cache.js'
+import type { BudgetChargeFailure, BudgetPeekEntry } from '../budget/engine.js'
 
 // ---------------------------------------------------------------------------
 // Block reasons — the discriminant for self-repair feedback.
@@ -22,6 +23,7 @@ export type BlockReason =
   | 'client_disconnected'
   | 'shutdown_cancelled'
   | 'tool_definition_drift'
+  | 'budget_exceeded'
 
 // ---------------------------------------------------------------------------
 // Feedback types — discriminated union keyed on `reason`.
@@ -134,6 +136,29 @@ export interface ToolDriftFeedback extends SelfRepairFeedbackBase {
   readonly drifted_aspects: readonly string[]
 }
 
+/** One breached (or invalid-amount) budget inside a budget_exceeded denial. */
+export interface BudgetBreachBlock {
+  readonly name: string
+  readonly limit: number
+  readonly spent: number
+  readonly remaining: number
+  readonly attempted_amount: number | null
+  readonly currency: string
+  readonly window: string
+  readonly on_exceed: 'deny' | 'require_approval'
+  /** ISO-8601 for duration windows; null for session pots (never replenish). */
+  readonly reset_at: string | null
+  /** Set when the contributor amount was missing or invalid (fail closed). */
+  readonly reason?: 'invalid_amount'
+}
+
+/** One or more named budgets denied the call (issue #14). */
+export interface BudgetExceededFeedback extends SelfRepairFeedbackBase {
+  readonly reason: 'budget_exceeded'
+  readonly action: 'budget'
+  readonly budgets: readonly BudgetBreachBlock[]
+}
+
 /** Discriminated union of all self-repair feedback types. */
 export type SelfRepairFeedback =
   | PolicyDeniedFeedback
@@ -147,6 +172,7 @@ export type SelfRepairFeedback =
   | RateLimitedFeedback
   | SpendLimitedFeedback
   | ToolDriftFeedback
+  | BudgetExceededFeedback
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -479,5 +505,69 @@ export function buildSpendLimitedFeedback(
     reset_at: resetAt,
     suggestion,
     retry_allowed: true,
+  }
+}
+
+/**
+ * Build self-repair feedback when named budgets deny a call (issue #14).
+ *
+ * Lists every breached budget (all-or-nothing gate: one breach denies the
+ * call and nothing is recorded anywhere) and every fail-closed invalid-amount
+ * contributor. Born snake_case with `rule_index` only where the alias story
+ * applies via ruleInfo.
+ */
+export function buildBudgetExceededFeedback(
+  decision: PolicyDecision,
+  breaches: readonly BudgetPeekEntry[],
+  failures: readonly BudgetChargeFailure[],
+): BudgetExceededFeedback {
+  const info = ruleInfo(decision.matchedRule)
+
+  const budgets: BudgetBreachBlock[] = [
+    ...breaches.map((entry) => ({
+      name: entry.budget.name,
+      limit: entry.budget.limit,
+      spent: entry.spent,
+      remaining: entry.remaining,
+      attempted_amount: entry.amount,
+      currency: entry.budget.currency,
+      window: entry.budget.windowRaw,
+      on_exceed: entry.budget.onExceed,
+      reset_at: entry.resetAtMs === null ? null : new Date(entry.resetAtMs).toISOString(),
+    })),
+    ...failures.map((failure) => ({
+      name: failure.budget.name,
+      limit: failure.budget.limit,
+      spent: failure.spent,
+      remaining: failure.remaining,
+      attempted_amount: null,
+      currency: failure.budget.currency,
+      window: failure.budget.windowRaw,
+      on_exceed: failure.budget.onExceed,
+      reset_at: failure.resetAtMs === null ? null : new Date(failure.resetAtMs).toISOString(),
+      reason: 'invalid_amount' as const,
+    })),
+  ]
+
+  // Budget-specific by design: a matched rule's feedback describes the RULE
+  // (which may have said allow), not the budget that denied the call.
+  const suggestion =
+    failures.length > 0
+      ? `Budget ${failures.map((f) => `"${f.budget.name}"`).join(', ')} could not read a valid spend amount from this call. Retry with a non-negative finite amount in the expected field.`
+      : `Budget ${breaches.map((b) => `"${b.budget.name}"`).join(', ')} would be exceeded by this call. Wait for the window to reset or reduce the amount.`
+
+  // Retryability hinges on the actual breaches: duration windows replenish,
+  // session pots never do. Invalid amounts are fixable, but only when no
+  // session breach would deny the retry anyway.
+  const retryAllowed = breaches.every((entry) => entry.budget.window.kind === 'duration')
+
+  return {
+    blocked: true,
+    reason: 'budget_exceeded',
+    ...info,
+    action: 'budget',
+    budgets,
+    suggestion,
+    retry_allowed: retryAllowed,
   }
 }

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -17,6 +17,17 @@ export { compilePolicies, PolicyParseError, matchRule, evaluatePolicy } from './
 export { GovernedForwarder } from './policy/index.js'
 export { RateLimiter } from './policy/index.js'
 export { SpendLimiter } from './policy/index.js'
+export { BudgetEngine, compileBudgets, BudgetParseError } from './budget/index.js'
+export type {
+  CompiledBudget,
+  CompiledBudgetContributor,
+  CompiledBudgetWindow,
+  BudgetState,
+  BudgetBucketState,
+  BudgetLedgerSink,
+  BudgetLedgerRow,
+  BudgetCommitEvent,
+} from './budget/index.js'
 export type {
   CompiledPolicy,
   CompiledPolicyRule,

--- a/packages/proxy/src/policy/governed-forwarder.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder.test.ts
@@ -13,6 +13,8 @@ import { QueueChannel } from '../approval/channels.js'
 import type { ApprovalChannel } from '../approval/types.js'
 import { RateLimiter } from './rate-limiter.js'
 import { SpendLimiter } from './spend-limiter.js'
+import { BudgetEngine } from '../budget/engine.js'
+import { compileBudgets } from '../budget/parser.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -3289,6 +3291,559 @@ describe('GovernedForwarder', () => {
   // -------------------------------------------------------------------------
   // spend_limit action
   // -------------------------------------------------------------------------
+
+  describe('budget gate (issue #14)', () => {
+    function createBudgetEngine(configs: Parameters<typeof compileBudgets>[0]) {
+      let time = 1_000_000
+      const advance = (ms: number) => {
+        time += ms
+      }
+      const engine = new BudgetEngine({
+        budgets: compileBudgets(configs),
+        now: () => time,
+        cleanupIntervalMs: 0,
+      })
+      return { engine, advance }
+    }
+
+    const stripeBudget = {
+      name: 'daily-cap',
+      limit: 100,
+      currency: 'USD',
+      window: '24h',
+      key: 'global' as const,
+      on_exceed: 'deny' as const,
+      contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+    }
+
+    it('forwards and records on every matching budget when all allow', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([
+        stripeBudget,
+        { ...stripeBudget, name: 'weekly-cap', limit: 500, window: '7d' },
+      ])
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { amount: 30 }))
+
+      expect(inner.forward).toHaveBeenCalledTimes(1)
+      expect(result.response.status).toBe(200)
+      const spent = engine.listStates().map((s) => s.buckets[0]?.spent)
+      expect(spent).toEqual([30, 30])
+    })
+
+    it('denies and records NOTHING when one budget breaches while another allows', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([
+        { ...stripeBudget, name: 'big', limit: 1000 },
+        { ...stripeBudget, name: 'small', limit: 10 },
+      ])
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+
+      expect(inner.forward).not.toHaveBeenCalled()
+      const error = errorFromResult(result)
+      expect(error.code).toBe(-32001)
+      expect(error.data['blocked']).toBe(true)
+      expect(error.data['reason']).toBe('budget_exceeded')
+      const budgets = error.data['budgets'] as Array<Record<string, unknown>>
+      expect(budgets).toHaveLength(1)
+      expect(budgets[0]?.['name']).toBe('small')
+      expect(budgets[0]?.['remaining']).toBe(10)
+      expect(budgets[0]?.['attempted_amount']).toBe(50)
+      // Atomicity: neither budget recorded anything.
+      expect(engine.listStates().flatMap((s) => s.buckets)).toEqual([])
+    })
+
+    it('does not consume rule rate counters when the budget gate denies', async () => {
+      const inner = mockForwarder()
+      const rateLimiter = new RateLimiter({ cleanupIntervalMs: 0 })
+      const { engine } = createBudgetEngine([{ ...stripeBudget, limit: 10 }])
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            name: 'rate',
+            match: { tool: 'stripe_*' },
+            action: 'rate_limit',
+            limits: { max_calls: 5, window: '1m' },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        budgetEngine: engine,
+        rateLimiter,
+      })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+
+      expect(inner.forward).not.toHaveBeenCalled()
+      expect(errorFromResult(result).data['reason']).toBe('budget_exceeded')
+      expect(rateLimiter.getKeyState('tool:stripe_charge')).toBeUndefined()
+    })
+
+    it('does not consume rule spend buckets when the budget gate denies', async () => {
+      const inner = mockForwarder()
+      const spendLimiter = new SpendLimiter({ cleanupIntervalMs: 0 })
+      const { engine } = createBudgetEngine([{ ...stripeBudget, limit: 10 }])
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            name: 'rule-cap',
+            match: { tool: 'stripe_*' },
+            action: 'spend_limit',
+            limits: {
+              max_spend: { field: '$.amount', limit: 1000, currency: 'USD', window: '1h' },
+            },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        budgetEngine: engine,
+        spendLimiter,
+      })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+
+      expect(inner.forward).not.toHaveBeenCalled()
+      expect(errorFromResult(result).data['reason']).toBe('budget_exceeded')
+      expect(spendLimiter.listKeyStates()).toEqual([])
+    })
+
+    it('records rule limits and budgets together when the call forwards', async () => {
+      const inner = mockForwarder()
+      const spendLimiter = new SpendLimiter({ cleanupIntervalMs: 0 })
+      const { engine } = createBudgetEngine([stripeBudget])
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            name: 'rule-cap',
+            match: { tool: 'stripe_*' },
+            action: 'spend_limit',
+            limits: {
+              max_spend: { field: '$.amount', limit: 1000, currency: 'USD', window: '1h' },
+            },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        budgetEngine: engine,
+        spendLimiter,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 40 }))
+
+      expect(inner.forward).toHaveBeenCalledTimes(1)
+      expect(spendLimiter.getKeyState('tool:stripe_charge:rule:0')?.current_spend).toBe(40)
+      expect(engine.listStates()[0]?.buckets[0]?.spent).toBe(40)
+    })
+
+    it('fails closed when a contributor amount is missing', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([stripeBudget])
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { note: 'no amt' }))
+
+      expect(inner.forward).not.toHaveBeenCalled()
+      const error = errorFromResult(result)
+      expect(error.data['reason']).toBe('budget_exceeded')
+      const budgets = error.data['budgets'] as Array<Record<string, unknown>>
+      expect(budgets[0]?.['reason']).toBe('invalid_amount')
+      expect(engine.listStates().flatMap((s) => s.buckets)).toEqual([])
+    })
+
+    it('a deny decision never consults budgets', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([stripeBudget])
+      const resolveSpy = vi.spyOn(engine, 'resolveCharges')
+      const policy = compile({
+        default: 'allow',
+        rules: [{ name: 'block', match: { tool: 'stripe_*' }, action: 'deny' }],
+      })
+      const governed = new GovernedForwarder(inner, policy, { budgetEngine: engine })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { amount: 5 }))
+
+      expect(errorFromResult(result).data['reason']).toBe('policy_denied')
+      expect(resolveSpy).not.toHaveBeenCalled()
+    })
+
+    it('nameless tools/call never reaches the budget gate', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([stripeBudget])
+      const resolveSpy = vi.spyOn(engine, 'resolveCharges')
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      const request: McpRequest = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { arguments: { amount: 5 } },
+      }
+      await governed.forward(request)
+
+      expect(resolveSpy).not.toHaveBeenCalled()
+      expect(inner.forward).not.toHaveBeenCalled()
+    })
+
+    it('dry-run peeks budgets and records nothing', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([{ ...stripeBudget, limit: 10 }])
+      const governed = new GovernedForwarder(
+        inner,
+        compile({ default: 'allow', dry_run: true, rules: [] }),
+        { budgetEngine: engine },
+      )
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+
+      expect(inner.forward).not.toHaveBeenCalled()
+      const body = result.response.body as { result: { content: Array<{ text: string }> } }
+      const payload = JSON.parse(body.result.content[0]?.text ?? '{}') as Record<string, unknown>
+      expect(payload['dry_run']).toBe(true)
+      expect(payload['would_forward']).toBe(false)
+      expect(payload['limits_ok']).toBe(false)
+      expect(engine.listStates().flatMap((s) => s.buckets)).toEqual([])
+    })
+
+    it('exactly one of two concurrent calls wins the last rate slot', async () => {
+      const inner = mockForwarder()
+      const rateLimiter = new RateLimiter({ cleanupIntervalMs: 0 })
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            name: 'one-per-min',
+            match: { tool: 'send_email' },
+            action: 'rate_limit',
+            limits: { max_calls: 1, window: '1m' },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, { rateLimiter })
+
+      // Concurrent macrotask interleaving: an await between peek and record
+      // would let both calls see the free slot and both forward.
+      const [a, b] = await Promise.all([
+        governed.forward(toolsCallRequest('send_email', {}, 1)),
+        governed.forward(toolsCallRequest('send_email', {}, 2)),
+      ])
+
+      expect(inner.forward).toHaveBeenCalledTimes(1)
+      const blockedResults = [a, b].filter(
+        (r) => (r.response.body as { error?: unknown }).error !== undefined,
+      )
+      expect(blockedResults).toHaveLength(1)
+      expect(errorFromResult(blockedResults[0] as ForwardResult).data['reason']).toBe(
+        'rate_limited',
+      )
+    })
+
+    it('exactly one of two concurrent calls wins the last budget slot', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([stripeBudget])
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      const [a, b] = await Promise.all([
+        governed.forward(toolsCallRequest('stripe_charge', { amount: 60 }, 1)),
+        governed.forward(toolsCallRequest('stripe_charge', { amount: 60 }, 2)),
+      ])
+
+      expect(inner.forward).toHaveBeenCalledTimes(1)
+      const blockedResults = [a, b].filter(
+        (r) => (r.response.body as { error?: unknown }).error !== undefined,
+      )
+      expect(blockedResults).toHaveLength(1)
+      expect(engine.listStates()[0]?.buckets[0]?.spent).toBe(60)
+    })
+
+    it('blocks without consuming rule counters when the ledger write fails', async () => {
+      const inner = mockForwarder()
+      const spendLimiter = new SpendLimiter({ cleanupIntervalMs: 0 })
+      const failing = new BudgetEngine({
+        budgets: compileBudgets([stripeBudget]),
+        cleanupIntervalMs: 0,
+        ledger: {
+          commitAll: () => {
+            throw new Error('disk full')
+          },
+        },
+      })
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            name: 'rule-cap',
+            match: { tool: 'stripe_*' },
+            action: 'spend_limit',
+            limits: {
+              max_spend: { field: '$.amount', limit: 1000, currency: 'USD', window: '1h' },
+            },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        budgetEngine: failing,
+        spendLimiter,
+      })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { amount: 40 }))
+
+      expect(inner.forward).not.toHaveBeenCalled()
+      const error = errorFromResult(result)
+      expect(error.data['failure_class']).toBe('budget_ledger_write_failed')
+      // The fallible ledger commits first: neither the rule counter nor any
+      // budget bucket may be consumed by a call that never forwarded.
+      expect(spendLimiter.listKeyStates()).toEqual([])
+      expect(failing.listStates().flatMap((s) => s.buckets)).toEqual([])
+    })
+
+    it('keeps separate session pots per session key on the MCP door', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([
+        { ...stripeBudget, name: 'sc', window: 'session', key: 'session' as const },
+      ])
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      await governed.forward(toolsCallWithSession('stripe_charge', 's1', { amount: 90 }))
+      // A different session gets its own full pot.
+      await governed.forward(toolsCallWithSession('stripe_charge', 's2', { amount: 90 }))
+      expect(inner.forward).toHaveBeenCalledTimes(2)
+
+      // s1's pot is nearly depleted; the next s1 call breaches.
+      inner.forward.mockClear()
+      const denied = await governed.forward(
+        toolsCallWithSession('stripe_charge', 's1', { amount: 20 }),
+      )
+      expect(inner.forward).not.toHaveBeenCalled()
+      expect(errorFromResult(denied).data['reason']).toBe('budget_exceeded')
+      const keys = engine
+        .listStates()
+        .flatMap((s2) => s2.buckets)
+        .map((b) => b.bucket_key)
+        .sort()
+      expect(keys).toEqual(['budget:sc:session:s1', 'budget:sc:session:s2'])
+    })
+
+    it('runs the budget gate after an approved rule ticket', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([stripeBudget])
+      const queue = new ApprovalQueue({ cleanupIntervalMs: 0 })
+      const channels = new Map<string, ApprovalChannel>([['dashboard', new QueueChannel()]])
+      const router = new ApprovalRouter({
+        defaultTimeoutMs: 300_000,
+        defaultOnTimeout: 'deny',
+        channels,
+        queue,
+      })
+      const policy = compile({
+        default: 'allow',
+        rules: [{ name: 'gate', match: { tool: 'stripe_*' }, action: 'require_approval' }],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        budgetEngine: engine,
+        approvalRouter: router,
+      })
+
+      const pending = governed.forward(toolsCallRequest('stripe_charge', { amount: 40 }))
+      await vi.waitFor(() => {
+        expect(queue.list({ status: 'pending' })).toHaveLength(1)
+      })
+      const ticket = queue.list({ status: 'pending' })[0]
+      router.approve(ticket?.id ?? '', 'alice')
+      const result = await pending
+
+      expect(inner.forward).toHaveBeenCalledTimes(1)
+      expect(result.response.status).toBe(200)
+      expect(engine.listStates()[0]?.buckets[0]?.spent).toBe(40)
+      router.close()
+      queue.close()
+    })
+
+    it('denies after an approved rule ticket when the budget gate breaches', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([{ ...stripeBudget, limit: 10 }])
+      const queue = new ApprovalQueue({ cleanupIntervalMs: 0 })
+      const channels = new Map<string, ApprovalChannel>([['dashboard', new QueueChannel()]])
+      const router = new ApprovalRouter({
+        defaultTimeoutMs: 300_000,
+        defaultOnTimeout: 'deny',
+        channels,
+        queue,
+      })
+      const policy = compile({
+        default: 'allow',
+        rules: [{ name: 'gate', match: { tool: 'stripe_*' }, action: 'require_approval' }],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        budgetEngine: engine,
+        approvalRouter: router,
+      })
+
+      const pending = governed.forward(toolsCallRequest('stripe_charge', { amount: 40 }))
+      await vi.waitFor(() => {
+        expect(queue.list({ status: 'pending' })).toHaveLength(1)
+      })
+      router.approve(queue.list({ status: 'pending' })[0]?.id ?? '', 'alice')
+      const result = await pending
+
+      // The human approved the RULE gate; the money gate still denies.
+      expect(inner.forward).not.toHaveBeenCalled()
+      expect(errorFromResult(result).data['reason']).toBe('budget_exceeded')
+      expect(engine.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+      router.close()
+      queue.close()
+    })
+
+    it('audits a ledger-write failure with its own block reason and evidence', async () => {
+      const inner = mockForwarder()
+      const failing = new BudgetEngine({
+        budgets: compileBudgets([stripeBudget]),
+        cleanupIntervalMs: 0,
+        ledger: {
+          commitAll: () => {
+            throw new Error('disk full')
+          },
+        },
+      })
+      const auditStore = new AuditStore({
+        path: ':memory:',
+        retention: '90d',
+        includeResponses: true,
+        cleanupIntervalMs: 0,
+      })
+      const auditWriter = new AuditWriter({ store: auditStore, flushIntervalMs: 0 })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: failing,
+        auditWriter,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 5 }))
+      auditWriter.flush()
+
+      const record = auditStore.list().records[0]
+      expect(record?.block_reason).toBe('budget_ledger_write_failed')
+      const chain = record?.evidence_chain as Record<string, unknown>
+      const budgets = chain['budgets'] as Array<Record<string, unknown>>
+      expect(budgets[0]?.['ledger_write_failed']).toBe(true)
+    })
+
+    it('returns the upstream result even when post-forward bookkeeping throws', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([stripeBudget])
+      const evidenceStore = new EvidenceStore({ cleanupIntervalMs: 0 })
+      vi.spyOn(evidenceStore, 'recordToolCall').mockImplementation(() => {
+        throw new Error('bookkeeping bug')
+      })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+        evidenceStore,
+      })
+
+      const result = await governed.forward(
+        toolsCallWithSession('stripe_charge', 's1', { amount: 5 }),
+      )
+
+      // The upstream call and the budget commit happened; a bookkeeping bug
+      // must not turn that into an error the caller would retry.
+      expect(result.response.status).toBe(200)
+      expect((result.response.body as { error?: unknown }).error).toBeUndefined()
+      expect(engine.listStates()[0]?.buckets[0]?.spent).toBe(5)
+      evidenceStore.close()
+    })
+
+    it('reports real accrued spend on invalid-amount denials', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([stripeBudget])
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 30 }))
+      const denied = await governed.forward(toolsCallRequest('stripe_charge', { note: 'x' }, 2))
+
+      const budgets = errorFromResult(denied).data['budgets'] as Array<Record<string, unknown>>
+      expect(budgets[0]?.['reason']).toBe('invalid_amount')
+      expect(budgets[0]?.['spent']).toBe(30)
+      expect(budgets[0]?.['remaining']).toBe(70)
+    })
+
+    it('audits a budget denial with block_reason and the budgets chain', async () => {
+      const inner = mockForwarder()
+      const { engine } = createBudgetEngine([{ ...stripeBudget, limit: 10 }])
+      const auditStore = new AuditStore({
+        path: ':memory:',
+        retention: '90d',
+        includeResponses: true,
+        cleanupIntervalMs: 0,
+      })
+      const auditWriter = new AuditWriter({ store: auditStore, flushIntervalMs: 0 })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+        auditWriter,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+      auditWriter.flush()
+
+      const record = auditStore.list().records[0]
+      expect(record?.block_reason).toBe('budget_exceeded')
+      expect(record?.policy_decision).toBe('allow')
+      const chain = record?.evidence_chain as Record<string, unknown>
+      const budgets = chain['budgets'] as Array<Record<string, unknown>>
+      expect(budgets[0]?.['name']).toBe('daily-cap')
+      expect(budgets[0]?.['allowed']).toBe(false)
+    })
+
+    it('threads the pre-generated audit id into the budget ledger rows', async () => {
+      const rows: Array<Record<string, unknown>> = []
+      const { engine } = createBudgetEngine([stripeBudget])
+      // Re-create with a capturing sink.
+      const capturing = new BudgetEngine({
+        budgets: compileBudgets([stripeBudget]),
+        cleanupIntervalMs: 0,
+        ledger: { commitAll: (batch) => rows.push(...(batch as never[])) },
+      })
+      void engine
+      const inner = mockForwarder()
+      const auditStore = new AuditStore({
+        path: ':memory:',
+        retention: '90d',
+        includeResponses: true,
+        cleanupIntervalMs: 0,
+      })
+      const auditWriter = new AuditWriter({ store: auditStore, flushIntervalMs: 0 })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: capturing,
+        auditWriter,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 5 }))
+      auditWriter.flush()
+
+      const record = auditStore.list().records[0]
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.['audit_record_id']).toBe(record?.id)
+      expect(rows[0]?.['origin']).toBe('mcp')
+      expect(rows[0]?.['kind']).toBe('spend')
+    })
+  })
 
   describe('spend_limit action', () => {
     function createSpendLimiter() {

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type {
   McpForwarder,
   McpForwarderWithInternal,
@@ -27,6 +28,7 @@ import {
   buildRateLimitedFeedback,
   buildSpendLimitedFeedback,
   buildToolDriftFeedback,
+  buildBudgetExceededFeedback,
   ruleInfo,
 } from '../feedback/self-repair.js'
 import type { ApprovalRouter } from '../approval/router.js'
@@ -35,6 +37,7 @@ import type { RateLimiter, RateLimitResult } from './rate-limiter.js'
 import type { SpendLimiter, SpendLimitResult } from './spend-limiter.js'
 import { spendBucketKey } from './spend-limiter.js'
 import { resolvePath } from './matchers.js'
+import type { BudgetEngine, BudgetPeekEntry } from '../budget/engine.js'
 
 /** Custom JSON-RPC error code for policy denials. */
 const POLICY_DENIED = -32001
@@ -53,6 +56,67 @@ export interface GovernedForwarderOptions {
   rateLimiter?: RateLimiter
   /** Spend limiter for handling spend_limit decisions. */
   spendLimiter?: SpendLimiter
+  /** Budget engine for named cross-tool budgets (issue #14). */
+  budgetEngine?: BudgetEngine
+}
+
+/**
+ * Phase-1 outcome: what an action branch decided, minus the forward itself.
+ * `commitRuleLimit` records a peeked rate/spend rule counter and runs at the
+ * forward site, in the same tick as the peek.
+ */
+interface ActionGateBase {
+  approvalOutcome?: ApprovalOutcome
+  approvalWaitMs: number
+  approvalContext?: ApprovalAuditContext
+  rateLimitResult?: RateLimitResult
+  spendLimitResult?: SpendLimitResult
+  commitRuleLimit?: () => void
+}
+
+type ActionGateResult =
+  | (ActionGateBase & { proceed: true; result?: undefined })
+  | (ActionGateBase & { proceed: false; result: ForwardResult })
+
+/** Build a blocked phase-1 outcome carrying only the block result. */
+function blocked(result: ForwardResult): ActionGateResult {
+  return { proceed: false, result, approvalWaitMs: 0 }
+}
+
+/** Phase-2 outcome: the budget gate's verdict plus its audit chain blocks. */
+type BudgetGateResult =
+  | {
+      proceed: true
+      result?: undefined
+      /** Wire-ready per-budget blocks for the audit record's evidence_chain. */
+      chain?: Array<Record<string, unknown>>
+      /** Records all charges; returns post-commit chain blocks. */
+      commit?: (auditRecordId: string) => Array<Record<string, unknown>>
+    }
+  | {
+      proceed: false
+      result: ForwardResult
+      chain: Array<Record<string, unknown>>
+      commit?: undefined
+    }
+
+/** Wire-ready evidence_chain block for one budget's view of a call. */
+function budgetChainBlock(
+  entry: BudgetPeekEntry,
+  kind?: 'spend' | 'approved_overage',
+): Record<string, unknown> {
+  return {
+    name: entry.budget.name,
+    bucket_key: entry.bucketKey,
+    allowed: entry.allowed,
+    amount: entry.amount,
+    spent: entry.spent,
+    limit: entry.budget.limit,
+    remaining: entry.remaining,
+    currency: entry.budget.currency,
+    ...(kind ? { kind } : {}),
+    ...(entry.stale ? { stale: true } : {}),
+  }
 }
 
 /** Result of attempting to prime the tool annotation cache. */
@@ -82,6 +146,7 @@ export class GovernedForwarder implements McpForwarder {
   private readonly approvalRouter: ApprovalRouter | undefined
   private readonly rateLimiter: RateLimiter | undefined
   private readonly spendLimiter: SpendLimiter | undefined
+  private readonly budgetEngine: BudgetEngine | undefined
   private readonly annotationCache = new ToolAnnotationCache()
   private agentKeyWarned = false
   private senderKeyWarned = false
@@ -95,6 +160,7 @@ export class GovernedForwarder implements McpForwarder {
     this.approvalRouter = options?.approvalRouter
     this.rateLimiter = options?.rateLimiter
     this.spendLimiter = options?.spendLimiter
+    this.budgetEngine = options?.budgetEngine
     if (this.evidenceStore) {
       this.evidenceStore.setAllowedEvidenceKeys(collectAllowedEvidenceKeys(policy))
     }
@@ -337,6 +403,10 @@ export class GovernedForwarder implements McpForwarder {
       driftEvent: this.annotationCache.getDrift(toolName),
     })
 
+    // Pre-generated so budget ledger rows can reference the audit record
+    // before it is written (the async writer accepts caller-supplied ids).
+    const auditRecordId = randomUUID()
+
     let result: ForwardResult
     let approvalOutcome: ApprovalOutcome | undefined
     let approvalWaitMs = 0
@@ -344,53 +414,81 @@ export class GovernedForwarder implements McpForwarder {
     let rateLimitResult: RateLimitResult | undefined
     let spendLimitResult: SpendLimitResult | undefined
     let forwardingError: Error | undefined
+    /** Whether the request actually reached the upstream — a fact recorded at
+     * the single forward site, not derived after the fact. */
+    let forwarded = false
+    let budgetsChain: Array<Record<string, unknown>> | undefined
     try {
       if (isDryRun) {
         result = this.handleDryRun(request, decision, toolName, toolArguments, evidenceBlocked)
-      } else if (sessionBlocked) {
-        result = this.makeSessionRequiredBlockResult(request, decision)
-      } else if (evidenceBlocked) {
-        result = this.makeEvidenceBlockResult(request, decision, evidenceResult, dependencyResult)
-      } else if (driftBlocked && driftEvent) {
-        result = this.makeDriftBlockResult(request, driftEvent)
-      } else if (decision.action === 'allow') {
-        result = await this.inner.forward(request)
-      } else if (decision.action === 'deny') {
-        result = this.makeDenyResult(request, decision)
-      } else if (decision.action === 'require_approval') {
-        if (!this.approvalRouter) {
-          result = this.makeUnsupportedResult(request, decision, toolName)
-        } else {
-          const approvalResult = await this.handleApproval(
-            request,
-            decision,
-            toolName,
-            toolArguments,
-          )
-          result = approvalResult.result
-          approvalOutcome = approvalResult.outcome
-          approvalWaitMs = approvalResult.approvalWaitMs
-          approvalContext = approvalResult.approvalContext
-        }
-      } else if (decision.action === 'rate_limit') {
-        if (!this.rateLimiter) {
-          result = this.makeUnsupportedResult(request, decision, toolName)
-        } else {
-          const rlResult = await this.handleRateLimit(request, decision, toolName)
-          result = rlResult.result
-          rateLimitResult = rlResult.rateLimitResult
-        }
-      } else if (decision.action === 'spend_limit') {
-        if (!this.spendLimiter) {
-          result = this.makeUnsupportedResult(request, decision, toolName)
-        } else {
-          const slResult = await this.handleSpendLimit(request, decision, toolName, toolArguments)
-          result = slResult.result
-          spendLimitResult = slResult.spendLimitResult
-        }
       } else {
-        // Unknown action (shouldn't happen) — deny defensively
-        result = this.makeDenyResult(request, decision)
+        // Phase 1 — action gate: everything the per-action branches decide,
+        // without forwarding. Rule rate/spend limits PEEK here and record at
+        // the forward site. Only the approval branch may await: an `await` on
+        // a fully-synchronous async function still yields to the microtask
+        // queue, and that gap would let a concurrent call peek the same last
+        // limiter slot before this one records it. Every other branch stays
+        // synchronous so peek → record has no interleaving point.
+        const gate =
+          decision.action === 'require_approval' && this.approvalRouter
+            ? await this.handleApproval(request, decision, toolName, toolArguments)
+            : this.resolveActionGate(request, decision, toolName, toolArguments, {
+                sessionBlocked,
+                evidenceBlocked,
+                driftBlocked,
+                driftEvent,
+                evidenceResult,
+                dependencyResult,
+              })
+        approvalOutcome = gate.approvalOutcome
+        approvalWaitMs = gate.approvalWaitMs
+        approvalContext = gate.approvalContext
+        rateLimitResult = gate.rateLimitResult
+        spendLimitResult = gate.spendLimitResult
+
+        if (!gate.proceed) {
+          result = gate.result
+        } else {
+          // Phase 2 — budget gate: peek every matching budget, all-or-nothing.
+          const budgetGate = this.gateBudgets(request, decision, toolName, toolArguments)
+          budgetsChain = budgetGate.chain
+          if (!budgetGate.proceed) {
+            result = budgetGate.result
+          } else {
+            // Phase 3 — commit, then the single forward site. No await sits
+            // between the gates' peeks and these commits, so two concurrent
+            // calls cannot double-spend the last slot. The fallible budget
+            // ledger commits FIRST: a durable-write failure must block the
+            // call WITHOUT having consumed the rule counters, and it reports
+            // its own failure class instead of masquerading as an upstream
+            // error.
+            let ledgerBlock: ForwardResult | undefined
+            try {
+              budgetsChain = budgetGate.commit?.(auditRecordId) ?? budgetsChain
+            } catch (ledgerError) {
+              const reason =
+                ledgerError instanceof Error ? ledgerError.message : String(ledgerError)
+              // eslint-disable-next-line no-console -- Intentional operational warning
+              console.error(
+                `[helio] Budget ledger write failed for tool "${toolName}"; blocking the call: ${reason}`,
+              )
+              ledgerBlock = makeErrorResult(request, INTERNAL_ERROR, 'budget ledger write failed', {
+                blocked: true,
+                reason: 'budget_ledger_write_failed',
+                failure_class: 'budget_ledger_write_failed',
+                failure_reason: reason,
+              })
+              budgetsChain = [{ ledger_write_failed: true, reason }]
+            }
+            if (ledgerBlock) {
+              result = ledgerBlock
+            } else {
+              gate.commitRuleLimit?.()
+              forwarded = true
+              result = await this.inner.forward(request)
+            }
+          }
+        }
       }
     } catch (error) {
       forwardingError = error instanceof Error ? error : new Error(String(error))
@@ -400,21 +498,25 @@ export class GovernedForwarder implements McpForwarder {
       })
     }
 
-    // Record tool call for dependency tracking (never in dry-run — nothing was forwarded)
-    const wasForwarded = this.wasForwardedUpstream(
-      decision,
-      approvalOutcome,
-      rateLimitResult,
-      spendLimitResult,
-    )
-    if (wasForwarded && !isDryRun && this.evidenceStore && request.sessionId && toolName) {
-      const succeeded = !hasJsonRpcError(result)
-      this.evidenceStore.recordToolCall(request.sessionId, toolName, succeeded)
+    // Post-forward bookkeeping is isolated: counters and the upstream call
+    // already happened, so a throwing evidence store or audit writer must
+    // degrade to a logged error, not reject the response (which would look
+    // retryable to the caller while the money state is already committed).
+    try {
+      // Record tool call for dependency tracking (never in dry-run — nothing was forwarded)
+      if (forwarded && !isDryRun && this.evidenceStore && request.sessionId && toolName) {
+        const succeeded = !hasJsonRpcError(result)
+        this.evidenceStore.recordToolCall(request.sessionId, toolName, succeeded)
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console -- Bookkeeping bugs must not affect the response
+      console.error('[helio] dependency tracking failed after forward:', err)
     }
 
     const totalDurationMs = performance.now() - startTime
-    this.writeAuditRecord(
+    this.writeAuditRecordSafely(
       request,
+      auditRecordId,
       timestamp,
       toolName,
       toolArguments,
@@ -423,6 +525,7 @@ export class GovernedForwarder implements McpForwarder {
       totalDurationMs,
       approvalWaitMs,
       flaggedDestructive,
+      forwarded,
       evidenceResult,
       dependencyResult,
       evidenceBlocked,
@@ -430,12 +533,168 @@ export class GovernedForwarder implements McpForwarder {
       approvalContext,
       rateLimitResult,
       spendLimitResult,
+      budgetsChain,
       isDryRun,
       forwardingError,
       driftEvent ? { event: driftEvent, mode: driftMode } : undefined,
     )
 
     return result
+  }
+
+  /** writeAuditRecord, isolated: an audit-writer bug must not reject the response. */
+  private writeAuditRecordSafely(...args: Parameters<GovernedForwarder['writeAuditRecord']>): void {
+    try {
+      this.writeAuditRecord(...args)
+    } catch (err) {
+      // eslint-disable-next-line no-console -- Bookkeeping bugs must not affect the response
+      console.error('[helio] audit record write failed:', err)
+    }
+  }
+
+  /**
+   * Everything the non-approval action branches decide, minus the forward
+   * itself. Deliberately SYNCHRONOUS: the caller must reach the phase-3
+   * commits without yielding to the microtask queue, or concurrent calls
+   * could double-spend a peeked limiter slot. The approval branch (the only
+   * one that genuinely waits) is dispatched by the caller directly.
+   */
+  private resolveActionGate(
+    request: McpRequest,
+    decision: PolicyDecision,
+    toolName: string,
+    toolArguments: Record<string, unknown> | undefined,
+    pipeline: {
+      sessionBlocked: boolean
+      evidenceBlocked: boolean
+      driftBlocked: boolean
+      driftEvent: ToolDriftEvent | undefined
+      evidenceResult: EvidenceCheckResult | undefined
+      dependencyResult: DependencyCheckResult | undefined
+    },
+  ): ActionGateResult {
+    if (pipeline.sessionBlocked) {
+      return blocked(this.makeSessionRequiredBlockResult(request, decision))
+    }
+    if (pipeline.evidenceBlocked) {
+      return blocked(
+        this.makeEvidenceBlockResult(
+          request,
+          decision,
+          pipeline.evidenceResult,
+          pipeline.dependencyResult,
+        ),
+      )
+    }
+    if (pipeline.driftBlocked && pipeline.driftEvent) {
+      return blocked(this.makeDriftBlockResult(request, pipeline.driftEvent))
+    }
+
+    switch (decision.action) {
+      case 'allow':
+        return { proceed: true, approvalWaitMs: 0 }
+      case 'deny':
+        return blocked(this.makeDenyResult(request, decision))
+      case 'require_approval':
+        // Reached only when no router is configured — the caller dispatches
+        // the awaiting approval path itself to keep this function synchronous.
+        return blocked(this.makeUnsupportedResult(request, decision, toolName))
+      case 'rate_limit':
+        if (!this.rateLimiter) {
+          return blocked(this.makeUnsupportedResult(request, decision, toolName))
+        }
+        return this.handleRateLimit(request, decision, toolName)
+      case 'spend_limit':
+        if (!this.spendLimiter) {
+          return blocked(this.makeUnsupportedResult(request, decision, toolName))
+        }
+        return this.handleSpendLimit(request, decision, toolName, toolArguments)
+      default:
+        // Unknown action (shouldn't happen) — deny defensively
+        return blocked(this.makeDenyResult(request, decision))
+    }
+  }
+
+  /**
+   * Phase 2: check every budget the call feeds, all-or-nothing (issue #14).
+   *
+   * Any breach denies (this release only ships `on_exceed: deny`) and records
+   * NOTHING on any budget — rejected calls never consume budget anywhere. On
+   * proceed, the returned `commit` records every charge together (ledger rows
+   * first, atomically, referencing the pre-generated audit id).
+   */
+  private gateBudgets(
+    request: McpRequest,
+    decision: PolicyDecision,
+    toolName: string,
+    toolArguments: Record<string, unknown> | undefined,
+  ): BudgetGateResult {
+    const engine = this.budgetEngine
+    if (!engine) return { proceed: true }
+
+    const { charges, failures } = engine.resolveCharges({
+      toolName,
+      toolArguments,
+      sessionId: request.sessionId ?? null,
+      senderId: null, // adapter context; absent on the MCP path
+    })
+
+    if (charges.length === 0 && failures.length === 0) return { proceed: true }
+
+    // Peek the valid charges even when failures deny the call — the feedback
+    // must show every failure AND every simultaneous breach, with real
+    // bucket snapshots throughout.
+    const peek = charges.length > 0 ? engine.peekAll(charges) : { allowed: true, entries: [] }
+    const breaches = peek.entries.filter((entry) => !entry.allowed)
+
+    if (failures.length > 0 || !peek.allowed) {
+      if (failures.length > 0) {
+        // eslint-disable-next-line no-console -- Intentional operational warning
+        console.error(
+          `[helio] Warning: budget ${failures.map((f) => `"${f.budget.name}"`).join(', ')} could not resolve a valid amount for tool "${toolName}", denying request`,
+        )
+      }
+      const feedback = buildBudgetExceededFeedback(decision, breaches, failures)
+      // The message is budget-specific by design: a matched rule's feedback
+      // describes the RULE (which may well have said allow), not the budget
+      // that denied the call.
+      const message =
+        failures.length > 0
+          ? `Budget denied: invalid amount for ${failures.map((f) => `"${f.budget.name}"`).join(', ')}`
+          : `Budget exceeded: ${breaches.map((entry) => `"${entry.budget.name}"`).join(', ')}`
+      return {
+        proceed: false,
+        result: makeErrorResult(request, POLICY_DENIED, message, { ...feedback }),
+        chain: [
+          ...peek.entries.map((entry) => budgetChainBlock(entry)),
+          ...failures.map((failure) => ({
+            name: failure.budget.name,
+            bucket_key: failure.bucketKey,
+            allowed: false,
+            reason: failure.reason,
+            spent: failure.spent,
+            limit: failure.budget.limit,
+            remaining: failure.remaining,
+            currency: failure.budget.currency,
+          })),
+        ],
+      }
+    }
+
+    return {
+      proceed: true,
+      chain: peek.entries.map((entry) => budgetChainBlock(entry)),
+      commit: (auditRecordId) =>
+        engine
+          .recordAll(charges, {
+            kind: 'spend',
+            auditRecordId,
+            origin: 'mcp',
+            toolName,
+            timestampIso: new Date().toISOString(),
+          })
+          .map((entry) => budgetChainBlock(entry, 'spend')),
+    }
   }
 
   /**
@@ -508,12 +767,7 @@ export class GovernedForwarder implements McpForwarder {
     decision: PolicyDecision,
     toolName: string,
     toolArguments: Record<string, unknown> | undefined,
-  ): Promise<{
-    result: ForwardResult
-    outcome: ApprovalOutcome
-    approvalWaitMs: number
-    approvalContext?: ApprovalAuditContext
-  }> {
+  ): Promise<ActionGateResult> {
     // Caller guarantees this.approvalRouter is defined
     const router = this.approvalRouter as ApprovalRouter
 
@@ -551,47 +805,82 @@ export class GovernedForwarder implements McpForwarder {
           }
         : undefined
 
-    let result: ForwardResult
-
+    // The approval gate decides but never forwards — the single forward site
+    // in handleToolsCall runs only after the budget gate also passes.
     if (outcome.status === 'approved' || outcome.status === 'break_glass') {
       if (request.signal?.aborted) {
-        result = this.makeClientDisconnectedBlockResult(request, decision)
-      } else {
-        result = await this.inner.forward(request)
+        return {
+          proceed: false,
+          result: this.makeClientDisconnectedBlockResult(request, decision),
+          approvalOutcome: outcome,
+          approvalWaitMs,
+          approvalContext,
+        }
       }
-    } else if (outcome.status === 'denied') {
+      return { proceed: true, approvalOutcome: outcome, approvalWaitMs, approvalContext }
+    }
+    if (outcome.status === 'denied') {
       const feedback = buildApprovalDeniedFeedback(decision, outcome.resolvedBy, outcome.reason)
       const message =
         decision.matchedRule?.feedback?.message ?? `Approval denied by ${outcome.resolvedBy}`
-      result = makeErrorResult(request, POLICY_DENIED, message, { ...feedback })
-    } else if (outcome.status === 'client_disconnected') {
-      result = this.makeClientDisconnectedBlockResult(request, decision)
-    } else if (outcome.status === 'shutdown_cancelled') {
+      return {
+        proceed: false,
+        result: makeErrorResult(request, POLICY_DENIED, message, { ...feedback }),
+        approvalOutcome: outcome,
+        approvalWaitMs,
+        approvalContext,
+      }
+    }
+    if (outcome.status === 'client_disconnected') {
+      return {
+        proceed: false,
+        result: this.makeClientDisconnectedBlockResult(request, decision),
+        approvalOutcome: outcome,
+        approvalWaitMs,
+        approvalContext,
+      }
+    }
+    if (outcome.status === 'shutdown_cancelled') {
       const feedback = buildShutdownCancelledFeedback(decision)
       const message =
         decision.matchedRule?.feedback?.message ?? 'Approval cancelled by proxy shutdown'
-      result = makeErrorResult(request, POLICY_DENIED, message, { ...feedback })
-    } else {
-      // timeout
-      if (router.defaultOnTimeout === 'allow' && !request.signal?.aborted) {
-        result = await this.inner.forward(request)
-      } else if (request.signal?.aborted) {
-        result = this.makeClientDisconnectedBlockResult(request, decision)
-      } else {
-        const feedback = buildApprovalTimeoutFeedback(decision, outcome.timeoutMs)
-        const message = decision.matchedRule?.feedback?.message ?? `Approval timed out`
-        result = makeErrorResult(request, POLICY_DENIED, message, { ...feedback })
+      return {
+        proceed: false,
+        result: makeErrorResult(request, POLICY_DENIED, message, { ...feedback }),
+        approvalOutcome: outcome,
+        approvalWaitMs,
+        approvalContext,
       }
     }
-
-    return { result, outcome, approvalWaitMs, approvalContext }
+    // timeout
+    if (router.defaultOnTimeout === 'allow' && !request.signal?.aborted) {
+      return { proceed: true, approvalOutcome: outcome, approvalWaitMs, approvalContext }
+    }
+    if (request.signal?.aborted) {
+      return {
+        proceed: false,
+        result: this.makeClientDisconnectedBlockResult(request, decision),
+        approvalOutcome: outcome,
+        approvalWaitMs,
+        approvalContext,
+      }
+    }
+    const feedback = buildApprovalTimeoutFeedback(decision, outcome.timeoutMs)
+    const message = decision.matchedRule?.feedback?.message ?? `Approval timed out`
+    return {
+      proceed: false,
+      result: makeErrorResult(request, POLICY_DENIED, message, { ...feedback }),
+      approvalOutcome: outcome,
+      approvalWaitMs,
+      approvalContext,
+    }
   }
 
-  private async handleRateLimit(
+  private handleRateLimit(
     request: McpRequest,
     decision: PolicyDecision,
     toolName: string,
-  ): Promise<{ result: ForwardResult; rateLimitResult: RateLimitResult }> {
+  ): ActionGateResult {
     // Caller guarantees this.rateLimiter is defined
     const limiter = this.rateLimiter as RateLimiter
     const limits = decision.matchedRule?.limits
@@ -603,36 +892,47 @@ export class GovernedForwarder implements McpForwarder {
         `Policy misconfigured: rate_limit rule for "${toolName}" requires limits.max_calls and limits.window`,
       )
       return {
+        proceed: false,
         result,
+        approvalWaitMs: 0,
         rateLimitResult: { allowed: false, current: 0, limit: 0, windowMs: 0, resetAtMs: 0 },
       }
     }
 
     const key = this.buildLimitKey(limits.key, toolName, request)
-    const rateLimitResult = limiter.check({
-      key,
-      maxCalls: limits.maxCalls,
-      windowMs: limits.windowMs,
-    })
+    const params = { key, maxCalls: limits.maxCalls, windowMs: limits.windowMs }
+    // Peek at the gate; record at the forward site (commitRuleLimit) so a call
+    // a later gate blocks never consumes the counter. Peek → record stays in
+    // one event-loop tick on this path, so no concurrent call can interleave.
+    const rateLimitResult = limiter.peek(params)
 
-    let result: ForwardResult
-    if (rateLimitResult.allowed) {
-      result = await this.inner.forward(request)
-    } else {
+    if (!rateLimitResult.allowed) {
       const feedback = buildRateLimitedFeedback(decision, rateLimitResult)
       const message = decision.matchedRule?.feedback?.message ?? `Rate limit exceeded for ${key}`
-      result = makeErrorResult(request, POLICY_DENIED, message, { ...feedback })
+      return {
+        proceed: false,
+        result: makeErrorResult(request, POLICY_DENIED, message, { ...feedback }),
+        approvalWaitMs: 0,
+        rateLimitResult,
+      }
     }
 
-    return { result, rateLimitResult }
+    return {
+      proceed: true,
+      approvalWaitMs: 0,
+      rateLimitResult,
+      commitRuleLimit: () => {
+        limiter.record(params)
+      },
+    }
   }
 
-  private async handleSpendLimit(
+  private handleSpendLimit(
     request: McpRequest,
     decision: PolicyDecision,
     toolName: string,
     toolArguments: Record<string, unknown> | undefined,
-  ): Promise<{ result: ForwardResult; spendLimitResult: SpendLimitResult }> {
+  ): ActionGateResult {
     // Caller guarantees this.spendLimiter is defined
     const limiter = this.spendLimiter as SpendLimiter
     const maxSpend = decision.matchedRule?.limits?.maxSpend
@@ -644,7 +944,9 @@ export class GovernedForwarder implements McpForwarder {
         `Policy misconfigured: spend_limit rule for "${toolName}" requires limits.max_spend`,
       )
       return {
+        proceed: false,
         result,
+        approvalWaitMs: 0,
         spendLimitResult: { allowed: false, currentSpend: 0, limit: 0, windowMs: 0, resetAtMs: 0 },
       }
     }
@@ -674,7 +976,9 @@ export class GovernedForwarder implements McpForwarder {
         { ...feedback },
       )
       return {
+        proceed: false,
         result,
+        approvalWaitMs: 0,
         spendLimitResult: invalidAmount,
       }
     }
@@ -684,39 +988,44 @@ export class GovernedForwarder implements McpForwarder {
     // carrying the real currentSpend / resetAtMs from any pre-existing
     // legitimate spend on this bucket. That gives the audit row an accurate
     // snapshot of the bucket at the time of the attack, instead of a fake-zero
-    // synthetic result.
-    const spendLimitResult = limiter.check({
-      key,
-      amount: rawAmount,
-      limit: maxSpend.limit,
-      windowMs: maxSpend.windowMs,
-    })
+    // synthetic result. Peek at the gate; record at the forward site
+    // (commitRuleLimit), so a call the budget gate blocks consumes nothing —
+    // peek → record stays in one event-loop tick on this path.
+    const params = { key, amount: rawAmount, limit: maxSpend.limit, windowMs: maxSpend.windowMs }
+    const spendLimitResult = limiter.peek(params)
 
     if (spendLimitResult.reason === 'invalid_amount') {
       // eslint-disable-next-line no-console -- Intentional operational warning
       console.error(
         `[helio] Warning: spend limit field "${maxSpend.field}" resolved to invalid amount (${String(rawAmount)}) for tool "${toolName}" (rule: ${decision.matchedRule.name ?? 'unnamed'}), denying request`,
       )
-    } else {
-      // Bucket was created or updated — label it for dashboard reads. Skip on
-      // the invalid-amount path because the limiter never created a bucket.
-      limiter.setCurrency(key, maxSpend.currency)
     }
 
-    let result: ForwardResult
-    if (spendLimitResult.allowed) {
-      result = await this.inner.forward(request)
-    } else {
+    if (!spendLimitResult.allowed) {
       const feedback = buildSpendLimitedFeedback(decision, spendLimitResult, maxSpend.currency)
       const message =
         spendLimitResult.reason === 'invalid_amount'
           ? `Spend limit denied: invalid amount for field "${maxSpend.field}"`
           : (decision.matchedRule.feedback?.message ??
             `Spend limit exceeded for ${key} (${maxSpend.currency})`)
-      result = makeErrorResult(request, POLICY_DENIED, message, { ...feedback })
+      return {
+        proceed: false,
+        result: makeErrorResult(request, POLICY_DENIED, message, { ...feedback }),
+        approvalWaitMs: 0,
+        spendLimitResult,
+      }
     }
 
-    return { result, spendLimitResult }
+    return {
+      proceed: true,
+      approvalWaitMs: 0,
+      spendLimitResult,
+      commitRuleLimit: () => {
+        limiter.record(params)
+        // Label the bucket for dashboard reads once it exists.
+        limiter.setCurrency(key, maxSpend.currency)
+      },
+    }
   }
 
   /**
@@ -790,7 +1099,46 @@ export class GovernedForwarder implements McpForwarder {
       }
     }
 
-    return this.makeDryRunResult(request, decision, wouldForward, evidenceSatisfied, limitsOk)
+    // Budget gate peek (issue #14): a call that would otherwise forward must
+    // also clear every matching budget. Dry-run never records.
+    let budgets: Array<Record<string, unknown>> | undefined
+    if (wouldForward && this.budgetEngine) {
+      const { charges, failures } = this.budgetEngine.resolveCharges({
+        toolName,
+        toolArguments,
+        sessionId: request.sessionId ?? null,
+        senderId: null,
+      })
+      if (failures.length > 0 || charges.length > 0) {
+        const peek =
+          charges.length > 0 ? this.budgetEngine.peekAll(charges) : { allowed: true, entries: [] }
+        const ok = failures.length === 0 && peek.allowed
+        wouldForward &&= ok
+        limitsOk &&= ok
+        budgets = [
+          ...peek.entries.map((entry) => budgetChainBlock(entry)),
+          ...failures.map((failure) => ({
+            name: failure.budget.name,
+            bucket_key: failure.bucketKey,
+            allowed: false,
+            reason: failure.reason,
+            spent: failure.spent,
+            limit: failure.budget.limit,
+            remaining: failure.remaining,
+            currency: failure.budget.currency,
+          })),
+        ]
+      }
+    }
+
+    return this.makeDryRunResult(
+      request,
+      decision,
+      wouldForward,
+      evidenceSatisfied,
+      limitsOk,
+      budgets,
+    )
   }
 
   /** Construct a limit bucket key based on the configured key type. */
@@ -844,26 +1192,9 @@ export class GovernedForwarder implements McpForwarder {
     return spendBucketKey(this.buildLimitKey(keyType, toolName, request), ruleIndex)
   }
 
-  /** Determine if the request was actually forwarded to the upstream MCP server. */
-  private wasForwardedUpstream(
-    decision: PolicyDecision,
-    approvalOutcome?: ApprovalOutcome,
-    rateLimitResult?: RateLimitResult,
-    spendLimitResult?: SpendLimitResult,
-  ): boolean {
-    return (
-      decision.action === 'allow' ||
-      approvalOutcome?.status === 'approved' ||
-      approvalOutcome?.status === 'break_glass' ||
-      (approvalOutcome?.status === 'timeout' &&
-        this.approvalRouter?.defaultOnTimeout === 'allow') ||
-      rateLimitResult?.allowed === true ||
-      spendLimitResult?.allowed === true
-    )
-  }
-
   private writeAuditRecord(
     request: McpRequest,
+    auditRecordId: string,
     timestamp: string,
     toolName: string,
     toolArguments: Record<string, unknown> | undefined,
@@ -872,6 +1203,7 @@ export class GovernedForwarder implements McpForwarder {
     totalDurationMs: number,
     approvalWaitMs: number,
     flaggedDestructive: boolean,
+    forwarded: boolean,
     evidenceResult?: EvidenceCheckResult,
     dependencyResult?: DependencyCheckResult,
     evidenceBlocked?: boolean,
@@ -879,22 +1211,16 @@ export class GovernedForwarder implements McpForwarder {
     approvalContext?: ApprovalAuditContext,
     rateLimitResult?: RateLimitResult,
     spendLimitResult?: SpendLimitResult,
+    budgetsChain?: Array<Record<string, unknown>>,
     isDryRun?: boolean,
     forwardingError?: Error,
     drift?: { event: ToolDriftEvent; mode: 'block' | 'require_approval' | 'log' },
   ): void {
     if (!this.auditWriter) return
 
-    const wasForwarded = this.wasForwardedUpstream(
-      decision,
-      approvalOutcome,
-      rateLimitResult,
-      spendLimitResult,
-    )
-
-    // In dry-run mode, nothing was actually forwarded regardless of what
-    // wasForwardedUpstream() returns based on the policy decision alone.
-    const actuallyForwarded = wasForwarded && !isDryRun
+    // `forwarded` is a fact captured at the single forward site — never a
+    // derivation. Dry-run never forwards by construction.
+    const actuallyForwarded = forwarded && !isDryRun
     const hadForwardingError = forwardingError !== undefined
 
     // Extract upstream error from JSON-RPC error response
@@ -958,6 +1284,13 @@ export class GovernedForwarder implements McpForwarder {
       }
     }
 
+    if (budgetsChain && budgetsChain.length > 0) {
+      evidenceChain = {
+        ...(evidenceChain ?? {}),
+        budgets: budgetsChain,
+      }
+    }
+
     if (drift) {
       evidenceChain = {
         ...(evidenceChain ?? {}),
@@ -1004,11 +1337,11 @@ export class GovernedForwarder implements McpForwarder {
     // flush queue. Ordinary allows stay buffered to reduce write churn.
     // Crash durability is preserved by the process-level crash-drain hook,
     // which synchronously flushes the writer before exit.
-    const isEnforcementDecision = !isDryRun && (!wasForwarded || approvalOutcome !== undefined)
+    const isEnforcementDecision = !isDryRun && (!forwarded || approvalOutcome !== undefined)
     if (isEnforcementDecision) {
-      this.auditWriter.pushImmediate(record)
+      this.auditWriter.pushImmediate(record, auditRecordId)
     } else {
-      this.auditWriter.push(record)
+      this.auditWriter.push(record, auditRecordId)
     }
   }
 
@@ -1069,6 +1402,7 @@ export class GovernedForwarder implements McpForwarder {
     wouldForward: boolean,
     evidenceSatisfied: boolean,
     limitsOk: boolean,
+    budgets?: Array<Record<string, unknown>>,
   ): ForwardResult {
     const payload = {
       dry_run: true,
@@ -1077,6 +1411,7 @@ export class GovernedForwarder implements McpForwarder {
       matched_rule: decision.matchedRule?.name ?? null,
       evidence_satisfied: evidenceSatisfied,
       limits_ok: limitsOk,
+      ...(budgets ? { budgets } : {}),
     }
     const body = {
       jsonrpc: '2.0' as const,

--- a/packages/proxy/src/policy/rate-limiter.ts
+++ b/packages/proxy/src/policy/rate-limiter.ts
@@ -138,7 +138,7 @@ export class RateLimiter {
 
     // Emit warning when approaching the limit
     if (this.onWarning && current / maxCalls >= this.warningThreshold) {
-      this.onWarning({ key, current, limit: maxCalls, window_ms: windowMs, reset_at_ms: resetAtMs })
+      this.safeWarn({ key, current, limit: maxCalls, window_ms: windowMs, reset_at_ms: resetAtMs })
     }
 
     return {
@@ -186,7 +186,7 @@ export class RateLimiter {
     const resetAtMs = (bucket.timestamps[0] ?? now) + windowMs
 
     if (this.onWarning && current <= maxCalls && current / maxCalls >= this.warningThreshold) {
-      this.onWarning({ key, current, limit: maxCalls, window_ms: windowMs, reset_at_ms: resetAtMs })
+      this.safeWarn({ key, current, limit: maxCalls, window_ms: windowMs, reset_at_ms: resetAtMs })
     }
 
     return {
@@ -333,6 +333,22 @@ export class RateLimiter {
   }
 
   /** Stop the cleanup timer and mark as closed. */
+  /**
+   * Invoke the warning callback without letting a subscriber throw into the
+   * limiter's caller: a warning fires after state has already mutated, and a
+   * governed call must not be blocked (or double-charged on retry) by an
+   * observability bug.
+   */
+  private safeWarn(state: RateLimitKeyState): void {
+    if (!this.onWarning) return
+    try {
+      this.onWarning(state)
+    } catch (err) {
+      // eslint-disable-next-line no-console -- Subscriber bugs must not affect enforcement
+      console.error('[helio] limit warning subscriber threw:', err)
+    }
+  }
+
   close(): void {
     if (this.closed) return
     this.closed = true

--- a/packages/proxy/src/policy/spend-limiter.ts
+++ b/packages/proxy/src/policy/spend-limiter.ts
@@ -193,7 +193,7 @@ export class SpendLimiter {
 
     // Emit warning when approaching the limit
     if (this.onWarning && newSpend / limit >= this.warningThreshold) {
-      this.onWarning({
+      this.safeWarn({
         key,
         current_spend: newSpend,
         limit,
@@ -255,7 +255,7 @@ export class SpendLimiter {
     const resetAtMs = (bucket.entries[0]?.timestamp ?? now) + windowMs
 
     if (this.onWarning && currentSpend <= limit && currentSpend / limit >= this.warningThreshold) {
-      this.onWarning({
+      this.safeWarn({
         key,
         current_spend: currentSpend,
         limit,
@@ -465,6 +465,22 @@ export class SpendLimiter {
   }
 
   /** Stop the cleanup timer and mark as closed. */
+  /**
+   * Invoke the warning callback without letting a subscriber throw into the
+   * limiter's caller: a warning fires after state has already mutated, and a
+   * governed call must not be blocked (or double-charged on retry) by an
+   * observability bug.
+   */
+  private safeWarn(state: SpendLimitKeyState): void {
+    if (!this.onWarning) return
+    try {
+      this.onWarning(state)
+    } catch (err) {
+      // eslint-disable-next-line no-console -- Subscriber bugs must not affect enforcement
+      console.error('[helio] limit warning subscriber threw:', err)
+    }
+  }
+
   close(): void {
     if (this.closed) return
     this.closed = true

--- a/packages/proxy/src/server.test.ts
+++ b/packages/proxy/src/server.test.ts
@@ -46,6 +46,7 @@ const minimalConfig = {
     include_responses: true,
   },
   sdk: { enabled: false, port: 3200, host: '127.0.0.1', evaluation_ttl: '10m' },
+  budgets: [],
 } as HelioConfig
 
 // ---------------------------------------------------------------------------

--- a/packages/proxy/src/sideband/governance-api.test.ts
+++ b/packages/proxy/src/sideband/governance-api.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { createSidebandApp } from '../evidence/api.js'
 import { EvidenceStore } from '../evidence/store.js'
 import { GovernanceService } from './governance-service.js'
+import { BudgetEngine } from '../budget/engine.js'
+import { compileBudgets } from '../budget/parser.js'
 import { compilePolicies } from '../policy/parser.js'
 import { ApprovalRouter } from '../approval/router.js'
 import { ApprovalQueue } from '../approval/queue.js'
@@ -448,5 +450,51 @@ describe('sideband governance routes', () => {
     })
     expect(res.status).toBe(413)
     expect(((await res.json()) as { error: string }).error).toBe('request_body_too_large')
+  })
+})
+
+describe('POST /evaluate — budget_exceeded over HTTP (issue #14)', () => {
+  it('returns the budget decision, limits block, and feedback through the route layer', async () => {
+    const policy = compilePolicies({ default: 'allow', dry_run: false, rules: [] }).policy
+    const budgetEngine = new BudgetEngine({
+      budgets: compileBudgets([
+        {
+          name: 'cap',
+          limit: 10,
+          currency: 'USD',
+          window: '24h',
+          key: 'global',
+          on_exceed: 'deny',
+          contributors: [{ tool: 'send', field: '$.amount' }],
+        },
+      ]),
+      cleanupIntervalMs: 0,
+    })
+    const governance = new GovernanceService({ policy, budgetEngine, sweepIntervalMs: 0 })
+    const store = new EvidenceStore()
+    const app = createSidebandApp(store, { governance })
+
+    const res = await app.request('/evaluate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        origin: 'openclaw',
+        tool: { name: 'send' },
+        arguments: { amount: 50 },
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body['decision']).toBe('budget_exceeded')
+    const limits = body['limits'] as { budgets: Array<Record<string, unknown>> }
+    expect(limits.budgets[0]?.['name']).toBe('cap')
+    expect(limits.budgets[0]?.['reset_at_ms']).toBeDefined()
+    const feedback = body['feedback'] as { message: string }
+    expect(feedback.message).toContain('"cap"')
+
+    budgetEngine.close()
+    governance.close()
+    store.close()
   })
 })

--- a/packages/proxy/src/sideband/governance-api.ts
+++ b/packages/proxy/src/sideband/governance-api.ts
@@ -22,7 +22,9 @@ const originSchema = z
 const metadataSchema = z.record(z.string(), z.unknown()).nullish()
 
 const toolDefinitionSchema = z.object({
-  name: z.string().min(1),
+  // Stored verbatim in pending entries and audit rows; capped so a
+  // caller-minted name cannot inflate the pending-entry footprint.
+  name: z.string().min(1).max(256),
   description: z.string().optional(),
   input_schema: z.unknown().optional(),
   output_schema: z.unknown().optional(),
@@ -33,8 +35,10 @@ const toolDefinitionSchema = z.object({
 const evaluateBody = z.object({
   origin: originSchema,
   adapter_version: z.string().max(64).optional(),
-  agent_id: z.string().nullish(),
-  session_id: z.string().nullish(),
+  // Stored in pending entries and limit bucket keys; capped (like origin and
+  // adapter_version) so caller-minted ids cannot inflate memory unaccounted.
+  agent_id: z.string().max(128).nullish(),
+  session_id: z.string().max(256).nullish(),
   tool: toolDefinitionSchema,
   arguments: z.record(z.string(), z.unknown()).optional(),
   metadata: metadataSchema,
@@ -42,8 +46,8 @@ const evaluateBody = z.object({
 
 const installScanBody = z.object({
   origin: originSchema,
-  agent_id: z.string().nullish(),
-  session_id: z.string().nullish(),
+  agent_id: z.string().max(128).nullish(),
+  session_id: z.string().max(256).nullish(),
   package: z.object({
     name: z.string().min(1),
     version: z.string().optional(),

--- a/packages/proxy/src/sideband/governance-service.test.ts
+++ b/packages/proxy/src/sideband/governance-service.test.ts
@@ -9,6 +9,9 @@ import type { AuditRecord } from '../audit/types.js'
 import type { AuditWriter } from '../audit/writer.js'
 import { RateLimiter } from '../policy/rate-limiter.js'
 import { SpendLimiter } from '../policy/spend-limiter.js'
+import { BudgetEngine } from '../budget/engine.js'
+import { compileBudgets } from '../budget/parser.js'
+import type { BudgetConfig } from '../config/schema.js'
 import { ApprovalRouter } from '../approval/router.js'
 import { ApprovalQueue } from '../approval/queue.js'
 import { EvidenceStore } from '../evidence/index.js'
@@ -49,6 +52,8 @@ interface ServiceHarness {
   spendLimiter: SpendLimiter | undefined
   approvalRouter: ApprovalRouter | undefined
   evidenceStore: EvidenceStore | undefined
+  budgetEngine?: BudgetEngine
+  queue?: ApprovalQueue
 }
 
 function makeService(opts?: {
@@ -58,6 +63,8 @@ function makeService(opts?: {
   withEvidence?: boolean
   ttlMs?: number
   maxSenderKeys?: number
+  maxPendingBytes?: number
+  budgets?: BudgetConfig[]
 }): ServiceHarness {
   let time = 1_000_000
   const now = () => time
@@ -85,6 +92,9 @@ function makeService(opts?: {
         })
       : undefined
   const evidenceStore = opts?.withEvidence ? new EvidenceStore({ now }) : undefined
+  const budgetEngine = opts?.budgets
+    ? new BudgetEngine({ budgets: compileBudgets(opts.budgets), now, cleanupIntervalMs: 0 })
+    : undefined
 
   const service = new GovernanceService({
     policy,
@@ -97,9 +107,21 @@ function makeService(opts?: {
     now,
     sweepIntervalMs: 0,
     ...(opts?.maxSenderKeys !== undefined && { maxSenderKeys: opts.maxSenderKeys }),
+    ...(opts?.maxPendingBytes !== undefined && { maxPendingBytes: opts.maxPendingBytes }),
+    budgetEngine,
   })
 
-  return { service, records, advance, rateLimiter, spendLimiter, approvalRouter, evidenceStore }
+  return {
+    service,
+    queue,
+    records,
+    advance,
+    rateLimiter,
+    spendLimiter,
+    approvalRouter,
+    evidenceStore,
+    budgetEngine,
+  }
 }
 
 function evalInput(overrides?: Partial<EvaluateInput>): EvaluateInput {
@@ -1040,7 +1062,7 @@ describe('GovernanceService /audit validation and budgets', () => {
     const service = new GovernanceService({
       policy: compile({ default: 'allow', rules: [] }),
       sweepIntervalMs: 0,
-      maxPendingBytes: 30,
+      maxPendingBytes: 120,
     })
     // First evaluate fits; second would push pendingBytes over the cap.
     const first = service.evaluate(evalInput({ arguments: { a: 'xxxxxxxxxx' } }))
@@ -1597,5 +1619,445 @@ describe('GovernanceService tool baseline cap', () => {
     expect(update.status).toBe(200)
     expect(update.body['error']).toBeUndefined()
     expect(update.body['tool_drift']).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Budget gate (issue #14)
+// ---------------------------------------------------------------------------
+
+describe('GovernanceService — spend rule bucket isolation and capacity (PR 0 rider)', () => {
+  it('gives each session-keyed spend rule its own bucket on the sideband', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [
+        {
+          name: 'cap-a',
+          match: { tool: 'payment_a' },
+          action: 'spend_limit',
+          limits: {
+            max_spend: {
+              field: '$.amount',
+              limit: 100,
+              currency: 'USD',
+              window: '1h',
+              key: 'session',
+            },
+          },
+        },
+        {
+          name: 'cap-b',
+          match: { tool: 'payment_b' },
+          action: 'spend_limit',
+          limits: {
+            max_spend: {
+              field: '$.amount',
+              limit: 100,
+              currency: 'USD',
+              window: '1h',
+              key: 'session',
+            },
+          },
+        },
+      ],
+    })
+    const { service, spendLimiter } = makeService({ policy, withLimiters: true })
+
+    const first = service.evaluate(
+      evalInput({ tool: { name: 'payment_a' }, arguments: { amount: 90 }, session_id: 's1' }),
+    )
+    service.audit(auditInput(first.body['evaluation_id'] as string), 'h')
+
+    // Under the old shared session:<id> bucket this second call would be
+    // blocked by rule cap-a's spend (90 + 90 > 100).
+    const second = service.evaluate(
+      evalInput({ tool: { name: 'payment_b' }, arguments: { amount: 90 }, session_id: 's1' }),
+    )
+    expect(second.body['decision']).toBe('allow')
+    service.audit(auditInput(second.body['evaluation_id'] as string), 'h')
+
+    expect(spendLimiter?.getKeyState('session:s1:rule:0')?.current_spend).toBe(90)
+    expect(spendLimiter?.getKeyState('session:s1:rule:1')?.current_spend).toBe(90)
+  })
+
+  it('suffixed sender spend keys still consume sender-capacity slots', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [
+        {
+          name: 'sp-sender',
+          match: { tool: 'send' },
+          action: 'spend_limit',
+          limits: {
+            max_spend: {
+              field: '$.cost',
+              limit: 100,
+              currency: 'USD',
+              window: '1d',
+              key: 'sender_id',
+            },
+          },
+        },
+      ],
+    })
+    const { service } = makeService({ policy, withLimiters: true, maxSenderKeys: 1 })
+
+    const first = service.evaluate(
+      evalInput({ arguments: { cost: 1 }, metadata: { sender_id: 'U1' } }),
+    )
+    expect(first.status).toBe(200)
+
+    const second = service.evaluate(
+      evalInput({ arguments: { cost: 1 }, metadata: { sender_id: 'U2' } }),
+    )
+    expect(second.status).toBe(503)
+    expect(second.body['error']).toBe('limit_capacity_exhausted')
+  })
+})
+
+describe('GovernanceService — budget gate (issue #14)', () => {
+  const stripeBudget = (overrides: Partial<BudgetConfig> = {}): BudgetConfig => ({
+    name: 'cap',
+    limit: 100,
+    currency: 'USD',
+    window: '24h',
+    key: 'global',
+    on_exceed: 'deny',
+    contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+    ...overrides,
+  })
+  const stripeEval = (amount: unknown, extra: Partial<Parameters<typeof evalInput>[0]> = {}) =>
+    evalInput({ tool: { name: 'stripe_charge' }, arguments: { amount }, ...extra })
+
+  it('returns budget_exceeded terminally on a deny-breach and records nothing', () => {
+    const { service, budgetEngine, records } = makeService({
+      budgets: [stripeBudget({ limit: 10 })],
+    })
+    const res = service.evaluate(stripeEval(50))
+
+    expect(res.status).toBe(200)
+    expect(res.body['decision']).toBe('budget_exceeded')
+    expect(res.body['feedback']).toBeDefined()
+    const limits = res.body['limits'] as { budgets: Array<Record<string, unknown>> }
+    expect(limits.budgets[0]?.['name']).toBe('cap')
+    expect(limits.budgets[0]?.['remaining']).toBe(10)
+
+    // Terminal at evaluate: audit already finalized, nothing recorded anywhere.
+    const id = res.body['evaluation_id'] as string
+    const replay = service.audit(auditInput(id), 'h')
+    expect(replay.status).toBe(200)
+    expect(replay.body['finalized_by']).toBe('evaluate')
+    expect(budgetEngine?.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+    expect(records[0]?.record.block_reason).toBe('budget_exceeded')
+  })
+
+  it('fails closed terminally when the contributor amount is invalid', () => {
+    const { service, budgetEngine } = makeService({ budgets: [stripeBudget()] })
+    const res = service.evaluate(stripeEval('not-a-number'))
+
+    expect(res.body['decision']).toBe('budget_exceeded')
+    const limits = res.body['limits'] as { budgets: Array<Record<string, unknown>> }
+    expect(limits.budgets[0]?.['reason']).toBe('invalid_amount')
+    expect(budgetEngine?.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+  })
+
+  it('stores budget plans on allow and commits them at /audit', () => {
+    const { service, budgetEngine } = makeService({ budgets: [stripeBudget()] })
+    const res = service.evaluate(stripeEval(30))
+
+    expect(res.body['decision']).toBe('allow')
+    const limits = res.body['limits'] as { budgets: Array<Record<string, unknown>> }
+    expect(limits.budgets[0]?.['remaining']).toBe(100)
+
+    // Nothing recorded until the call actually ran.
+    expect(budgetEngine?.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+
+    const id = res.body['evaluation_id'] as string
+    const audit = service.audit(auditInput(id), 'h')
+    expect(audit.status).toBe(201)
+    expect(budgetEngine?.listStates()[0]?.buckets[0]?.spent).toBe(30)
+  })
+
+  it('commits nothing on not_executed', () => {
+    const { service, budgetEngine } = makeService({ budgets: [stripeBudget()] })
+    const id = service.evaluate(stripeEval(30)).body['evaluation_id'] as string
+    service.audit(auditInput(id, { status: 'not_executed' }), 'h')
+    expect(budgetEngine?.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+  })
+
+  it('commits nothing when the evaluation expires', () => {
+    const { service, budgetEngine, advance } = makeService({
+      budgets: [stripeBudget()],
+      ttlMs: 1_000,
+    })
+    const id = service.evaluate(stripeEval(30)).body['evaluation_id'] as string
+    advance(1_001)
+    const res = service.audit(auditInput(id), 'h')
+    expect(res.status).toBe(404)
+    expect(budgetEngine?.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+  })
+
+  it('actual_amount overrides every budget plan amount', () => {
+    const { service, budgetEngine } = makeService({
+      budgets: [stripeBudget({ name: 'a' }), stripeBudget({ name: 'b' })],
+    })
+    const id = service.evaluate(stripeEval(30)).body['evaluation_id'] as string
+    const res = service.audit(auditInput(id, { actual_amount: 42 }), 'h')
+    expect(res.status).toBe(201)
+    expect(budgetEngine?.listStates().map((s2) => s2.buckets[0]?.spent)).toEqual([42, 42])
+  })
+
+  it('commits rule spend plans and budget plans together', () => {
+    const policy = compile({
+      default: 'allow',
+      rules: [
+        {
+          name: 'rule-cap',
+          match: { tool: 'stripe_*' },
+          action: 'spend_limit',
+          limits: {
+            max_spend: { field: '$.amount', limit: 1000, currency: 'USD', window: '1h' },
+          },
+        },
+      ],
+    })
+    const { service, budgetEngine, spendLimiter } = makeService({
+      policy,
+      withLimiters: true,
+      budgets: [stripeBudget()],
+    })
+    const id = service.evaluate(stripeEval(30)).body['evaluation_id'] as string
+    service.audit(auditInput(id), 'h')
+
+    expect(spendLimiter?.getKeyState('tool:stripe_charge:rule:0')?.current_spend).toBe(30)
+    expect(budgetEngine?.listStates()[0]?.buckets[0]?.spent).toBe(30)
+  })
+
+  it('reserves sender-key slots for sender-keyed budget buckets', () => {
+    const { service } = makeService({
+      budgets: [stripeBudget({ name: 'sb', key: 'sender_id' })],
+      maxSenderKeys: 1,
+    })
+    const first = service.evaluate(stripeEval(1, { metadata: { sender_id: 'U1' } }))
+    expect(first.status).toBe(200)
+    const firstId = first.body['evaluation_id'] as string
+    void firstId
+
+    const second = service.evaluate(stripeEval(1, { metadata: { sender_id: 'U2' } }))
+    expect(second.status).toBe(503)
+    expect(second.body['error']).toBe('limit_capacity_exhausted')
+  })
+
+  it('counts the plans list into pending-entry byte accounting', () => {
+    // The cap (250) sits between each call's BASE size (~110–160, which
+    // passes the early admission check) and the long-sender call's base +
+    // plans (~304) — only the post-planning re-check can refuse it. The
+    // short-sender call (~204 with plans) fits end to end THROUGH THE SAME
+    // SERVICE, which with maxSenderKeys: 1 also proves the refused call
+    // released its sender reservation.
+    const budgets = [stripeBudget({ name: 'cap-for-senders', key: 'sender_id' })]
+    const { service } = makeService({ budgets, maxSenderKeys: 1, maxPendingBytes: 250 })
+
+    const refused = service.evaluate(
+      stripeEval(10, {
+        metadata: { sender_id: 'sender-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+      }),
+    )
+    expect(refused.status).toBe(503)
+    expect(refused.body['error']).toBe('evaluation_backlog_full')
+
+    const admitted = service.evaluate(stripeEval(10, { metadata: { sender_id: 'B' } }))
+    expect(admitted.status).toBe(200)
+    expect(admitted.body['decision']).toBe('allow')
+  })
+
+  it('releases sender reservations and creates no ticket when the byte re-check refuses', () => {
+    // require_approval + sender-keyed budget: the late 503 must not leave an
+    // orphaned native ticket, and the retry runs through the SAME service.
+    const policy = compile({
+      default: 'allow',
+      rules: [{ name: 'gate', match: { tool: 'stripe_*' }, action: 'require_approval' }],
+    })
+    const budgets = [stripeBudget({ name: 'cap-for-senders', key: 'sender_id' })]
+    const { service, queue } = makeService({
+      policy,
+      withApprovals: true,
+      budgets,
+      maxSenderKeys: 1,
+      maxPendingBytes: 250,
+    })
+
+    const refused = service.evaluate(
+      stripeEval(10, {
+        metadata: { sender_id: 'sender-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+      }),
+    )
+    expect(refused.status).toBe(503)
+    expect(refused.body['error']).toBe('evaluation_backlog_full')
+    expect(queue?.list({ status: 'pending' })).toEqual([])
+
+    // Same service: the refused call's slot must be free for the next sender.
+    const admitted = service.evaluate(stripeEval(10, { metadata: { sender_id: 'C' } }))
+    expect(admitted.status).toBe(200)
+    expect(admitted.body['decision']).toBe('require_approval')
+    expect(queue?.list({ status: 'pending' })).toHaveLength(1)
+  })
+
+  it('dry-run peeks budgets, reports limits_ok, and records nothing', () => {
+    const policy = compile({ default: 'allow', dry_run: true, rules: [] })
+    const { service, budgetEngine } = makeService({
+      policy,
+      budgets: [stripeBudget({ limit: 10 })],
+    })
+
+    const res = service.evaluate(stripeEval(50))
+    expect(res.body['decision']).toBe('dry_run')
+    const dryRun = res.body['dry_run'] as Record<string, unknown>
+    expect(dryRun['would_forward']).toBe(false)
+    expect(dryRun['limits_ok']).toBe(false)
+    const limits = res.body['limits'] as { budgets: Array<Record<string, unknown>> }
+    expect(limits.budgets[0]?.['allowed']).toBe(false)
+    expect(budgetEngine?.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+  })
+
+  it('budget_exceeded feedback names the budget, not the policy decision', () => {
+    // The matched decision here is the default allow — its reason ("No
+    // matching rule; applied default policy: allow") must never surface as
+    // the denial message.
+    const { service } = makeService({ budgets: [stripeBudget({ limit: 10 })] })
+    const res = service.evaluate(stripeEval(50))
+
+    const feedback = res.body['feedback'] as { message: string; suggestion?: string }
+    expect(feedback.message).toContain('"cap"')
+    expect(feedback.message).not.toContain('allow')
+    expect(feedback.suggestion).toBeDefined()
+  })
+
+  it('reports simultaneous breaches and invalid amounts together', () => {
+    const { service } = makeService({
+      budgets: [
+        stripeBudget({ name: 'valid-but-breached', limit: 10 }),
+        stripeBudget({
+          name: 'invalid-field',
+          contributors: [{ tool: 'stripe_*', field: '$.missing' }],
+        }),
+      ],
+    })
+    const res = service.evaluate(stripeEval(50))
+
+    expect(res.body['decision']).toBe('budget_exceeded')
+    const limits = res.body['limits'] as { budgets: Array<Record<string, unknown>> }
+    const names = limits.budgets.map((b) => b['name'])
+    expect(names).toContain('valid-but-breached')
+    expect(names).toContain('invalid-field')
+    const invalid = limits.budgets.find((b) => b['name'] === 'invalid-field')
+    expect(invalid?.['reason']).toBe('invalid_amount')
+    expect(invalid?.['spent']).toBe(0)
+  })
+
+  it('retries after a post-commit failure without double-recording (exactly-once)', () => {
+    // An evidence store whose recordToolCall throws once: the first /audit
+    // commits the plans, then dies post-commit → the adapter retries → the
+    // retry must reuse the latched commit instead of recording again.
+    const policy = compile({ default: 'allow', rules: [] })
+    const { service, budgetEngine, evidenceStore } = makeService({
+      policy,
+      withEvidence: true,
+      budgets: [stripeBudget()],
+    })
+    const original = evidenceStore?.recordToolCall.bind(evidenceStore)
+    let threw = false
+    vi.spyOn(evidenceStore as EvidenceStore, 'recordToolCall').mockImplementation(
+      (...args: Parameters<EvidenceStore['recordToolCall']>) => {
+        if (!threw) {
+          threw = true
+          throw new Error('bookkeeping bug')
+        }
+        return original?.(...args)
+      },
+    )
+
+    const ev = service.evaluate(stripeEval(30, { session_id: 's1' }))
+    const id = ev.body['evaluation_id'] as string
+
+    expect(() => service.audit(auditInput(id), 'h')).toThrow('bookkeeping bug')
+    // Committed exactly once already.
+    expect(budgetEngine?.listStates()[0]?.buckets[0]?.spent).toBe(30)
+
+    const retry = service.audit(auditInput(id), 'h')
+    expect(retry.status).toBe(201)
+    // Still exactly once.
+    expect(budgetEngine?.listStates()[0]?.buckets[0]?.spent).toBe(30)
+  })
+
+  it('marks committed sideband budget audit blocks with kind: spend', () => {
+    const { service, records } = makeService({ budgets: [stripeBudget()] })
+    const id = service.evaluate(stripeEval(30)).body['evaluation_id'] as string
+    service.audit(auditInput(id), 'h')
+
+    const record = records.find((r) => r.record.tool_name === 'stripe_charge')
+    const chain = record?.record.evidence_chain as Record<string, unknown>
+    const budgets = chain['budgets'] as Array<Record<string, unknown>>
+    expect(budgets[0]?.['kind']).toBe('spend')
+  })
+
+  it('rejects a post-commit retry that presents a different payload', () => {
+    const policy = compile({ default: 'allow', rules: [] })
+    const { service, budgetEngine, evidenceStore } = makeService({
+      policy,
+      withEvidence: true,
+      budgets: [stripeBudget()],
+    })
+    let threw = false
+    vi.spyOn(evidenceStore as EvidenceStore, 'recordToolCall').mockImplementation(() => {
+      if (!threw) {
+        threw = true
+        throw new Error('bookkeeping bug')
+      }
+    })
+
+    const id = service.evaluate(stripeEval(30, { session_id: 's1' })).body[
+      'evaluation_id'
+    ] as string
+    expect(() => service.audit(auditInput(id, { actual_amount: 30 }), 'hash-a')).toThrow()
+
+    // The commit ran with actual_amount 30; a retry claiming a different
+    // amount must conflict, not finalize inconsistent audit data.
+    const conflicting = service.audit(auditInput(id, { actual_amount: 999 }), 'hash-b')
+    expect(conflicting.status).toBe(409)
+    expect(conflicting.body['error']).toBe('evaluation_conflict')
+
+    // The identical payload still completes exactly-once.
+    const retry = service.audit(auditInput(id, { actual_amount: 30 }), 'hash-a')
+    expect(retry.status).toBe(201)
+    expect(budgetEngine?.listStates()[0]?.buckets[0]?.spent).toBe(30)
+  })
+
+  it('documents the sideband TOCTOU: two concurrent evaluates can both peek the last slot', () => {
+    // Decision and execution are separate calls on this door: both evaluates
+    // see headroom, both calls run, both audits commit — the pot ends over
+    // its limit but the counters stay truthful after the fact. This is the
+    // documented host-enforced-tier caveat, pinned as a regression.
+    const { service, budgetEngine } = makeService({ budgets: [stripeBudget({ limit: 100 })] })
+
+    const first = service.evaluate(stripeEval(60))
+    const second = service.evaluate(stripeEval(60))
+    expect(first.body['decision']).toBe('allow')
+    expect(second.body['decision']).toBe('allow')
+
+    service.audit(auditInput(first.body['evaluation_id'] as string), 'h1')
+    service.audit(auditInput(second.body['evaluation_id'] as string), 'h2')
+
+    expect(budgetEngine?.listStates()[0]?.buckets[0]?.spent).toBe(120)
+    // The NEXT evaluate sees the truthful, over-limit pot and denies.
+    expect(service.evaluate(stripeEval(1)).body['decision']).toBe('budget_exceeded')
+  })
+
+  it('keeps working without limiters configured (budget-only deployment)', () => {
+    const { service, budgetEngine } = makeService({ budgets: [stripeBudget()] })
+    const id = service.evaluate(stripeEval(5)).body['evaluation_id'] as string
+    const res = service.audit(auditInput(id), 'h')
+    expect(res.status).toBe(201)
+    expect(budgetEngine?.listStates()[0]?.buckets[0]?.spent).toBe(5)
   })
 })

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -35,6 +35,8 @@ import type { ApprovalAuditContext, ApprovalTicket } from '../approval/types.js'
 import type { RateLimiter } from '../policy/rate-limiter.js'
 import type { SpendLimiter } from '../policy/spend-limiter.js'
 import { spendBucketKey } from '../policy/spend-limiter.js'
+import type { BudgetEngine, BudgetChargeFailure, BudgetPeekEntry } from '../budget/engine.js'
+import type { CompiledBudget } from '../budget/types.js'
 import { GovernanceConfigError } from './errors.js'
 
 // ---------------------------------------------------------------------------
@@ -73,6 +75,7 @@ export type WireDecision =
   | 'require_approval'
   | 'rate_limited'
   | 'spend_limited'
+  | 'budget_exceeded'
   | 'dry_run'
 
 /** Tool definition carried by /evaluate (optional; enables the drift guard). */
@@ -175,6 +178,19 @@ interface LimitPlan {
   readonly currency?: string
 }
 
+/** A budget's share of a call, frozen at /evaluate and committed at /audit. */
+interface BudgetPlan {
+  readonly kind: 'budget'
+  readonly budget: CompiledBudget
+  readonly bucketKey: string
+  readonly amount: number
+  /** Config generation at evaluate time; stale charges are skipped at commit. */
+  readonly generation: number
+}
+
+/** Everything /audit must commit once the call actually executed. */
+type Plan = LimitPlan | BudgetPlan
+
 interface PendingEvaluation {
   readonly evaluationId: string
   readonly origin: string
@@ -187,7 +203,20 @@ interface PendingEvaluation {
   readonly matchedRuleName: string | null
   readonly matchedRuleIndex: number | null
   readonly flaggedDestructive: boolean
-  readonly limitPlan: LimitPlan | undefined
+  readonly plans: readonly Plan[]
+  /**
+   * Set once the plans have been committed (mutable latch): a throw AFTER the
+   * commit (evidence, audit write) surfaces as a 500 the adapter retries, and
+   * the retry must reuse this state instead of committing a second time.
+   */
+  commitState?: {
+    auditId: string
+    limitsChain: Record<string, unknown> | undefined
+    /** Hash of the payload that performed the commit — a retry with a
+     * DIFFERENT payload must 409 rather than finalize audit data that
+     * disagrees with the committed amounts. */
+    payloadHash: string
+  }
   readonly approvalTicketId: string | undefined
   readonly timestampIso: string
   readonly createdAtMs: number
@@ -222,6 +251,8 @@ export interface GovernanceServiceOptions {
   readonly approvalRouter?: ApprovalRouter
   readonly rateLimiter?: RateLimiter
   readonly spendLimiter?: SpendLimiter
+  /** Budget engine for named cross-tool budgets (issue #14). */
+  readonly budgetEngine?: BudgetEngine
   readonly auditWriter?: AuditWriter
   /** Default approval timeout (ms) when a rule sets none. */
   readonly approvalTimeoutMs?: number
@@ -250,6 +281,7 @@ export class GovernanceService {
   private readonly approvalRouter: ApprovalRouter | undefined
   private readonly rateLimiter: RateLimiter | undefined
   private readonly spendLimiter: SpendLimiter | undefined
+  private readonly budgetEngine: BudgetEngine | undefined
   private readonly auditWriter: AuditWriter | undefined
   private readonly approvalTimeoutMs: number
   private readonly ttlMs: number
@@ -284,6 +316,7 @@ export class GovernanceService {
     this.approvalRouter = options.approvalRouter
     this.rateLimiter = options.rateLimiter
     this.spendLimiter = options.spendLimiter
+    this.budgetEngine = options.budgetEngine
     this.auditWriter = options.auditWriter
     this.approvalTimeoutMs = options.approvalTimeoutMs ?? 300_000
     this.ttlMs = options.ttlMs ?? 600_000
@@ -328,8 +361,18 @@ export class GovernanceService {
       return { status: 413, body: { error: 'tool_input_too_large' } }
     }
     // Account for this entry's footprint up front so the global cap cannot be
-    // overshot by the entry that crosses it.
-    const entryBytes = inputBytes + byteLength(req.metadata ?? {})
+    // overshot by the entry that crosses it. Every stored caller-controlled
+    // string counts — tool name, agent id, session id — not just the two
+    // object payloads (the route also length-caps each of them).
+    const entryBytes =
+      inputBytes +
+      byteLength(req.metadata ?? {}) +
+      byteLength({
+        tool: req.tool.name,
+        agent_id: req.agent_id,
+        session_id: req.session_id,
+        origin: req.origin,
+      })
     if (!this.caches.has(req.origin) && this.caches.size >= MAX_ORIGINS) {
       return { status: 400, body: { error: 'origin_limit_exceeded' } }
     }
@@ -377,8 +420,19 @@ export class GovernanceService {
 
     // Resolve the limit step (peek — never consume at /evaluate).
     let wire: WireDecision
-    let limitPlan: LimitPlan | undefined
+    const plans: Plan[] = []
     let limitsBlock: Record<string, unknown> | undefined
+    // Sender-key slots inserted by THIS call, released if a later gate 503s.
+    const reservedThisCall: string[] = []
+    const reserve = (key: string): boolean => {
+      const preexisting = this.senderKeys.has(key)
+      if (!this.reserveSenderKey(key)) return false
+      if (!preexisting && this.senderKeys.has(key)) reservedThisCall.push(key)
+      return true
+    }
+    const releaseReservations = (): void => {
+      for (const key of reservedThisCall) this.senderKeys.delete(key)
+    }
 
     // sender_id is sourced from adapter metadata (host-enforced path only).
     const senderId = senderIdOf(req.metadata)
@@ -391,22 +445,87 @@ export class GovernanceService {
       wire = 'require_approval'
     } else if (decision.action === 'rate_limit') {
       const planned = this.planRate(decision, toolName, req.session_id, senderId)
-      if (planned?.plan && !this.reserveSenderKey(planned.plan.key)) {
+      if (planned?.plan && !reserve(planned.plan.key)) {
         return { status: 503, body: { error: 'limit_capacity_exhausted' } }
       }
-      limitPlan = planned?.plan
+      if (planned?.plan) plans.push(planned.plan)
       limitsBlock = planned?.block ? { rate: planned.block } : undefined
       wire = planned?.allowed ? 'allow' : 'rate_limited'
     } else if (decision.action === 'spend_limit') {
       const planned = this.planSpend(decision, toolName, req.session_id, req.arguments, senderId)
-      if (planned?.plan && !this.reserveSenderKey(planned.plan.key)) {
+      if (planned?.plan && !reserve(planned.plan.key)) {
         return { status: 503, body: { error: 'limit_capacity_exhausted' } }
       }
-      limitPlan = planned?.plan
+      if (planned?.plan) plans.push(planned.plan)
       limitsBlock = planned?.block ? { spend: planned.block } : undefined
       wire = planned?.allowed ? 'allow' : 'spend_limited'
     } else {
       wire = 'allow'
+    }
+
+    // Budget gate (issue #14): peek every matching budget, all-or-nothing.
+    // Runs for calls that could still execute (allow / require_approval) and
+    // as a pure peek for dry-run. A deny-breach is terminal even under a
+    // require_approval rule — the money gate forbids what the approver would
+    // be asked to allow, and this release only ships on_exceed: deny.
+    let budgetsBlock: Array<Record<string, unknown>> | undefined
+    let budgetDryRunOk = true
+    let budgetDenial: { breached: string[]; invalid: string[] } | undefined
+    if (
+      this.budgetEngine &&
+      (wire === 'allow' || wire === 'require_approval' || wire === 'dry_run')
+    ) {
+      const { charges, failures } = this.budgetEngine.resolveCharges({
+        toolName,
+        toolArguments: req.arguments,
+        sessionId: req.session_id,
+        senderId,
+      })
+
+      if (charges.length > 0 || failures.length > 0) {
+        // Peek the valid charges even when failures deny the call: the
+        // response must show every failure AND every simultaneous breach.
+        const peek =
+          charges.length > 0
+            ? this.budgetEngine.peekAll(charges)
+            : { allowed: true, entries: [] as BudgetPeekEntry[] }
+        budgetsBlock = [
+          ...peek.entries.map((entry) => budgetWireBlock(entry)),
+          ...failures.map((failure) => budgetFailureBlock(failure)),
+        ]
+
+        if (failures.length > 0 || !peek.allowed) {
+          budgetDryRunOk = false
+          if (wire !== 'dry_run') {
+            releaseReservations()
+            plans.length = 0
+            wire = 'budget_exceeded'
+            budgetDenial = {
+              breached: peek.entries
+                .filter((entry) => !entry.allowed)
+                .map((entry) => entry.budget.name),
+              invalid: failures.map((failure) => failure.budget.name),
+            }
+          }
+        } else if (wire !== 'dry_run') {
+          for (const charge of charges) {
+            if (!reserve(charge.bucketKey)) {
+              releaseReservations()
+              return { status: 503, body: { error: 'limit_capacity_exhausted' } }
+            }
+            plans.push({
+              kind: 'budget',
+              budget: charge.budget,
+              bucketKey: charge.bucketKey,
+              amount: charge.amount,
+              generation: charge.generation,
+            })
+          }
+        }
+      }
+    }
+    if (budgetsBlock) {
+      limitsBlock = { ...(limitsBlock ?? {}), budgets: budgetsBlock }
     }
 
     const matchedRuleName = decision.matchedRule?.name ?? null
@@ -422,12 +541,27 @@ export class GovernanceService {
     if (shouldAttachFeedback(wire, decision)) {
       responseBody['feedback'] = buildFeedback(decision.matchedRule, decision.reason)
     }
+    if (wire === 'budget_exceeded' && budgetDenial) {
+      // Budget-specific by design: the matched rule's feedback (and the
+      // decision reason, which may literally say the call was allowed)
+      // describes the RULE, not the budget that denied the call.
+      responseBody['feedback'] = {
+        message:
+          budgetDenial.invalid.length > 0
+            ? `Budget ${budgetDenial.invalid.map((n) => `"${n}"`).join(', ')} could not read a valid spend amount from this call`
+            : `Budget ${budgetDenial.breached.map((n) => `"${n}"`).join(', ')} would be exceeded by this call`,
+        suggestion:
+          budgetDenial.invalid.length > 0
+            ? 'Retry with a non-negative finite amount in the expected field.'
+            : 'Wait for the window to reset or reduce the amount.',
+      }
+    }
     if (limitsBlock) responseBody['limits'] = limitsBlock
     if (wire === 'dry_run') {
       responseBody['dry_run'] = {
-        would_forward: decision.action === 'allow' && !pipeline.evidenceBlocked,
+        would_forward: decision.action === 'allow' && !pipeline.evidenceBlocked && budgetDryRunOk,
         evidence_satisfied: !pipeline.evidenceBlocked,
-        limits_ok: true,
+        limits_ok: budgetDryRunOk,
       }
     }
     if (pipeline.driftEvent) {
@@ -460,6 +594,18 @@ export class GovernanceService {
         expiresAtMs: this.now() + this.ttlMs,
       })
       return { status: 200, body: responseBody }
+    }
+
+    // The admission check above ran before planning; the plans list (and its
+    // caller-influenced bucket keys) is part of the entry's real footprint,
+    // so re-check the byte cap with it counted BEFORE creating any approval
+    // ticket — a late refusal must not leave an orphaned native ticket
+    // (amended per implementation review). Over the cap → release this
+    // call's sender reservations and refuse.
+    const totalBytes = entryBytes + planBytes(plans)
+    if (this.pendingBytes + totalBytes > this.maxPendingBytes) {
+      releaseReservations()
+      return { status: 503, body: { error: 'evaluation_backlog_full' } }
     }
 
     // allow / require_approval → pending entry awaiting /audit.
@@ -507,16 +653,16 @@ export class GovernanceService {
       matchedRuleName,
       matchedRuleIndex,
       flaggedDestructive: pipeline.flaggedDestructive,
-      limitPlan,
+      plans,
       approvalTicketId,
       timestampIso,
       createdAtMs: this.now(),
       evaluationExpiresAtMs: this.now() + this.ttlMs,
       ticketTimeoutAtMs,
-      bytes: entryBytes,
+      bytes: totalBytes,
     }
     this.pending.set(evaluationId, entry)
-    this.pendingBytes += entryBytes
+    this.pendingBytes += totalBytes
     if (approvalTicketId) this.ticketToEvaluation.set(approvalTicketId, evaluationId)
 
     return { status: 200, body: responseBody }
@@ -603,17 +749,39 @@ export class GovernanceService {
       if (!Number.isFinite(req.actual_amount) || req.actual_amount < 0) {
         return { status: 400, body: { error: 'invalid_actual_amount' } }
       }
-      if (entry.limitPlan?.kind !== 'spend') {
+      // The override applies to anything that tracks this call's money: the
+      // spend-rule plan and every budget plan (a call has one true cost).
+      const hasMoneyPlan = entry.plans.some(
+        (plan) => plan.kind === 'spend' || plan.kind === 'budget',
+      )
+      if (!hasMoneyPlan) {
         return { status: 400, body: { error: 'no_spend_rule' } }
       }
     }
 
     const callHappened = req.status === 'success' || req.status === 'error'
 
-    // Consume limit counters now — only when the call actually executed.
-    let limitsChain: Record<string, unknown> | undefined
-    if (callHappened && entry.limitPlan) {
-      limitsChain = this.commitLimit(entry.limitPlan, req.actual_amount)
+    // Pre-generated so budget ledger rows can reference the audit record; a
+    // retry after a post-commit failure reuses the latched id so the rows
+    // already written keep pointing at the record that finally lands.
+    // A post-commit retry must present the SAME payload the commit ran with;
+    // anything else would finalize an audit row inconsistent with the
+    // committed amounts (same contract as the tombstone replay path).
+    if (entry.commitState && entry.commitState.payloadHash !== payloadHash) {
+      return { status: 409, body: { error: 'evaluation_conflict' } }
+    }
+
+    const auditId = entry.commitState?.auditId ?? randomUUID()
+
+    // Consume limit counters now — only when the call actually executed. All
+    // plans of the call commit together. A budget ledger failure throws out
+    // of audit() BEFORE the latch is set, so the retry re-attempts the whole
+    // commit; any failure AFTER the latch (evidence, audit write) makes the
+    // retry skip straight past the commit — exactly-once either way.
+    let limitsChain = entry.commitState?.limitsChain
+    if (callHappened && entry.plans.length > 0 && !entry.commitState) {
+      limitsChain = this.commitPlans(entry, req.actual_amount, auditId)
+      entry.commitState = { auditId, limitsChain, payloadHash }
     }
 
     // Record the tool call for evidence/dependency tracking.
@@ -628,7 +796,8 @@ export class GovernanceService {
     // would be worse than a dropped evidence entry.
     const evidenceOutcomes = this.populateEvidence(req, entry)
 
-    const auditId = this.writeAudit({
+    this.writeAudit({
+      id: auditId,
       timestampIso: entry.timestampIso,
       origin: entry.origin,
       agentId: entry.agentId,
@@ -965,7 +1134,7 @@ export class GovernanceService {
    * closed, so an emptied bucket frees its slot without waiting for the sweep.
    */
   private reserveSenderKey(key: string): boolean {
-    if (!key.startsWith('sender:')) return true
+    if (!isSenderScopedKey(key)) return true
     if (this.senderKeys.has(key)) return true
     if (this.hasLiveBucket(key)) {
       this.senderKeys.add(key)
@@ -984,8 +1153,9 @@ export class GovernanceService {
     if (this.senderKeys.size === 0) return
     const inUse = new Set<string>()
     for (const entry of this.pending.values()) {
-      if (entry.limitPlan && entry.limitPlan.key.startsWith('sender:')) {
-        inUse.add(entry.limitPlan.key)
+      for (const plan of entry.plans) {
+        const key = plan.kind === 'budget' ? plan.bucketKey : plan.key
+        if (isSenderScopedKey(key)) inUse.add(key)
       }
     }
     for (const key of this.senderKeys) {
@@ -1003,7 +1173,8 @@ export class GovernanceService {
   private hasLiveBucket(key: string): boolean {
     return (
       this.rateLimiter?.getKeyState(key) !== undefined ||
-      this.spendLimiter?.getKeyState(key) !== undefined
+      this.spendLimiter?.getKeyState(key) !== undefined ||
+      this.budgetEngine?.hasBucket(key) === true
     )
   }
 
@@ -1172,51 +1343,95 @@ export class GovernanceService {
     }
   }
 
-  /** Commit a limit plan at /audit time and return the evidence_chain block. */
-  private commitLimit(
-    plan: LimitPlan,
+  /** Commit every plan of one call at /audit time; returns the chain blocks. */
+  private commitPlans(
+    entry: PendingEvaluation,
     actualAmount: number | undefined,
+    auditId: string,
   ): Record<string, unknown> | undefined {
-    if (plan.kind === 'rate' && this.rateLimiter && plan.limits.maxCalls && plan.limits.windowMs) {
-      const r = this.rateLimiter.record({
-        key: plan.key,
-        maxCalls: plan.limits.maxCalls,
-        windowMs: plan.limits.windowMs,
-      })
-      return {
-        rate_limit: {
-          allowed: r.allowed,
-          current: r.current,
-          limit: r.limit,
-          window_ms: r.windowMs,
-          reset_at_ms: r.resetAtMs,
+    let chain: Record<string, unknown> | undefined
+
+    // The fallible budget ledger commits FIRST: a throw here propagates out
+    // of audit() with the entry still pending and NO limiter state consumed,
+    // so the adapter's idempotent retry cannot double-record rate/spend.
+    const budgetPlans = entry.plans.filter((plan): plan is BudgetPlan => plan.kind === 'budget')
+    if (budgetPlans.length > 0 && this.budgetEngine) {
+      // actual_amount, when supplied, is the call's one true realized cost
+      // and overrides every budget plan amount.
+      const snapshots = this.budgetEngine.recordAll(
+        budgetPlans.map((plan) => ({
+          budget: plan.budget,
+          bucketKey: plan.bucketKey,
+          amount: actualAmount ?? plan.amount,
+          generation: plan.generation,
+        })),
+        {
+          kind: 'spend',
+          auditRecordId: auditId,
+          origin: entry.origin,
+          toolName: entry.toolName,
+          timestampIso: new Date(this.now()).toISOString(),
         },
+      )
+      chain = {
+        ...(chain ?? {}),
+        budgets: snapshots.map((snapshot) => budgetWireBlock(snapshot, 'spend')),
       }
     }
-    if (plan.kind === 'spend' && this.spendLimiter && plan.limits.maxSpend) {
-      const amount = actualAmount ?? plan.amount ?? 0
-      const r = this.spendLimiter.record({
-        key: plan.key,
-        amount,
-        limit: plan.limits.maxSpend.limit,
-        windowMs: plan.limits.maxSpend.windowMs,
-      })
-      this.spendLimiter.setCurrency(plan.key, plan.limits.maxSpend.currency)
-      return {
-        spend_limit: {
-          allowed: r.allowed,
-          current_spend: r.currentSpend,
-          limit: r.limit,
-          window_ms: r.windowMs,
-          reset_at_ms: r.resetAtMs,
-        },
+
+    for (const plan of entry.plans) {
+      if (plan.kind === 'budget') {
+        continue
+      }
+      if (
+        plan.kind === 'rate' &&
+        this.rateLimiter &&
+        plan.limits.maxCalls &&
+        plan.limits.windowMs
+      ) {
+        const r = this.rateLimiter.record({
+          key: plan.key,
+          maxCalls: plan.limits.maxCalls,
+          windowMs: plan.limits.windowMs,
+        })
+        chain = {
+          ...(chain ?? {}),
+          rate_limit: {
+            allowed: r.allowed,
+            current: r.current,
+            limit: r.limit,
+            window_ms: r.windowMs,
+            reset_at_ms: r.resetAtMs,
+          },
+        }
+      }
+      if (plan.kind === 'spend' && this.spendLimiter && plan.limits.maxSpend) {
+        const amount = actualAmount ?? plan.amount ?? 0
+        const r = this.spendLimiter.record({
+          key: plan.key,
+          amount,
+          limit: plan.limits.maxSpend.limit,
+          windowMs: plan.limits.maxSpend.windowMs,
+        })
+        this.spendLimiter.setCurrency(plan.key, plan.limits.maxSpend.currency)
+        chain = {
+          ...(chain ?? {}),
+          spend_limit: {
+            allowed: r.allowed,
+            current_spend: r.currentSpend,
+            limit: r.limit,
+            window_ms: r.windowMs,
+            reset_at_ms: r.resetAtMs,
+          },
+        }
       }
     }
-    return undefined
+
+    return chain
   }
 
   private writeAudit(args: WriteAuditArgs): string {
-    const id = randomUUID()
+    const id = args.id ?? randomUUID()
     if (!this.auditWriter) return id
 
     const blockReason = deriveBlockReason(args)
@@ -1282,6 +1497,8 @@ export class GovernanceService {
 // ---------------------------------------------------------------------------
 
 interface WriteAuditArgs {
+  /** Caller-supplied record id (pre-allocated when ledger rows reference it). */
+  id?: string
   timestampIso: string
   origin: string
   agentId: string | null
@@ -1322,6 +1539,8 @@ function deriveBlockReason(args: WriteAuditArgs): string | null {
       return 'rate_limited'
     case 'spend_limited':
       return 'spend_limited'
+    case 'budget_exceeded':
+      return 'budget_exceeded'
     default:
       return null
   }
@@ -1337,7 +1556,12 @@ function buildFeedback(
 }
 
 function isBlocking(wire: WireDecision): boolean {
-  return wire === 'deny' || wire === 'rate_limited' || wire === 'spend_limited'
+  return (
+    wire === 'deny' ||
+    wire === 'rate_limited' ||
+    wire === 'spend_limited' ||
+    wire === 'budget_exceeded'
+  )
 }
 
 /**
@@ -1357,7 +1581,11 @@ function shouldAttachFeedback(
 
 function isTerminalAtEvaluate(wire: WireDecision): boolean {
   return (
-    wire === 'deny' || wire === 'rate_limited' || wire === 'spend_limited' || wire === 'dry_run'
+    wire === 'deny' ||
+    wire === 'rate_limited' ||
+    wire === 'spend_limited' ||
+    wire === 'budget_exceeded' ||
+    wire === 'dry_run'
   )
 }
 
@@ -1444,3 +1672,71 @@ function byteLength(value: unknown): number {
 
 /** Drift changes are re-exported for the route layer's response typing. */
 export type { ToolDriftChange }
+
+/**
+ * Whether a limiter/budget bucket key is scoped to a caller-minted sender id
+ * and therefore consumes a sender-cardinality slot. Budget names are
+ * charset-constrained (no ":"), so the prefix parse is unambiguous.
+ */
+function isSenderScopedKey(key: string): boolean {
+  if (key.startsWith('sender:')) return true
+  if (!key.startsWith('budget:')) return false
+  const scope = key.slice('budget:'.length)
+  const sep = scope.indexOf(':')
+  return sep !== -1 && scope.slice(sep + 1).startsWith('sender:')
+}
+
+/** Wire block for one budget's view of a call (epoch-ms reset, limiter idiom). */
+function budgetWireBlock(
+  entry: BudgetPeekEntry,
+  kind?: 'spend' | 'approved_overage',
+): Record<string, unknown> {
+  return {
+    ...(kind ? { kind } : {}),
+    name: entry.budget.name,
+    limit: entry.budget.limit,
+    spent: entry.spent,
+    remaining: entry.remaining,
+    attempted_amount: entry.amount,
+    currency: entry.budget.currency,
+    window: entry.budget.windowRaw,
+    on_exceed: entry.budget.onExceed,
+    allowed: entry.allowed,
+    reset_at_ms: entry.resetAtMs,
+    ...(entry.stale ? { stale: true } : {}),
+  }
+}
+
+/** Wire block for a fail-closed invalid-amount contributor (real snapshot). */
+function budgetFailureBlock(failure: BudgetChargeFailure): Record<string, unknown> {
+  return {
+    name: failure.budget.name,
+    limit: failure.budget.limit,
+    spent: failure.spent,
+    remaining: failure.remaining,
+    attempted_amount: null,
+    currency: failure.budget.currency,
+    window: failure.budget.windowRaw,
+    on_exceed: failure.budget.onExceed,
+    allowed: false,
+    reason: 'invalid_amount',
+    reset_at_ms: failure.resetAtMs,
+  }
+}
+
+/**
+ * Byte footprint of a pending entry's plans for admission accounting. Plans
+ * hold compiled objects (matcher functions), so serialize a projection of the
+ * caller-influenced parts instead of the plan itself.
+ */
+function planBytes(plans: readonly Plan[]): number {
+  let total = 0
+  for (const plan of plans) {
+    total += byteLength(
+      plan.kind === 'budget'
+        ? { kind: plan.kind, name: plan.budget.name, key: plan.bucketKey, amount: plan.amount }
+        : { kind: plan.kind, key: plan.key, amount: plan.amount ?? 0 },
+    )
+  }
+  return total
+}

--- a/packages/proxy/src/upstream/e2e.test.ts
+++ b/packages/proxy/src/upstream/e2e.test.ts
@@ -61,6 +61,7 @@ function makeConfig(upstreamUrl: string): HelioConfig {
       include_responses: true,
     },
     sdk: { enabled: false, port: 3200, host: '127.0.0.1', evaluation_ttl: '10m' },
+    budgets: [],
   } as HelioConfig
 }
 


### PR DESCRIPTION
## What

The first implementation slice of named budgets (#14): a first-class `budgets:` config layer, independent of policy rules, enforced deterministically at the MCP gate and best-effort on the host-enforced sideband tier.

**Config.** A `budgets:` section (placed beside `policies` — it is the second half of the governance declaration) defines named pots: `limit`/`currency`, sliding duration windows or `session` pots that never replenish (idle-collected after `idle_ttl`), scoped `global`, per `session`, or per adapter `sender_id`, fed by `contributors` (tool glob + amount field). `on_exceed` accepts only `deny` in this slice; break-glass approvals come next in the train. Validation: unique charset-constrained names, session-window/key coupling, sideband gate for sender scoping. Budgets hot-reload by name identity: contributor edits preserve accrued spend; `limit`/`currency`/`window`/`key` changes reset the pot.

**MCP door.** `handleToolsCall` is restructured into synchronous gates with a single forward site: the per-action branches decide, the budget gate peeks every matching budget all-or-nothing, and commits happen with no interleaving point before the forward (two concurrent calls cannot double-spend the last slot — regression-tested with `Promise.all`). Rule rate/spend limits moved from consume-at-check to peek-at-gate/record-at-forward, so a call a later gate blocks consumes nothing. The fallible budget ledger commits before rule counters and blocks with `budget_ledger_write_failed` on failure.

**Sideband door.** The single `limitPlan` generalizes to a plan list. Budget breaches are terminal at `/evaluate` with a new `budget_exceeded` decision (a normative adapter requirement now pins unknown decisions as deny; the fielded openclaw 0.1.0 already fails closed). Charges are generation-stamped: in-flight calls that outlive a tuple-changing reload still ledger under their evaluate-time generation but cannot repopulate the reset pot. `/audit` commits are exactly-once via a commit latch with payload-conflict detection (`409 evaluation_conflict` on a divergent retry). Pending-entry byte accounting now covers the plans list and all stored caller-controlled strings, which gained route caps.

**Surfaces.** Budget denials return budget-specific self-repair feedback (`reason: budget_exceeded`, per-budget breakdown with real bucket snapshots); audit rows carry `evidence_chain.budgets` and the new block reason; the dashboard renders Budget Exceeded (outcome, filters, badge) instead of falling through to Allow.

Engine state is in-memory in this slice; SQLite persistence and the spend ledger tables, break-glass, and the Budgets dashboard view follow in the next PRs of the train.

## Review

Four external review rounds on the implementation (three REQUEST-CHANGES, final pass verified); the load-bearing findings — an await-induced peek/record race, commit ordering against the fallible ledger, stale-generation accounting, exactly-once retries — are fixed with dedicated regression tests.

## Testing

TDD throughout. 1,834 proxy + 309 dashboard + 47 python-sdk tests, including: multi-budget atomicity (one denies → nothing recorded anywhere), concurrent last-slot races on both gates, cross-door shared pot, watcher-to-engine reconciliation (benign, tuple-changing, and invalid reloads), session pots and idle GC, sideband TOCTOU pin, ledger-failure fail-closed paths, and an end-to-end HTTP budget depletion flow.

Part of #14.