### PR TITLE
feat(budgets): persist spend to a ledger and replay on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,27 @@ Maintainer notes:
   `/audit` only when the call executed. Budgets hot-reload by name identity:
   contributor edits preserve accrued spend; `limit`/`currency`/`window`
   changes reset it. `on_exceed: deny` is the only breach mode in this
-  release; break-glass approvals, persistence, and the dashboard Budgets view
-  land next in this release train. State is in-memory for now.
+  release; break-glass approvals and the dashboard Budgets view land next in
+  this release train.
+- **Budget spend persists across restarts (#14).** Every budget charge is
+  written to a ledger in the audit database — synchronously, in one
+  transaction per call, at record time — and replayed at startup: duration
+  windows resume mid-window exactly where they left off, and `session` pots
+  still within their `idle_ttl` come back with their full accrued spend.
+  Config identity extends across restarts: a
+  `limit`/`currency`/`window`/`key` change while the proxy was down resets
+  the pot instead of replaying, matching hot-reload semantics, and a removal
+  the proxy observes (live, or at a startup without the budget) retires the
+  spend so a later re-add starts fresh. Ledger writes fail closed per door:
+  the MCP door blocks the call before forwarding, with
+  `failure_class: budget_ledger_write_failed` in the error feedback and the
+  same value as the audit record's `block_reason`, consuming no counters;
+  the sideband door fails the `/audit` report and keeps the evaluation
+  pending, so nothing is counted unless the adapter's idempotent retry
+  lands the write. Ledger rows follow `audit.retention` on the audit
+  store's existing sweep, and a budget window longer than the retention
+  draws a startup warning. Rule-level rate/spend limit buckets remain
+  in-memory and still reset on restart.
 
 ### Fixed
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -113,9 +113,21 @@ audit:
 
 **Indexes** are created on `created_at`, `tool_name`, `policy_decision`, `block_reason`, `session_id`, `record_kind`, and `origin` for fast queries, plus a composite `(upstream_http_status, created_at)` index for upstream status rollups and status-over-time alert queries.
 
+### Budget Ledger Tables
+
+Named budgets ([configuration reference](./configuration.md#budgets)) persist their spend in the same database file, in three tables the budget ledger owns:
+
+- **`budget_events`** — one row per committed charge. Columns: `id` (UUID, primary key), `budget_name`, `epoch`, `bucket_key`, `kind` (`spend`, or `approved_overage` once break-glass approvals ship later in this release train), `amount`, `currency`, `tool_name`, `origin` (`mcp` or the adapter origin), `audit_record_id` (the pre-generated id of the call's audit record; no foreign key), `timestamp` (ISO 8601 event time), `timestamp_ms` (the same instant in epoch milliseconds — the axis every replay and retention query uses), and `created_at` (insert time). Every charge of one call is written in a single synchronous transaction at record time, so the ledger can never disagree with the in-memory pots about money. Record time differs per door: the MCP proxy commits before forwarding, so a failed ledger write there blocks the call itself (`block_reason: budget_ledger_write_failed`) without consuming any counters; the sideband commits at `/audit`, after the host already executed the call, so a failed write there fails the `/audit` report and the adapter's idempotent retry re-attempts the commit — again with nothing counted until the write lands.
+- **`budget_meta`** — one small row per budget name: the config identity tuple (`limit_amount`, `currency`, `window`, `key`), the `epoch` counter, and `updated_at`. A change the proxy observes — a tuple edit or a removal, live via hot-reload or discovered at startup — bumps the epoch and resets the pot; rows from older epochs stay queryable as history but are never replayed.
+- **`budget_bucket_gc`** — idle-collection watermarks for session pots (`budget_name` + `bucket_key` primary key, `gc_after_ms`), so a session key that reappears after its pot was collected does not re-absorb pre-collection spend on the next restart.
+
+Two indexes serve the hot paths: `idx_budget_events_replay` on `(budget_name, epoch, bucket_key, timestamp_ms)` for startup replay, and `idx_budget_events_timestamp_ms` for the retention sweep. The schema is validated at startup against the canonical definition — names, types, constraints, and keys — under the same clean-break policy as the audit table.
+
+At startup the engine replays the ledger: duration windows rebuild from the rows inside the window (equivalent to never having restarted), and `window: session` pots rebuild from their lifetime sums if their last activity is within `idle_ttl`. Ledger rows may reference an audit record that is still in the async writer buffer (or was lost to a crash): the ledger is the source of truth for spend, the audit table for calls.
+
 ### Local Schema Resets (Pre-1.0)
 
-Helio currently uses a clean-break local schema policy for the audit SQLite file. If startup reports an audit schema mismatch (for example after pulling a new build that introduces a required column), reset local audit files and restart:
+Helio currently uses a clean-break local schema policy for the audit SQLite file, covering the audit table and the budget ledger tables alike. If startup reports a schema mismatch (for example after pulling a new build that introduces a required column), reset local audit files and restart:
 
 ```bash
 rm helio-audit.db helio-audit.db-wal helio-audit.db-shm
@@ -268,8 +280,11 @@ audit:
 - Records older than the retention period are permanently deleted.
 - Cleanup runs automatically every 24 hours and at proxy startup.
 - Set a larger value (e.g. `365d`) if you need longer retention.
+- The same sweep purges budget ledger events older than the retention cutoff and prunes idle-collection watermarks that no longer guard any surviving row, so `budget_events` and `budget_bucket_gc` stay bounded by the retention window. `budget_meta` is not swept: it keeps one small row per budget name the proxy has ever seen configured, because the epoch history is what keeps retired spend retired.
 
 > **Note:** Retention cleanup is irreversible. If you need permanent audit records, export them before they expire or set retention to a very large value.
+
+> **Bound:** a `window: session` budget pot that stays continuously active for longer than the retention period loses its oldest ledger rows to the sweep, so a restart after that point under-counts its lifetime spend. With the 90-day default this is a theoretical bound, not an expected operating mode. The same bound applies to a duration window (or a session `idle_ttl`) configured **longer** than `audit.retention` — that combination can forget in-window spend on every restart, so Helio logs a startup warning for it.
 
 ## Performance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -252,7 +252,9 @@ budgets:
 
 Validation: budget names must be unique; `window: session` requires `key: session` or `key: sender_id`; `idle_ttl` is only valid with `window: session`; `key: sender_id` requires `sdk.enabled: true`. A matched contributor whose amount field is missing, non-numeric, negative, or non-finite fails closed — the call is denied.
 
-Budget state lives in buckets keyed `budget:<name>:<scope>` — visible in audit records' `evidence_chain.budgets`. Budgets hot-reload by name identity: edits to `contributors` preserve accrued spend (they do not change what was already spent), while a change to `limit`, `currency`, `window`, or `key` resets the budget's buckets (a different pool or scope structure). Budget state is in-memory in this release; persistence and a spend ledger are planned.
+Budget state lives in buckets keyed `budget:<name>:<scope>` — visible in audit records' `evidence_chain.budgets`. Budgets hot-reload by name identity: edits to `contributors` preserve accrued spend (they do not change what was already spent), while a change to `limit`, `currency`, `window`, or `key` resets the budget's buckets (a different pool or scope structure).
+
+Budget spend **persists across restarts**: every charge is written to a ledger in the audit database (see [Budget Ledger Tables](./audit.md#budget-ledger-tables)) synchronously at record time, and startup replays it — duration windows resume mid-window exactly where they left off, and `session` pots whose last activity is within `idle_ttl` come back with their full accrued spend. The reset rules above extend across restarts: if the `limit`/`currency`/`window`/`key` tuple in the config differs from what the ledger last saw, the pot starts fresh instead of replaying, and a removal the proxy observes — live via hot-reload, or discovered at a startup without the budget — retires the accrued spend, so re-adding the budget later starts fresh even with an identical tuple. Ledger rows follow `audit.retention` on the audit store's sweep schedule; configuring a budget window (or session `idle_ttl`) longer than the retention draws a startup warning, because the sweep would forget in-window spend across restarts. Unlike budgets, rule-level rate/spend limit buckets remain in-memory and reset on restart.
 
 ### approval
 
@@ -434,10 +436,10 @@ On successful reload:
 [helio] Policy reloaded: 5 rules (default: allow)
 ```
 
-If the new configuration is invalid, Helio keeps the current policy and logs the error:
+If the new configuration is invalid — or its budget epoch changes cannot be durably recorded — Helio rejects the reload as a whole, keeps the complete current configuration (policy rules and budgets alike), and logs the error:
 
 ```
-[helio] Config reload failed (keeping current policy): YAML parse error in helio.yaml: ...
+[helio] Config reload failed (keeping current configuration): YAML parse error in helio.yaml: ...
 ```
 
 ### Limit reconciliation
@@ -446,7 +448,7 @@ Rate and spend limit buckets survive a hot-reload as long as their underlying ru
 
 Spend bucket keys carry a `:rule:<index>` suffix (for example `session:abc:rule:2`), so two `spend_limit` rules that share a scope — say, two session-keyed rules — track their spend in separate buckets instead of silently sharing one with last-write-wins config. The suffixed keys are what you see in `GET /api/limits`, `limit_warning` events, and denial messages. Rate bucket keys are unchanged. For suffixed keys, reconciliation matches the tuple at the bucket's own rule index: an edit that shifts a spend rule's position (inserting or removing a rule above it, or reordering) evicts its bucket and the rule starts a fresh window — accrued spend does not follow a rule to its new position. Two caveats: swapping two spend rules with identical `limit`/`currency`/`window` keeps each bucket at its position, so the rules exchange accrued spend; and a sideband call evaluated before a reload commits its spend (at `/audit`) into the bucket keyed at evaluation time, which may be a just-evicted label.
 
-> **Note:** Limit state is reconciled, not persisted. Restarting the proxy still clears all buckets. Persistence across restarts is planned for a later release.
+> **Note:** Rule-level limit state is reconciled, not persisted — restarting the proxy clears rate/spend rule buckets. Named budgets are different: their spend persists across restarts via the budget ledger (see [budgets](#budgets)).
 
 ### Disabling hot reload
 

--- a/packages/proxy/src/audit/index.ts
+++ b/packages/proxy/src/audit/index.ts
@@ -1,4 +1,5 @@
 export { AuditStore, EXPORT_MAX_RECORDS, LIST_MAX_PAGE_SIZE } from './store.js'
+export type { RetentionSweepCutoff } from './store.js'
 export { AuditWriter } from './writer.js'
 export type { AuditWriterOptions } from './writer.js'
 export type {

--- a/packages/proxy/src/audit/store.test.ts
+++ b/packages/proxy/src/audit/store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, rmSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -896,6 +896,63 @@ CREATE TABLE IF NOT EXISTS audit_records (
       store.insert(makeRecord(), '2019-12-01T00:00:00.000Z')
       const deleted = store.purgeExpired()
       expect(deleted).toBe(3)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Retention sweep hooks (issue #14 — budget ledger co-residence)
+  // -------------------------------------------------------------------------
+
+  describe('runRetentionSweep', () => {
+    it('purges expired audit records like purgeExpired', () => {
+      store.insert(makeRecord(), '2020-01-01T00:00:00.000Z')
+      store.insert(makeRecord()) // recent
+      store.runRetentionSweep()
+      expect(store.count()).toBe(1)
+    })
+
+    it('fires registered hooks with the sweep cutoff in both spellings', () => {
+      const cutoffs: Array<{ iso: string; ms: number }> = []
+      store.onRetentionSweep((cutoff) => {
+        cutoffs.push(cutoff)
+      })
+
+      const before = Date.now()
+      store.runRetentionSweep()
+      const after = Date.now()
+
+      expect(cutoffs).toHaveLength(1)
+      const cutoff = cutoffs[0]
+      if (!cutoff) throw new Error('hook did not fire')
+      // retention is 90d in this store; the cutoff is now - retention,
+      // computed once per sweep and shared with every hook.
+      const retentionMs = 90 * 24 * 60 * 60 * 1000
+      expect(cutoff.ms).toBeGreaterThanOrEqual(before - retentionMs)
+      expect(cutoff.ms).toBeLessThanOrEqual(after - retentionMs)
+      expect(cutoff.iso).toBe(new Date(cutoff.ms).toISOString())
+    })
+
+    it('isolates a throwing hook: the purge and other hooks still run', () => {
+      const seen: string[] = []
+      store.onRetentionSweep(() => {
+        seen.push('first')
+        throw new Error('hook bug')
+      })
+      store.onRetentionSweep(() => {
+        seen.push('second')
+      })
+      store.insert(makeRecord(), '2020-01-01T00:00:00.000Z')
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => {
+          store.runRetentionSweep()
+        }).not.toThrow()
+      } finally {
+        errorSpy.mockRestore()
+      }
+      expect(seen).toEqual(['first', 'second'])
+      expect(store.count()).toBe(0)
     })
   })
 

--- a/packages/proxy/src/audit/store.ts
+++ b/packages/proxy/src/audit/store.ts
@@ -298,6 +298,16 @@ function restrictAuditFilePerms(dbPath: string): void {
 // ---------------------------------------------------------------------------
 
 /**
+ * The retention cutoff of one sweep, computed once and shared with every
+ * registered hook: `iso` for `created_at`-style string comparisons, `ms`
+ * for epoch-millisecond columns.
+ */
+export interface RetentionSweepCutoff {
+  readonly iso: string
+  readonly ms: number
+}
+
+/**
  * SQLite-backed audit record store.
  *
  * All read/write operations are synchronous (better-sqlite3 design).
@@ -308,6 +318,7 @@ export class AuditStore {
   private readonly insertStmt: Statement
   private readonly retentionMs: number
   private readonly includeResponses: boolean
+  private readonly retentionSweepHooks: Array<(cutoff: RetentionSweepCutoff) => void> = []
   private cleanupTimer: ReturnType<typeof setInterval> | null = null
 
   constructor(options: AuditStoreOptions) {
@@ -347,11 +358,54 @@ export class AuditStore {
     const intervalMs = options.cleanupIntervalMs ?? 86_400_000
     if (intervalMs > 0) {
       this.cleanupTimer = setInterval(() => {
-        this.purgeExpired()
+        this.runRetentionSweep()
         restrictAuditFilePerms(options.path)
       }, intervalMs)
       this.cleanupTimer.unref()
     }
+  }
+
+  /**
+   * Register a hook to run on every retention sweep, receiving the sweep's
+   * cutoff. This is how co-resident tables (the budget ledger) join the
+   * store's single sweep schedule instead of running their own timers.
+   * Hooks registered after construction miss the constructor's initial
+   * purge — call {@link runRetentionSweep} once after registering to cover
+   * rows that aged out while the process was down.
+   */
+  onRetentionSweep(fn: (cutoff: RetentionSweepCutoff) => void): void {
+    this.retentionSweepHooks.push(fn)
+  }
+
+  /**
+   * One full retention sweep: purge expired audit records, then fire every
+   * registered hook with the sweep's cutoff. Hook failures degrade to a
+   * logged error — a broken co-resident purge must not stop the audit
+   * table's own retention.
+   */
+  runRetentionSweep(): void {
+    const ms = Date.now() - this.retentionMs
+    const cutoff: RetentionSweepCutoff = { iso: new Date(ms).toISOString(), ms }
+    this.purgeBefore(cutoff.iso)
+    for (const hook of this.retentionSweepHooks) {
+      try {
+        hook(cutoff)
+      } catch (err) {
+        // eslint-disable-next-line no-console -- Intentional operational warning
+        console.error('[helio] retention sweep hook failed:', err)
+      }
+    }
+  }
+
+  /**
+   * Package-internal: the store's open database handle, for components that
+   * co-locate their tables in the audit db (the budget ledger). Sharing the
+   * handle keeps one connection, one WAL domain, and one file-permission
+   * hardening pass. Not part of the public embedding API — do not re-export
+   * anything built on this from the package root.
+   */
+  get database(): DatabaseType {
+    return this.db
   }
 
   /**
@@ -633,8 +687,11 @@ export class AuditStore {
 
   /** Delete records older than the retention period. Returns the count of deleted records. */
   purgeExpired(): number {
-    const cutoff = new Date(Date.now() - this.retentionMs).toISOString()
-    const result = this.db.prepare('DELETE FROM audit_records WHERE created_at < ?').run(cutoff)
+    return this.purgeBefore(new Date(Date.now() - this.retentionMs).toISOString())
+  }
+
+  private purgeBefore(cutoffIso: string): number {
+    const result = this.db.prepare('DELETE FROM audit_records WHERE created_at < ?').run(cutoffIso)
     return result.changes
   }
 

--- a/packages/proxy/src/budget/engine.test.ts
+++ b/packages/proxy/src/budget/engine.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
+import Database from 'better-sqlite3'
 import { BudgetEngine } from './engine.js'
-import type { BudgetCommitEvent, BudgetLedgerSink } from './engine.js'
+import type { BudgetCommitEvent, BudgetLedgerSink, BudgetPersistence } from './engine.js'
+import { BudgetLedger } from './ledger.js'
 import { compileBudgets } from './parser.js'
 import type { BudgetConfig } from '../config/schema.js'
 
@@ -672,5 +674,682 @@ describe('BudgetEngine read surface', () => {
     )
     engine.close()
     expect(engine.listStates().flatMap((s) => s.buckets)).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Persistence — hydrate / epoch / GC watermarks (PR 2)
+// ---------------------------------------------------------------------------
+
+/** A real-ledger delegate with selective overrides (fault injection). */
+function delegatingPersistence(
+  ledger: BudgetLedger,
+  overrides: Partial<BudgetPersistence> = {},
+): BudgetPersistence {
+  return {
+    commitAll: (rows) => {
+      ledger.commitAll(rows)
+    },
+    readMeta: (name) => ledger.readMeta(name),
+    readAllMeta: () => ledger.readAllMeta(),
+    writeMeta: (meta) => {
+      ledger.writeMeta(meta)
+    },
+    writeMetaBatch: (metas) => {
+      ledger.writeMetaBatch(metas)
+    },
+    maxEventEpoch: (name) => ledger.maxEventEpoch(name),
+    replayDurationEvents: (name, epoch, since) => ledger.replayDurationEvents(name, epoch, since),
+    replaySessionBuckets: (name, epoch) => ledger.replaySessionBuckets(name, epoch),
+    recordBucketGc: (name, key, gcAfter) => {
+      ledger.recordBucketGc(name, key, gcAfter)
+    },
+    ...overrides,
+  }
+}
+
+/**
+ * A restartable harness: one SQLite ledger and one fake clock shared across
+ * engine "boots". Each boot() constructs a fresh engine on the same ledger
+ * and hydrates it — dropping the previous engine simulates a process death.
+ * An optional sink override per boot injects faults around the real ledger.
+ */
+function persistentHarness(initialTime = 1_000_000) {
+  const db = new Database(':memory:')
+  const clock = { time: initialTime }
+  const now = () => clock.time
+  const ledger = new BudgetLedger({ database: db, now })
+  const boot = (configs: BudgetConfig[], sink?: BudgetPersistence) => {
+    const engine = new BudgetEngine({
+      budgets: compileBudgets(configs),
+      now,
+      cleanupIntervalMs: 0,
+      ledger: sink ?? ledger,
+    })
+    engine.hydrate()
+    return engine
+  }
+  const advance = (ms: number) => {
+    clock.time += ms
+  }
+  return { boot, ledger, db, advance }
+}
+
+function spentAfterBoot(engine: BudgetEngine, amount = 1): number {
+  const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount }))
+  return engine.peekAll(charges).entries[0]?.spent ?? -1
+}
+
+describe('BudgetEngine persistence (PR 2)', () => {
+  it('writes a first-boot meta row at epoch 1', () => {
+    const { boot, ledger } = persistentHarness()
+    boot([budgetConfig()])
+    expect(ledger.readMeta('daily-cap')).toEqual({
+      budget_name: 'daily-cap',
+      limit_amount: 100,
+      currency: 'USD',
+      window: '24h',
+      key: 'global',
+      epoch: 1,
+    })
+  })
+
+  it('replays duration-window spend across a restart inside the window', () => {
+    const { boot, advance } = persistentHarness()
+    const first = boot([budgetConfig({ window: '1h' })])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    advance(1_800_000) // half the window
+    const second = boot([budgetConfig({ window: '1h' })])
+    expect(spentAfterBoot(second)).toBe(30)
+    // Sliding-window equivalence: the replayed entry keeps its original
+    // timestamp, so it ages out exactly when it would have without a restart.
+    advance(1_800_001)
+    expect(spentAfterBoot(second)).toBe(0)
+  })
+
+  it('replays nothing for a duration window when the whole window elapsed while down', () => {
+    const { boot, advance } = persistentHarness()
+    const first = boot([budgetConfig({ window: '1h' })])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    advance(3_600_001)
+    const second = boot([budgetConfig({ window: '1h' })])
+    expect(spentAfterBoot(second)).toBe(0)
+    expect(second.listStates().flatMap((s) => s.buckets)).toEqual([])
+  })
+
+  it('rebuilds separate buckets for a session-keyed duration budget', () => {
+    const config = budgetConfig({ window: '1h', key: 'session' as const })
+    const { boot, advance } = persistentHarness()
+    const first = boot([config])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 10 }, 's1')).charges,
+      COMMIT_META,
+    )
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 20 }, 's2')).charges,
+      COMMIT_META,
+    )
+
+    advance(60_000)
+    const second = boot([config])
+    const buckets = second.listStates().flatMap((s) => s.buckets)
+    expect(buckets.map((b) => [b.bucket_key, b.spent])).toEqual([
+      ['budget:daily-cap:session:s1', 10],
+      ['budget:daily-cap:session:s2', 20],
+    ])
+  })
+
+  it('rebuilds a live session pot with its full lifetime sum and last activity', () => {
+    const config = budgetConfig({
+      name: 'sc',
+      window: 'session',
+      key: 'session' as const,
+      idle_ttl: '1h',
+    })
+    const { boot, advance } = persistentHarness()
+    const first = boot([config])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 10 }, 's1')).charges,
+      COMMIT_META,
+    )
+    advance(30 * 60_000)
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 20 }, 's1')).charges,
+      COMMIT_META,
+    )
+
+    advance(30 * 60_000) // 30min idle < 1h TTL: still live
+    const second = boot([config])
+    const bucket = second.listStates()[0]?.buckets[0]
+    expect(bucket).toMatchObject({
+      bucket_key: 'budget:sc:session:s1',
+      spent: 30,
+      reset_at_ms: null,
+      last_activity_ms: 1_000_000 + 30 * 60_000,
+    })
+  })
+
+  it('does not rebuild a session pot idle past its TTL', () => {
+    const config = budgetConfig({
+      name: 'sc',
+      window: 'session',
+      key: 'session' as const,
+      idle_ttl: '1h',
+    })
+    const { boot, advance } = persistentHarness()
+    const first = boot([config])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 10 }, 's1')).charges,
+      COMMIT_META,
+    )
+
+    advance(3_600_001)
+    const second = boot([config])
+    expect(second.listStates().flatMap((s) => s.buckets)).toEqual([])
+  })
+
+  it('gc writes a watermark so a resurrected pot replays only post-GC spend', () => {
+    const config = budgetConfig({
+      name: 'sc',
+      window: 'session',
+      key: 'session' as const,
+      idle_ttl: '1h',
+    })
+    const { boot, advance, db } = persistentHarness()
+    const first = boot([config])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 40 }, 's1')).charges,
+      COMMIT_META,
+    )
+
+    advance(3_600_001)
+    first.gc() // evicts the idle pot and records the watermark
+    expect(first.listStates().flatMap((s) => s.buckets)).toEqual([])
+    const watermarks = db.prepare('SELECT * FROM budget_bucket_gc').all() as Array<
+      Record<string, unknown>
+    >
+    expect(watermarks).toEqual([
+      {
+        budget_name: 'sc',
+        bucket_key: 'budget:sc:session:s1',
+        gc_after_ms: 1_000_000 + 3_600_001,
+      },
+    ])
+
+    // The same session id comes back: a fresh pot in memory...
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 7 }, 's1')).charges,
+      COMMIT_META,
+    )
+
+    // ...and a restart must NOT re-absorb the pre-GC 40.
+    advance(60_000)
+    const second = boot([config])
+    const bucket = second.listStates()[0]?.buckets[0]
+    expect(bucket).toMatchObject({ bucket_key: 'budget:sc:session:s1', spent: 7 })
+  })
+
+  it('keeps the bucket when the GC watermark write fails (retry next sweep)', () => {
+    const config = budgetConfig({
+      name: 'sc',
+      window: 'session',
+      key: 'session' as const,
+      idle_ttl: '1h',
+    })
+    const db = new Database(':memory:')
+    const clock = { time: 1_000_000 }
+    const ledger = new BudgetLedger({ database: db, now: () => clock.time })
+    const failing = delegatingPersistence(ledger, {
+      recordBucketGc: () => {
+        throw new Error('disk full')
+      },
+    })
+    const engine = new BudgetEngine({
+      budgets: compileBudgets([config]),
+      now: () => clock.time,
+      cleanupIntervalMs: 0,
+      ledger: failing,
+    })
+    engine.hydrate()
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 40 }, 's1')).charges,
+      COMMIT_META,
+    )
+
+    clock.time += 3_600_001
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      engine.gc()
+    } finally {
+      errorSpy.mockRestore()
+    }
+
+    // Evicting without a durable watermark could resurrect pre-GC spend
+    // after a restart — the sweep must keep the bucket and retry later.
+    expect(engine.listStates().flatMap((s) => s.buckets)).toHaveLength(1)
+  })
+
+  it('bumps the epoch and replays nothing when the tuple changed while down', () => {
+    const { boot, advance, ledger } = persistentHarness()
+    const first = boot([budgetConfig()])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    advance(60_000)
+    const second = boot([budgetConfig({ limit: 200 })])
+    expect(spentAfterBoot(second)).toBe(0)
+    expect(ledger.readMeta('daily-cap')).toMatchObject({ limit_amount: 200, epoch: 2 })
+  })
+
+  it('bumps the epoch when only the key scope changed while down', () => {
+    const { boot, advance, ledger } = persistentHarness()
+    const first = boot([budgetConfig()])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    advance(60_000)
+    const second = boot([budgetConfig({ key: 'session' })])
+    expect(ledger.readMeta('daily-cap')).toMatchObject({ key: 'session', epoch: 2 })
+    expect(second.listStates().flatMap((s) => s.buckets)).toEqual([])
+  })
+
+  it('replays nothing from either old epoch after an A-to-B-to-A double change', () => {
+    const { boot, advance, ledger } = persistentHarness()
+    const first = boot([budgetConfig()]) // A, epoch 1
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    advance(60_000)
+    const second = boot([budgetConfig({ limit: 200 })]) // B, epoch 2
+    second.recordAll(
+      second.resolveCharges(chargeCtx('stripe_charge', { amount: 50 })).charges,
+      COMMIT_META,
+    )
+
+    advance(60_000)
+    const third = boot([budgetConfig()]) // A again — epoch 3, not a return to 1
+    expect(spentAfterBoot(third)).toBe(0)
+    expect(ledger.readMeta('daily-cap')?.epoch).toBe(3)
+  })
+
+  it('writes the bumped epoch synchronously on a hot-reload tuple change', () => {
+    const { boot, ledger, advance } = persistentHarness()
+    const engine = boot([budgetConfig()])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    engine.reconcile(compileBudgets([budgetConfig({ limit: 200 })]))
+    expect(ledger.readMeta('daily-cap')).toMatchObject({ limit_amount: 200, epoch: 2 })
+
+    // Crash immediately after the reload: the on-disk epoch already moved,
+    // so the next boot starts the new pot fresh instead of replaying epoch-1
+    // rows into it.
+    advance(1_000)
+    const second = boot([budgetConfig({ limit: 200 })])
+    expect(spentAfterBoot(second)).toBe(0)
+  })
+
+  it('flushes the epoch bump when a budget is removed, so a re-add stays fresh across restarts', () => {
+    const { boot, ledger, advance } = persistentHarness()
+    const engine = boot([budgetConfig()])
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    engine.reconcile([]) // budget removed at runtime
+    expect(ledger.readMeta('daily-cap')?.epoch).toBe(2)
+
+    // Restart with the budget back in the config, same tuple: removal reset
+    // the pot, so the restart must not resurrect the pre-removal spend.
+    advance(1_000)
+    const second = boot([budgetConfig()])
+    expect(spentAfterBoot(second)).toBe(0)
+  })
+
+  it('mints a hot-reload-added budget past the on-disk epoch history', () => {
+    const { boot, advance } = persistentHarness()
+    const first = boot([budgetConfig()])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    // Restart WITHOUT the budget, then hot-reload re-adds it: the fresh
+    // process has no memory of the name, but the disk does — the minted
+    // epoch must move past the history, not collide back into epoch 1.
+    advance(1_000)
+    const second = boot([])
+    second.reconcile(compileBudgets([budgetConfig()]))
+    second.recordAll(
+      second.resolveCharges(chargeCtx('stripe_charge', { amount: 10 })).charges,
+      COMMIT_META,
+    )
+    expect(spentAfterBoot(second)).toBe(10)
+
+    advance(1_000)
+    const third = boot([budgetConfig()])
+    expect(spentAfterBoot(third)).toBe(10) // the re-added pot's own spend only
+  })
+
+  it('replays approved_overage rows identically to spend rows', () => {
+    const { boot, advance } = persistentHarness()
+    const first = boot([budgetConfig({ window: '1h' })])
+    first.recordAll(first.resolveCharges(chargeCtx('stripe_charge', { amount: 120 })).charges, {
+      ...COMMIT_META,
+      kind: 'approved_overage',
+    })
+
+    advance(60_000)
+    const second = boot([budgetConfig({ window: '1h' })])
+    expect(spentAfterBoot(second)).toBe(120) // an overage stays spent
+  })
+
+  it('hydrate is a no-op for a plain commit sink (in-memory mode)', () => {
+    const rows: unknown[] = []
+    const { engine } = createEngine([budgetConfig()], {
+      ledger: { commitAll: (batch) => rows.push(...batch) },
+    })
+    expect(() => {
+      engine.hydrate()
+    }).not.toThrow()
+    expect(engine.listStates().flatMap((s) => s.buckets)).toEqual([])
+  })
+
+  it('hydrate is latched: a second call cannot double-count replayed entries', () => {
+    const { boot, advance } = persistentHarness()
+    const first = boot([budgetConfig({ window: '1h' })])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    advance(60_000)
+    const second = boot([budgetConfig({ window: '1h' })])
+    second.hydrate() // boot() already hydrated once
+    expect(spentAfterBoot(second)).toBe(30)
+  })
+
+  it('replays nothing at exactly the window bound (memory-eviction parity)', () => {
+    const { boot, advance } = persistentHarness()
+    const first = boot([budgetConfig({ window: '1h' })])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    advance(3_600_000) // exactly one window: expired on both sides
+    const second = boot([budgetConfig({ window: '1h' })])
+    expect(spentAfterBoot(second)).toBe(0)
+  })
+
+  it('rebuilds a session pot at exactly the idle-TTL bound (memory-sweep parity)', () => {
+    const config = budgetConfig({
+      name: 'sc',
+      window: 'session',
+      key: 'session' as const,
+      idle_ttl: '1h',
+    })
+    const { boot, advance } = persistentHarness()
+    const first = boot([config])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 10 }, 's1')).charges,
+      COMMIT_META,
+    )
+
+    advance(3_600_000) // exactly the TTL: the memory sweep would keep it
+    const second = boot([config])
+    expect(second.listStates()[0]?.buckets[0]).toMatchObject({
+      bucket_key: 'budget:sc:session:s1',
+      spent: 10,
+    })
+  })
+
+  it('retires a pot that crossed its idle TTL while down (watermark at hydrate)', () => {
+    const config = budgetConfig({
+      name: 'sc',
+      window: 'session',
+      key: 'session' as const,
+      idle_ttl: '1h',
+    })
+    const { boot, advance, db } = persistentHarness()
+    const first = boot([config])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 40 }, 's1')).charges,
+      COMMIT_META,
+    )
+
+    // The pot dies during downtime — no sweep ever observed it.
+    advance(3_600_001)
+    const second = boot([config])
+    expect(second.listStates().flatMap((s) => s.buckets)).toEqual([])
+    // Hydrate durably retired it.
+    const readWatermarks = () =>
+      db.prepare('SELECT * FROM budget_bucket_gc').all() as Array<Record<string, unknown>>
+    const stamped = readWatermarks()
+    expect(stamped).toHaveLength(1)
+
+    // Another restart BEFORE any resurrection: the `total > 0` guard makes
+    // the retirement idempotent — the watermark is not re-stamped, so its
+    // retention lifetime is anchored to the original retirement, not
+    // refreshed forever by every boot.
+    advance(60_000)
+    const secondB = boot([config])
+    expect(secondB.listStates().flatMap((s) => s.buckets)).toEqual([])
+    expect(readWatermarks()).toEqual(stamped)
+
+    // The same session key resurrects with fresh spend...
+    secondB.recordAll(
+      secondB.resolveCharges(chargeCtx('stripe_charge', { amount: 7 }, 's1')).charges,
+      COMMIT_META,
+    )
+
+    // ...and the NEXT restart must not re-absorb the dead pot's 40.
+    advance(60_000)
+    const third = boot([config])
+    expect(third.listStates()[0]?.buckets[0]).toMatchObject({
+      bucket_key: 'budget:sc:session:s1',
+      spent: 7,
+    })
+  })
+
+  it('retires a budget removed while down, so a cold re-add starts fresh', () => {
+    const { boot, advance, ledger } = persistentHarness()
+    const first = boot([budgetConfig()])
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+
+    // A boot without the budget observes the removal and bumps the epoch.
+    advance(1_000)
+    boot([])
+    expect(ledger.readMeta('daily-cap')?.epoch).toBe(2)
+
+    // Idempotent: further boots without it write nothing more.
+    advance(1_000)
+    boot([])
+    expect(ledger.readMeta('daily-cap')?.epoch).toBe(2)
+
+    // Re-added with the identical tuple: fresh pot, like a live removal.
+    advance(1_000)
+    const readded = boot([budgetConfig()])
+    expect(spentAfterBoot(readded)).toBe(0)
+  })
+
+  it('never replays rows whose epoch no meta row records (events-max backstop, no-meta branch)', () => {
+    // Divergence from any historical source (an interrupted older build, a
+    // hand-poked db): rows exist at epoch 1 with no meta row. Minting must
+    // move past them, never re-mint their epoch for a fresh pot.
+    const { boot, ledger, db } = persistentHarness()
+    db.prepare(
+      `INSERT INTO budget_events (id, budget_name, epoch, bucket_key, kind, amount, currency,
+         tool_name, origin, audit_record_id, timestamp, timestamp_ms, created_at)
+       VALUES ('row-1', 'daily-cap', 1, 'budget:daily-cap:global', 'spend', 90, 'USD',
+         'stripe_charge', 'mcp', 'audit-x', '2026-07-10T00:00:00.000Z', 999_000, '2026-07-10T00:00:00.000Z')`,
+    ).run()
+
+    const engine = boot([budgetConfig()])
+    expect(ledger.readMeta('daily-cap')?.epoch).toBe(2)
+    expect(spentAfterBoot(engine)).toBe(0)
+  })
+
+  it('mints past orphaned row epochs on a tuple change while down (events-max backstop)', () => {
+    const { boot, advance, ledger, db } = persistentHarness()
+    const first = boot([budgetConfig()]) // meta {limit 100, epoch 1}
+    first.recordAll(
+      first.resolveCharges(chargeCtx('stripe_charge', { amount: 30 })).charges,
+      COMMIT_META,
+    )
+    // Divergent rows above the meta epoch (historical corruption).
+    db.prepare('UPDATE budget_events SET epoch = 5').run()
+
+    advance(1_000)
+    boot([budgetConfig({ limit: 300 })])
+    // meta.epoch + 1 would be 2; the backstop mints past the rows instead.
+    expect(ledger.readMeta('daily-cap')).toMatchObject({ limit_amount: 300, epoch: 6 })
+
+    advance(1_000)
+    const third = boot([budgetConfig({ limit: 300 })])
+    expect(spentAfterBoot(third)).toBe(0)
+  })
+
+  it('rejects a reload whose epoch flush fails, leaving memory and disk untouched', () => {
+    const { boot, advance, ledger } = persistentHarness()
+    let failBatch = false
+    const flaky = delegatingPersistence(ledger, {
+      writeMetaBatch: (metas) => {
+        if (failBatch) throw new Error('disk full')
+        ledger.writeMetaBatch(metas)
+      },
+    })
+    const engine = boot([budgetConfig()], flaky)
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 })).charges,
+      COMMIT_META,
+    )
+
+    failBatch = true
+    expect(() => {
+      engine.reconcile(compileBudgets([budgetConfig({ limit: 200 })]))
+    }).toThrow('disk full')
+
+    // The failed reload never happened: the OLD config still enforces with
+    // its accrued state, and later rows still carry the old epoch.
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 1 }))
+    expect(charges[0]?.budget.limit).toBe(100)
+    expect(charges[0]?.generation).toBe(1)
+    expect(engine.peekAll(charges).entries[0]?.spent).toBe(60)
+    expect(ledger.readMeta('daily-cap')).toMatchObject({ limit_amount: 100, epoch: 1 })
+
+    // Restart on the ORIGINAL config: continuity, not resurrection — the pot
+    // was never reset, so its spend rightly survives.
+    advance(1_000)
+    const second = boot([budgetConfig()])
+    expect(spentAfterBoot(second)).toBe(60)
+
+    // Restart on the NEW config: a normal tuple change, fresh pot.
+    advance(1_000)
+    const third = boot([budgetConfig({ limit: 200 })])
+    expect(spentAfterBoot(third)).toBe(0)
+    expect(ledger.readMeta('daily-cap')).toMatchObject({ limit_amount: 200, epoch: 2 })
+  })
+
+  it('rejects a removal whose epoch flush fails, keeping the budget enforced', () => {
+    const { boot, ledger } = persistentHarness()
+    let failBatch = false
+    const flaky = delegatingPersistence(ledger, {
+      writeMetaBatch: (metas) => {
+        if (failBatch) throw new Error('disk full')
+        ledger.writeMetaBatch(metas)
+      },
+    })
+    const engine = boot([budgetConfig()], flaky)
+    engine.recordAll(
+      engine.resolveCharges(chargeCtx('stripe_charge', { amount: 60 })).charges,
+      COMMIT_META,
+    )
+
+    failBatch = true
+    expect(() => {
+      engine.reconcile([])
+    }).toThrow('disk full')
+
+    // Still configured, still enforcing, nothing bumped anywhere.
+    expect(engine.listStates().map((s) => s.name)).toEqual(['daily-cap'])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 50 }))
+    expect(engine.peekAll(charges).allowed).toBe(false) // 60 + 50 > 100
+    expect(ledger.readMeta('daily-cap')?.epoch).toBe(1)
+  })
+
+  it('persists all epoch mints of one reload in a single batch (all-or-nothing)', () => {
+    const { boot, ledger } = persistentHarness()
+    const engine = boot([budgetConfig({ name: 'a' }), budgetConfig({ name: 'b' })])
+
+    // One reload: 'a' changes tuple, 'b' is removed, 'c' appears.
+    engine.reconcile(
+      compileBudgets([budgetConfig({ name: 'a', limit: 500 }), budgetConfig({ name: 'c' })]),
+    )
+
+    expect(ledger.readMeta('a')).toMatchObject({ limit_amount: 500, epoch: 2 })
+    expect(ledger.readMeta('b')?.epoch).toBe(2) // removal tombstone
+    expect(ledger.readMeta('c')?.epoch).toBe(1)
+  })
+
+  it('hydrate fails the boot when the meta write throws', () => {
+    const { ledger } = persistentHarness()
+    const broken = delegatingPersistence(ledger, {
+      writeMeta: () => {
+        throw new Error('disk full')
+      },
+    })
+    const engine = new BudgetEngine({
+      budgets: compileBudgets([budgetConfig()]),
+      now: () => 1_000_000,
+      cleanupIntervalMs: 0,
+      ledger: broken,
+    })
+    expect(() => {
+      engine.hydrate()
+    }).toThrow('disk full')
+  })
+
+  it('rolls back the whole call and leaves memory untouched on a genuine mid-batch fault', () => {
+    const { boot, db } = persistentHarness()
+    const engine = boot([budgetConfig({ name: 'a' }), budgetConfig({ name: 'b' })])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 30 }))
+    const [chargeA, chargeB] = charges
+    if (!chargeA || !chargeB) throw new Error('expected two charges')
+
+    // NaN binds as NULL and violates the amount NOT NULL constraint on the
+    // SECOND insert of the transaction — a genuine mid-batch fault through
+    // the full recordAll path.
+    expect(() => engine.recordAll([chargeA, { ...chargeB, amount: NaN }], COMMIT_META)).toThrow()
+
+    const countRows = () =>
+      (db.prepare('SELECT COUNT(*) AS count FROM budget_events').get() as { count: number }).count
+    expect(countRows()).toBe(0)
+    expect(engine.listStates().flatMap((s) => s.buckets)).toEqual([])
+
+    // The fault clears; the same call then commits cleanly.
+    expect(() => engine.recordAll(charges, COMMIT_META)).not.toThrow()
+    expect(countRows()).toBe(2)
+    expect(engine.listStates().map((s) => s.buckets[0]?.spent)).toEqual([30, 30])
   })
 })

--- a/packages/proxy/src/budget/engine.ts
+++ b/packages/proxy/src/budget/engine.ts
@@ -111,6 +111,93 @@ export interface BudgetLedgerSink {
   commitAll(rows: readonly BudgetLedgerRow[]): void
 }
 
+/**
+ * On-disk identity and epoch of one budget (a `budget_meta` row). The
+ * `{limit_amount, currency, window, key}` tuple is the reset tuple persisted
+ * across restarts; `epoch` is the on-disk spelling of the engine's config
+ * generation. `key` is typed as a plain string because it is only ever
+ * compared, never dispatched on.
+ */
+export interface BudgetMetaRow {
+  readonly budget_name: string
+  readonly limit_amount: number
+  readonly currency: string
+  /** Raw config window string: '1h' | 'session'. */
+  readonly window: string
+  readonly key: string
+  readonly epoch: number
+}
+
+/** One replayed `budget_events` row for rebuilding a duration window. */
+export interface BudgetReplayEvent {
+  readonly bucket_key: string
+  readonly amount: number
+  readonly timestamp_ms: number
+}
+
+/** One rebuilt session pot: post-watermark lifetime sum + last activity. */
+export interface BudgetReplayBucket {
+  readonly bucket_key: string
+  readonly total: number
+  readonly last_activity_ms: number
+}
+
+/**
+ * Full persistence contract the SQLite ledger implements on top of the
+ * commit sink: meta/epoch bookkeeping, startup replay reads, and GC
+ * watermarks. The engine probes its sink for these capabilities once and
+ * persists exactly what the sink can persist — a plain sink (tests, no-op)
+ * keeps the PR 1 in-memory behavior.
+ */
+export interface BudgetPersistence extends BudgetLedgerSink {
+  readMeta(budgetName: string): BudgetMetaRow | undefined
+  /** Every meta row on disk, including names no longer configured. */
+  readAllMeta(): readonly BudgetMetaRow[]
+  /** Upsert: the on-disk epoch must be authoritative at all times. */
+  writeMeta(meta: BudgetMetaRow): void
+  /**
+   * Upsert every row in ONE transaction: a reload's epoch mints land
+   * together or not at all, so a failed reload can be rejected with disk
+   * and memory both untouched.
+   */
+  writeMetaBatch(metas: readonly BudgetMetaRow[]): void
+  /**
+   * The highest epoch present in `budget_events` for the name; 0 when none.
+   * Epoch minting consults this so an epoch that already has rows — for
+   * example after a swallowed reconcile-time meta-write failure — can never
+   * be re-minted for a different pot.
+   */
+  maxEventEpoch(budgetName: string): number
+  /** MUST return rows in ascending `timestamp_ms` order (ties by insert order). */
+  replayDurationEvents(
+    budgetName: string,
+    epoch: number,
+    sinceMs: number,
+  ): readonly BudgetReplayEvent[]
+  /**
+   * Every bucket of the epoch with its post-watermark sum and last activity.
+   * Liveness policy (idle-TTL) is the engine's job, not the store's.
+   */
+  replaySessionBuckets(budgetName: string, epoch: number): readonly BudgetReplayBucket[]
+  /** Upsert the idle-GC watermark for one session bucket. */
+  recordBucketGc(budgetName: string, bucketKey: string, gcAfterMs: number): void
+}
+
+/** Whether a sink carries the full persistence contract. */
+export function isBudgetPersistence(sink: BudgetLedgerSink): sink is BudgetPersistence {
+  const candidate = sink as Partial<BudgetPersistence>
+  return (
+    typeof candidate.readMeta === 'function' &&
+    typeof candidate.readAllMeta === 'function' &&
+    typeof candidate.writeMeta === 'function' &&
+    typeof candidate.writeMetaBatch === 'function' &&
+    typeof candidate.maxEventEpoch === 'function' &&
+    typeof candidate.replayDurationEvents === 'function' &&
+    typeof candidate.replaySessionBuckets === 'function' &&
+    typeof candidate.recordBucketGc === 'function'
+  )
+}
+
 /** Payload for the per-charge commit callback (dashboard event bus). */
 export interface BudgetCommitEvent {
   readonly name: string
@@ -174,13 +261,17 @@ export class BudgetEngine {
   private readonly generations = new Map<string, number>()
   private readonly now: () => number
   private readonly ledger: BudgetLedgerSink
+  /** The sink again, when it carries the full persistence contract. */
+  private readonly persistence: BudgetPersistence | null
   private readonly onCommit: ((event: BudgetCommitEvent) => void) | undefined
   private timer: ReturnType<typeof setInterval> | null = null
   private closed = false
+  private hydrated = false
 
   constructor(options: BudgetEngineOptions = {}) {
     this.now = options.now ?? Date.now
     this.ledger = options.ledger ?? NOOP_LEDGER
+    this.persistence = isBudgetPersistence(this.ledger) ? this.ledger : null
     this.onCommit = options.onCommit
     for (const budget of options.budgets ?? []) {
       this.budgets.set(budget.name, budget)
@@ -362,35 +453,156 @@ export class BudgetEngine {
   // -------------------------------------------------------------------------
 
   /**
+   * Rebuild in-memory state from the ledger. Call once at startup, after
+   * construction and before serving traffic; a no-op when the configured
+   * sink does not carry the persistence contract (in-memory mode).
+   *
+   * Per configured budget, `budget_meta` decides:
+   * - no row → first boot for this name: mint epoch 1, nothing to replay;
+   * - a different `{limit, currency, window, key}` tuple → the config
+   *   changed while down: bump the epoch, replay nothing (the same reset a
+   *   live tuple-changing reload performs, extended across restarts). Old
+   *   rows keep their epoch — history stays queryable, replay ignores it;
+   * - a matching tuple → replay at the meta epoch: duration windows rebuild
+   *   entry lists from a window lookback (bit-equivalent to never having
+   *   restarted), session windows rebuild still-live pots (idle-TTL bound)
+   *   from their post-GC-watermark lifetime sums.
+   *
+   * Meta writes here propagate failures: a ledger that cannot record epochs
+   * at startup must fail the boot loudly, the same posture as the audit
+   * store's schema assertion.
+   */
+  hydrate(): void {
+    if (!this.persistence) return
+    // Latched: a second hydrate would append every replayed duration entry
+    // again, double-counting real money.
+    if (this.hydrated) return
+    this.hydrated = true
+    const nowMs = this.now()
+
+    const metaByName = new Map(
+      this.persistence.readAllMeta().map((meta) => [meta.budget_name, meta]),
+    )
+
+    for (const budget of this.budgets.values()) {
+      const meta = metaByName.get(budget.name)
+      if (!meta) {
+        // First boot for this name. Minting still consults the rows: a
+        // swallowed reconcile-time meta-write failure can leave rows at an
+        // epoch no meta row records, and re-minting that epoch would replay
+        // them into a pot they never belonged to. Those retired rows stay
+        // history only.
+        const epoch = this.persistence.maxEventEpoch(budget.name) + 1
+        this.persistence.writeMeta(metaOf(budget, epoch))
+        this.generations.set(budget.name, epoch)
+        continue
+      }
+      if (metaTupleChanged(meta, budget)) {
+        const epoch = Math.max(meta.epoch, this.persistence.maxEventEpoch(budget.name)) + 1
+        this.persistence.writeMeta(metaOf(budget, epoch))
+        this.generations.set(budget.name, epoch)
+        continue
+      }
+
+      this.generations.set(budget.name, meta.epoch)
+      if (budget.window.kind === 'duration') {
+        const events = this.persistence.replayDurationEvents(
+          budget.name,
+          meta.epoch,
+          nowMs - budget.window.windowMs,
+        )
+        for (const event of events) {
+          const bucket = this.bucketFor(budget.name, event.bucket_key)
+          bucket.entries.push({ timestampMs: event.timestamp_ms, amount: event.amount })
+          // Events arrive time-ordered, so the last assignment is the max.
+          bucket.lastActivityMs = event.timestamp_ms
+        }
+      } else {
+        const liveAfterMs = nowMs - budget.window.idleTtlMs
+        for (const row of this.persistence.replaySessionBuckets(budget.name, meta.epoch)) {
+          if (row.last_activity_ms >= liveAfterMs) {
+            const bucket = this.bucketFor(budget.name, row.bucket_key)
+            bucket.total = row.total
+            bucket.lastActivityMs = row.last_activity_ms
+          } else if (row.total > 0) {
+            // The pot crossed its idle TTL while no sweep could observe it
+            // (downtime, or a crash before the next sweep tick). Durably
+            // retire it now: without the watermark, a same-key resurrection
+            // followed by another restart would re-absorb this dead pot's
+            // spend. All of the pot's rows are strictly older than nowMs,
+            // so the inclusive watermark bound stays safe.
+            this.persistence.recordBucketGc(budget.name, row.bucket_key, nowMs)
+          }
+        }
+      }
+    }
+
+    // Removal observed at boot: a meta row whose name is not configured was
+    // removed while the proxy was down (a live removal writes its tombstone
+    // in reconcile). Retire whatever the current epoch accrued so a later
+    // re-add starts fresh, exactly like a live removal. Idempotent: after
+    // the bump no rows exist at or above the new epoch, so later boots skip
+    // the write.
+    for (const [name, meta] of metaByName) {
+      if (this.budgets.has(name)) continue
+      const maxEventEpoch = this.persistence.maxEventEpoch(name)
+      if (maxEventEpoch < meta.epoch) continue
+      this.persistence.writeMeta({ ...meta, epoch: Math.max(meta.epoch, maxEventEpoch) + 1 })
+    }
+  }
+
+  /**
    * Swap budget configs on hot-reload. Identity is the NAME: removed names
    * drop their live buckets; a changed `{limit, currency, window, key}` tuple
    * resets the budget's buckets (a different pool or scope structure);
    * everything else — contributors, on_exceed — applies to the accrued state
    * as-is, because those edits do not change what was already spent.
+   *
+   * Persist-before-swap: every epoch this reload mints lands in
+   * `budget_meta` in ONE transaction BEFORE any memory changes. A throw
+   * rejects the whole reload — the caller keeps the previous config — so
+   * disk and memory can never diverge; a failed reload simply never
+   * happened, and no later restart can misread it. (A swallow-and-continue
+   * posture here would let an A→B reload with a failed flush resurrect the
+   * retired A pot after a revert-and-restart.)
+   *
+   * Removed names mint too: an in-flight charge frozen before the removal
+   * must go stale, or its commit would recreate hidden bucket state for a
+   * budget that no longer exists — and without the on-disk tombstone, a
+   * restart with the budget back in the config would resurrect the
+   * pre-removal pot that the removal had reset. Generations for removed
+   * names are kept (not deleted) so a later re-add keeps counting up.
+   *
+   * @throws When the epoch flush fails; the engine is unchanged.
    */
   reconcile(next: readonly CompiledBudget[]): void {
     const nextByName = new Map(next.map((budget) => [budget.name, budget]))
 
+    // Phase 1 — compute every pot reset this swap needs, mutating nothing.
+    const mints: Array<{ name: string; tuple: CompiledBudget; epoch: number }> = []
     for (const [name, budget] of nextByName) {
       const current = this.budgets.get(name)
       if (!current || tupleChanged(current, budget)) {
         // New name or a different pool: reset state and invalidate any
         // in-flight charges frozen under the old generation.
-        this.state.delete(name)
-        this.generations.set(name, (this.generations.get(name) ?? 0) + 1)
+        mints.push({ name, tuple: budget, epoch: this.nextEpoch(name) })
       }
     }
-    for (const name of [...this.budgets.keys()]) {
+    for (const [name, removed] of this.budgets) {
       if (nextByName.has(name)) continue
-      this.state.delete(name)
-      // A removed budget's generation bumps too: an in-flight charge frozen
-      // before the removal must go stale, or its commit would recreate
-      // hidden bucket state for a budget that no longer exists. Generations
-      // for removed names are kept (not deleted) so a later re-add keeps
-      // counting up instead of colliding with older in-flight charges.
-      this.generations.set(name, (this.generations.get(name) ?? 0) + 1)
+      mints.push({ name, tuple: removed, epoch: this.nextEpoch(name) })
     }
 
+    // Phase 2 — durability, all-or-nothing.
+    if (this.persistence && mints.length > 0) {
+      this.persistence.writeMetaBatch(mints.map((mint) => metaOf(mint.tuple, mint.epoch)))
+    }
+
+    // Phase 3 — memory: pure Map operations, nothing here can throw.
+    for (const mint of mints) {
+      this.state.delete(mint.name)
+      this.generations.set(mint.name, mint.epoch)
+    }
     this.budgets = nextByName
   }
 
@@ -405,7 +617,27 @@ export class BudgetEngine {
       }
       for (const [key, bucket] of buckets) {
         if (budget.window.kind === 'session') {
-          if (nowMs - bucket.lastActivityMs > budget.window.idleTtlMs) buckets.delete(key)
+          if (nowMs - bucket.lastActivityMs > budget.window.idleTtlMs) {
+            // Watermark before eviction: replaying without it would let a
+            // later resurrection of the same key re-absorb pre-GC spend
+            // after a restart. If the watermark cannot be written, keep the
+            // pot and retry on the next sweep — an over-held bucket is
+            // recoverable, silently revived spend is not.
+            if (this.persistence) {
+              try {
+                this.persistence.recordBucketGc(name, key, nowMs)
+              } catch (err) {
+                // eslint-disable-next-line no-console -- Intentional operational warning
+                console.error(
+                  `[helio] Budget "${name}": failed to record the GC watermark for ` +
+                    `"${key}"; keeping the idle pot until the next sweep:`,
+                  err,
+                )
+                continue
+              }
+            }
+            buckets.delete(key)
+          }
         } else {
           this.evictExpired(bucket, budget.window.windowMs, nowMs)
           if (bucket.entries.length === 0) buckets.delete(key)
@@ -479,6 +711,31 @@ export class BudgetEngine {
   // Internals
   // -------------------------------------------------------------------------
 
+  /**
+   * The next epoch for a name: one past the highest that memory, the meta
+   * row, or the rows themselves have seen. Pure — the caller applies it to
+   * `generations` only after the mint is durable. The meta consult matters
+   * for names this process has no memory of (a hot-reload re-add after a
+   * restart); the rows consult is a backstop against historical divergence
+   * (rows at an epoch no meta row records) — minting from memory or meta
+   * alone could collide into an epoch that already has rows and replay them
+   * into a different pot.
+   */
+  private nextEpoch(name: string): number {
+    const memory = this.generations.get(name) ?? 0
+    const disk = this.persistence
+      ? Math.max(this.persistence.readMeta(name)?.epoch ?? 0, this.persistence.maxEventEpoch(name))
+      : 0
+    return Math.max(memory, disk) + 1
+  }
+
+  /**
+   * The key format is part of the ON-DISK contract: hydrate rebuilds buckets
+   * from `budget_events.bucket_key` verbatim, so renaming any segment here
+   * would strand every persisted bucket of an unchanged tuple as an
+   * unreachable ghost (displayed, never charged). Changing the format
+   * requires folding a format version into the epoch decision.
+   */
   private bucketKey(budget: CompiledBudget, ctx: BudgetChargeContext): string {
     switch (budget.key) {
       case 'session':
@@ -564,6 +821,27 @@ export class BudgetEngine {
       resetAtMs,
     }
   }
+}
+
+function metaOf(budget: CompiledBudget, epoch: number): BudgetMetaRow {
+  return {
+    budget_name: budget.name,
+    limit_amount: budget.limit,
+    currency: budget.currency,
+    window: budget.windowRaw,
+    key: budget.key,
+    epoch,
+  }
+}
+
+/** The on-disk spelling of {@link tupleChanged}: meta row vs compiled budget. */
+function metaTupleChanged(meta: BudgetMetaRow, budget: CompiledBudget): boolean {
+  return (
+    meta.limit_amount !== budget.limit ||
+    meta.currency !== budget.currency ||
+    meta.window !== budget.windowRaw ||
+    meta.key !== budget.key
+  )
 }
 
 function tupleChanged(a: CompiledBudget, b: CompiledBudget): boolean {

--- a/packages/proxy/src/budget/index.ts
+++ b/packages/proxy/src/budget/index.ts
@@ -1,5 +1,7 @@
 export { compileBudgets, BudgetParseError } from './parser.js'
 export { BudgetEngine } from './engine.js'
+export { BudgetLedger } from './ledger.js'
+export type { BudgetLedgerOptions } from './ledger.js'
 export type {
   BudgetChargeContext,
   BudgetCharge,
@@ -8,6 +10,10 @@ export type {
   BudgetCommitMeta,
   BudgetLedgerRow,
   BudgetLedgerSink,
+  BudgetPersistence,
+  BudgetMetaRow,
+  BudgetReplayEvent,
+  BudgetReplayBucket,
   BudgetCommitEvent,
   BudgetBucketState,
   BudgetState,

--- a/packages/proxy/src/budget/ledger.test.ts
+++ b/packages/proxy/src/budget/ledger.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, rmSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import Database from 'better-sqlite3'
+import type { Database as DatabaseType } from 'better-sqlite3'
+import { BudgetLedger } from './ledger.js'
+import type { BudgetLedgerRow, BudgetMetaRow } from './engine.js'
+import { AuditStore } from '../audit/index.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ledgerRow(overrides: Partial<BudgetLedgerRow> = {}): BudgetLedgerRow {
+  return {
+    budget_name: 'daily-cap',
+    bucket_key: 'budget:daily-cap:global',
+    kind: 'spend',
+    amount: 25,
+    currency: 'USD',
+    tool_name: 'stripe_charge',
+    origin: 'mcp',
+    audit_record_id: 'audit-1',
+    timestamp: '2026-07-10T12:00:00.000Z',
+    timestamp_ms: 1_000_000,
+    generation: 1,
+    ...overrides,
+  }
+}
+
+function metaRow(overrides: Partial<BudgetMetaRow> = {}): BudgetMetaRow {
+  return {
+    budget_name: 'daily-cap',
+    limit_amount: 100,
+    currency: 'USD',
+    window: '24h',
+    key: 'global',
+    epoch: 1,
+    ...overrides,
+  }
+}
+
+function createLedger(database?: DatabaseType) {
+  const db = database ?? new Database(':memory:')
+  let time = 5_000_000
+  const ledger = new BudgetLedger({ database: db, now: () => time })
+  const advance = (ms: number) => {
+    time += ms
+  }
+  return { ledger, db, advance }
+}
+
+function countEvents(db: DatabaseType): number {
+  const { count } = db.prepare('SELECT COUNT(*) AS count FROM budget_events').get() as {
+    count: number
+  }
+  return count
+}
+
+// ---------------------------------------------------------------------------
+// DDL and clean-break schema policy
+// ---------------------------------------------------------------------------
+
+describe('BudgetLedger DDL', () => {
+  it('creates the three budget tables in the given database', () => {
+    const { db } = createLedger()
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      .all() as Array<{ name: string }>
+    const names = tables.map((t) => t.name)
+    expect(names).toContain('budget_meta')
+    expect(names).toContain('budget_events')
+    expect(names).toContain('budget_bucket_gc')
+  })
+
+  it('is idempotent: constructing twice on the same database is safe', () => {
+    const { db, ledger } = createLedger()
+    ledger.commitAll([ledgerRow()])
+    expect(() => new BudgetLedger({ database: db })).not.toThrow()
+    expect(countEvents(db)).toBe(1)
+  })
+
+  it('rejects a stale budget_events schema with the delete-the-db recovery message', () => {
+    const db = new Database(':memory:')
+    db.exec('CREATE TABLE budget_events (id TEXT PRIMARY KEY, budget_name TEXT NOT NULL)')
+    expect(() => new BudgetLedger({ database: db })).toThrow(/Delete/)
+  })
+
+  it('rejects a stale budget_meta schema missing the key column', () => {
+    const db = new Database(':memory:')
+    db.exec(
+      'CREATE TABLE budget_meta (budget_name TEXT PRIMARY KEY, limit_amount REAL NOT NULL, ' +
+        'currency TEXT NOT NULL, window TEXT NOT NULL, epoch INTEGER NOT NULL, updated_at TEXT NOT NULL)',
+    )
+    expect(() => new BudgetLedger({ database: db })).toThrow(/Delete/)
+  })
+
+  it('rejects a stale budget_meta schema missing updated_at', () => {
+    const db = new Database(':memory:')
+    db.exec(
+      'CREATE TABLE budget_meta (budget_name TEXT PRIMARY KEY, limit_amount REAL NOT NULL, ' +
+        'currency TEXT NOT NULL, window TEXT NOT NULL, key TEXT NOT NULL, epoch INTEGER NOT NULL)',
+    )
+    expect(() => new BudgetLedger({ database: db })).toThrow(/Delete/)
+  })
+
+  it('rejects a column whose declared type drifted (timestamp_ms TEXT)', () => {
+    // Name-only validation would pass this schema, and TEXT affinity turns
+    // every timestamp comparison lexicographic ('900' > '1000'), silently
+    // resurrecting expired spend on replay.
+    const db = new Database(':memory:')
+    db.exec(
+      `CREATE TABLE budget_events (
+        id TEXT PRIMARY KEY, budget_name TEXT NOT NULL, epoch INTEGER NOT NULL,
+        bucket_key TEXT NOT NULL, kind TEXT NOT NULL, amount REAL NOT NULL,
+        currency TEXT NOT NULL, tool_name TEXT NOT NULL, origin TEXT NOT NULL,
+        audit_record_id TEXT, timestamp TEXT NOT NULL, timestamp_ms TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      )`,
+    )
+    expect(() => new BudgetLedger({ database: db })).toThrow(/timestamp_ms/)
+  })
+
+  it('rejects a column that lost its NOT NULL constraint', () => {
+    // A nullable amount would let a NaN bind slip through the transactional
+    // rollback contract instead of failing the batch.
+    const db = new Database(':memory:')
+    db.exec(
+      `CREATE TABLE budget_events (
+        id TEXT PRIMARY KEY, budget_name TEXT NOT NULL, epoch INTEGER NOT NULL,
+        bucket_key TEXT NOT NULL, kind TEXT NOT NULL, amount REAL,
+        currency TEXT NOT NULL, tool_name TEXT NOT NULL, origin TEXT NOT NULL,
+        audit_record_id TEXT, timestamp TEXT NOT NULL, timestamp_ms INTEGER NOT NULL,
+        created_at TEXT NOT NULL
+      )`,
+    )
+    expect(() => new BudgetLedger({ database: db })).toThrow(/amount/)
+  })
+
+  it('rejects a table whose primary key drifted', () => {
+    const db = new Database(':memory:')
+    db.exec(
+      // budget_bucket_gc without the composite (budget_name, bucket_key) PK:
+      // the watermark upsert's ON CONFLICT target would not exist.
+      `CREATE TABLE budget_bucket_gc (
+        budget_name TEXT NOT NULL, bucket_key TEXT NOT NULL, gc_after_ms INTEGER NOT NULL
+      )`,
+    )
+    expect(() => new BudgetLedger({ database: db })).toThrow(/budget_bucket_gc/)
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'leaves the audit db file permissions at 0o600 (shared-connection hardening)',
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-budget-ledger-'))
+      const dbPath = join(dir, 'audit.db')
+      const store = new AuditStore({
+        path: dbPath,
+        retention: '90d',
+        includeResponses: true,
+        cleanupIntervalMs: 0,
+      })
+      try {
+        const ledger = new BudgetLedger({ database: store.database })
+        ledger.commitAll([ledgerRow()])
+        expect(statSync(dbPath).mode & 0o777).toBe(0o600)
+        for (const suffix of ['-wal', '-shm'] as const) {
+          expect(statSync(dbPath + suffix).mode & 0o777).toBe(0o600)
+        }
+      } finally {
+        store.close()
+        rmSync(dir, { recursive: true, force: true })
+      }
+    },
+  )
+})
+
+// ---------------------------------------------------------------------------
+// commitAll — the transactional sink
+// ---------------------------------------------------------------------------
+
+describe('BudgetLedger.commitAll', () => {
+  it('persists one row per charge with every column and a generated id', () => {
+    const { ledger, db, advance } = createLedger()
+    ledger.commitAll([
+      ledgerRow(),
+      ledgerRow({ budget_name: 'weekly', bucket_key: 'budget:weekly:global', generation: 3 }),
+    ])
+    advance(2_000)
+    ledger.commitAll([ledgerRow({ budget_name: 'later' })])
+
+    const rows = db.prepare('SELECT * FROM budget_events ORDER BY budget_name').all() as Array<
+      Record<string, unknown>
+    >
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toMatchObject({
+      budget_name: 'daily-cap',
+      epoch: 1,
+      bucket_key: 'budget:daily-cap:global',
+      kind: 'spend',
+      amount: 25,
+      currency: 'USD',
+      tool_name: 'stripe_charge',
+      origin: 'mcp',
+      audit_record_id: 'audit-1',
+      timestamp: '2026-07-10T12:00:00.000Z',
+      timestamp_ms: 1_000_000,
+    })
+    // The charge's generation is the row's epoch.
+    expect(rows[2]?.['epoch']).toBe(3)
+    // Generated per row: UUID ids, insert-time created_at from the clock.
+    expect(rows[0]?.['id']).toMatch(/^[0-9a-f-]{36}$/)
+    expect(rows[0]?.['id']).not.toBe(rows[2]?.['id'])
+    expect(rows[0]?.['created_at']).toBe(new Date(5_000_000).toISOString())
+    expect(rows[1]?.['created_at']).toBe(new Date(5_002_000).toISOString())
+  })
+
+  it('is transactional: a poisoned row rolls back the whole batch', () => {
+    const { ledger, db } = createLedger()
+    // NaN binds as NULL, violating the NOT NULL constraint on amount — a
+    // genuine mid-batch insert failure.
+    expect(() => {
+      ledger.commitAll([ledgerRow(), ledgerRow({ budget_name: 'weekly', amount: NaN })])
+    }).toThrow()
+    expect(countEvents(db)).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// budget_meta
+// ---------------------------------------------------------------------------
+
+describe('BudgetLedger meta', () => {
+  it('returns undefined for a budget with no meta row', () => {
+    const { ledger } = createLedger()
+    expect(ledger.readMeta('daily-cap')).toBeUndefined()
+  })
+
+  it('round-trips the identity tuple and epoch', () => {
+    const { ledger } = createLedger()
+    ledger.writeMeta(metaRow({ window: 'session', key: 'session', epoch: 4 }))
+    expect(ledger.readMeta('daily-cap')).toEqual({
+      budget_name: 'daily-cap',
+      limit_amount: 100,
+      currency: 'USD',
+      window: 'session',
+      key: 'session',
+      epoch: 4,
+    })
+  })
+
+  it('upserts: a second write for the same budget replaces the row', () => {
+    const { ledger, db } = createLedger()
+    ledger.writeMeta(metaRow())
+    ledger.writeMeta(metaRow({ limit_amount: 250, epoch: 2 }))
+    expect(ledger.readMeta('daily-cap')?.limit_amount).toBe(250)
+    expect(ledger.readMeta('daily-cap')?.epoch).toBe(2)
+    const { count } = db.prepare('SELECT COUNT(*) AS count FROM budget_meta').get() as {
+      count: number
+    }
+    expect(count).toBe(1)
+  })
+
+  it('writeMetaBatch is transactional: a second-write fault rolls back the first', () => {
+    const { ledger } = createLedger()
+    // A non-transactional loop would leave the first upsert behind. NaN
+    // binds as NULL and violates the NOT NULL constraint on limit_amount —
+    // a genuine failure on the batch's SECOND statement.
+    expect(() => {
+      ledger.writeMetaBatch([
+        metaRow({ budget_name: 'a' }),
+        metaRow({ budget_name: 'b', limit_amount: NaN }),
+      ])
+    }).toThrow()
+    expect(ledger.readMeta('a')).toBeUndefined()
+  })
+
+  it('writeMetaBatch rollback restores pre-existing rows the batch had updated', () => {
+    const { ledger } = createLedger()
+    ledger.writeMeta(metaRow({ budget_name: 'a', epoch: 1 }))
+
+    // The batch UPDATES 'a' to epoch 2, then dies on the poisoned 'b': the
+    // rollback must restore 'a' to epoch 1, not leave the half-applied mint.
+    expect(() => {
+      ledger.writeMetaBatch([
+        metaRow({ budget_name: 'a', limit_amount: 500, epoch: 2 }),
+        metaRow({ budget_name: 'b', limit_amount: NaN }),
+      ])
+    }).toThrow()
+    expect(ledger.readMeta('a')).toMatchObject({ limit_amount: 100, epoch: 1 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Replay queries
+// ---------------------------------------------------------------------------
+
+describe('BudgetLedger.replayDurationEvents', () => {
+  it('returns only rows inside the lookback, at the given epoch, in time order', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([
+      ledgerRow({ timestamp_ms: 900 }), // outside lookback
+      ledgerRow({ timestamp_ms: 2_000 }),
+      ledgerRow({ timestamp_ms: 1_500 }),
+      ledgerRow({ timestamp_ms: 3_000, generation: 2 }), // old/other epoch
+      ledgerRow({ budget_name: 'other', timestamp_ms: 2_500 }), // other budget
+    ])
+
+    const events = ledger.replayDurationEvents('daily-cap', 1, 1_000)
+    expect(events.map((e) => e.timestamp_ms)).toEqual([1_500, 2_000])
+    expect(events[0]).toEqual({
+      bucket_key: 'budget:daily-cap:global',
+      amount: 25,
+      timestamp_ms: 1_500,
+    })
+  })
+
+  it('excludes a row at exactly the lookback bound (memory-eviction parity)', () => {
+    // spentOf/evictExpired keep entries with `ts > windowStart` strictly; a
+    // row at exactly `now - window` is expired on both sides.
+    const { ledger } = createLedger()
+    ledger.commitAll([ledgerRow({ timestamp_ms: 1_000 })])
+    expect(ledger.replayDurationEvents('daily-cap', 1, 1_000)).toEqual([])
+  })
+})
+
+describe('BudgetLedger.replaySessionBuckets', () => {
+  it('returns every bucket of the epoch with totals and last activity', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([
+      ledgerRow({ bucket_key: 'budget:daily-cap:session:a', timestamp_ms: 5_000, amount: 10 }),
+      ledgerRow({ bucket_key: 'budget:daily-cap:session:a', timestamp_ms: 7_000, amount: 15 }),
+      ledgerRow({ bucket_key: 'budget:daily-cap:session:b', timestamp_ms: 1_000, amount: 99 }),
+    ])
+
+    // Liveness (idle-TTL) is the engine's policy: the store reports every
+    // bucket, including ones the engine will judge dead.
+    const buckets = ledger.replaySessionBuckets('daily-cap', 1)
+    expect(buckets).toEqual([
+      { bucket_key: 'budget:daily-cap:session:a', total: 25, last_activity_ms: 7_000 },
+      { bucket_key: 'budget:daily-cap:session:b', total: 99, last_activity_ms: 1_000 },
+    ])
+  })
+
+  it('filters rows before the GC watermark but keeps last activity from all rows', () => {
+    const { ledger } = createLedger()
+    const key = 'budget:daily-cap:session:s1'
+    // spend → idle-GC (watermark) → same session id resurrects → new spend.
+    ledger.commitAll([ledgerRow({ bucket_key: key, timestamp_ms: 1_000, amount: 40 })])
+    ledger.recordBucketGc('daily-cap', key, 3_000)
+    ledger.commitAll([ledgerRow({ bucket_key: key, timestamp_ms: 5_000, amount: 7 })])
+
+    const buckets = ledger.replaySessionBuckets('daily-cap', 1)
+    expect(buckets).toEqual([{ bucket_key: key, total: 7, last_activity_ms: 5_000 }])
+  })
+
+  it('keeps a post-GC spend that shares the watermark millisecond', () => {
+    const { ledger } = createLedger()
+    const key = 'budget:daily-cap:session:s1'
+    // A resurrecting spend can land in the same tick as the sweep that
+    // evicted the pot; pre-GC rows are always strictly older than the
+    // watermark (idle-TTL inequality), so the inclusive bound is safe.
+    ledger.commitAll([ledgerRow({ bucket_key: key, timestamp_ms: 1_000, amount: 40 })])
+    ledger.recordBucketGc('daily-cap', key, 3_000)
+    ledger.commitAll([ledgerRow({ bucket_key: key, timestamp_ms: 3_000, amount: 7 })])
+
+    const buckets = ledger.replaySessionBuckets('daily-cap', 1)
+    expect(buckets).toEqual([{ bucket_key: key, total: 7, last_activity_ms: 3_000 }])
+  })
+
+  it('ignores rows from other epochs', () => {
+    const { ledger } = createLedger()
+    const key = 'budget:daily-cap:session:s1'
+    ledger.commitAll([
+      ledgerRow({ bucket_key: key, timestamp_ms: 5_000, amount: 40, generation: 1 }),
+      ledgerRow({ bucket_key: key, timestamp_ms: 6_000, amount: 5, generation: 2 }),
+    ])
+    expect(ledger.replaySessionBuckets('daily-cap', 2)).toEqual([
+      { bucket_key: key, total: 5, last_activity_ms: 6_000 },
+    ])
+  })
+})
+
+describe('BudgetLedger.maxEventEpoch', () => {
+  it('returns 0 for a budget with no rows and the max epoch otherwise', () => {
+    const { ledger } = createLedger()
+    expect(ledger.maxEventEpoch('daily-cap')).toBe(0)
+    ledger.commitAll([
+      ledgerRow({ generation: 1 }),
+      ledgerRow({ generation: 3 }),
+      ledgerRow({ budget_name: 'other', generation: 9 }),
+    ])
+    expect(ledger.maxEventEpoch('daily-cap')).toBe(3)
+  })
+})
+
+describe('BudgetLedger.readAllMeta', () => {
+  it('returns every meta row, configured or not', () => {
+    const { ledger } = createLedger()
+    ledger.writeMeta(metaRow())
+    ledger.writeMeta(metaRow({ budget_name: 'retired', epoch: 4 }))
+    expect(
+      ledger
+        .readAllMeta()
+        .map((m) => m.budget_name)
+        .sort(),
+    ).toEqual(['daily-cap', 'retired'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GC watermarks
+// ---------------------------------------------------------------------------
+
+describe('BudgetLedger.recordBucketGc', () => {
+  it('upserts: a later GC replaces the watermark for the same bucket', () => {
+    const { ledger, db } = createLedger()
+    ledger.recordBucketGc('daily-cap', 'budget:daily-cap:session:s1', 1_000)
+    ledger.recordBucketGc('daily-cap', 'budget:daily-cap:session:s1', 9_000)
+
+    const rows = db.prepare('SELECT * FROM budget_bucket_gc').all() as Array<
+      Record<string, unknown>
+    >
+    expect(rows).toEqual([
+      {
+        budget_name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:session:s1',
+        gc_after_ms: 9_000,
+      },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Retention
+// ---------------------------------------------------------------------------
+
+describe('BudgetLedger.purgeExpired', () => {
+  it('deletes events older than the cutoff and keeps newer ones', () => {
+    const { ledger, db } = createLedger()
+    ledger.commitAll([
+      ledgerRow({ timestamp_ms: 1_000 }),
+      ledgerRow({ timestamp_ms: 2_000 }),
+      ledgerRow({ timestamp_ms: 9_000 }),
+    ])
+
+    ledger.purgeExpired(5_000)
+
+    const remaining = db.prepare('SELECT timestamp_ms FROM budget_events').all() as Array<{
+      timestamp_ms: number
+    }>
+    expect(remaining.map((r) => r.timestamp_ms)).toEqual([9_000])
+  })
+
+  it('prunes GC watermarks older than the cutoff (finding 4)', () => {
+    const { ledger, db } = createLedger()
+    ledger.recordBucketGc('daily-cap', 'budget:daily-cap:session:old', 1_000)
+    ledger.recordBucketGc('daily-cap', 'budget:daily-cap:session:new', 9_000)
+
+    ledger.purgeExpired(5_000)
+
+    const rows = db.prepare('SELECT bucket_key FROM budget_bucket_gc').all() as Array<{
+      bucket_key: string
+    }>
+    expect(rows.map((r) => r.bucket_key)).toEqual(['budget:daily-cap:session:new'])
+  })
+
+  it('purges on the audit sweep through the same hook wiring the CLI registers', () => {
+    // The composed contract: AuditStore computes one cutoff per sweep and
+    // the hook feeds cutoff.ms to the ledger — the exact closure cli.ts
+    // registers. An axis mixup (iso vs ms) would purge nothing or everything.
+    const store = new AuditStore({
+      path: ':memory:',
+      retention: '90d',
+      includeResponses: true,
+      cleanupIntervalMs: 0,
+    })
+    try {
+      const ledger = new BudgetLedger({ database: store.database })
+      store.onRetentionSweep((cutoff) => {
+        ledger.purgeExpired(cutoff.ms)
+      })
+      ledger.commitAll([
+        ledgerRow({ timestamp_ms: 1_000 }), // ancient: far past any retention
+        ledgerRow({ budget_name: 'fresh', timestamp_ms: Date.now() }),
+      ])
+
+      store.runRetentionSweep()
+
+      const rows = store.database.prepare('SELECT budget_name FROM budget_events').all() as Array<{
+        budget_name: string
+      }>
+      expect(rows.map((r) => r.budget_name)).toEqual(['fresh'])
+    } finally {
+      store.close()
+    }
+  })
+
+  it('bounds the watermark table under session-bucket churn', () => {
+    const { ledger, db } = createLedger()
+    // Many sender-keyed session pots cycle through GC; each sweep prunes the
+    // watermarks that fell out of the retention window, so the table stays
+    // bounded by churn-within-retention, not lifetime churn.
+    for (let round = 0; round < 20; round++) {
+      for (let i = 0; i < 50; i++) {
+        ledger.recordBucketGc(
+          'daily-cap',
+          `budget:daily-cap:sender:r${String(round)}-s${String(i)}`,
+          round * 100,
+        )
+      }
+      ledger.purgeExpired(round * 100 - 250)
+    }
+    const { count } = db.prepare('SELECT COUNT(*) AS count FROM budget_bucket_gc').get() as {
+      count: number
+    }
+    // Only the last ~3 rounds' watermarks survive the final cutoff.
+    expect(count).toBeLessThanOrEqual(3 * 50)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WAL co-existence with a second connection (the CLI-export pattern)
+// ---------------------------------------------------------------------------
+
+describe('BudgetLedger WAL co-existence', () => {
+  it('serves a concurrent read-only connection while committing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'helio-budget-wal-'))
+    const dbPath = join(dir, 'audit.db')
+    const store = new AuditStore({
+      path: dbPath,
+      retention: '90d',
+      includeResponses: true,
+      cleanupIntervalMs: 0,
+    })
+    let second: DatabaseType | undefined
+    try {
+      const ledger = new BudgetLedger({ database: store.database })
+      ledger.commitAll([ledgerRow()])
+
+      second = new Database(dbPath, { readonly: true })
+      const { count } = second.prepare('SELECT COUNT(*) AS count FROM budget_events').get() as {
+        count: number
+      }
+      expect(count).toBe(1)
+
+      // The first connection keeps writing while the second stays open, and
+      // a fresh read on the export connection sees the post-open commit.
+      ledger.commitAll([ledgerRow({ budget_name: 'weekly' })])
+      expect(countEvents(store.database)).toBe(2)
+      expect(
+        (second.prepare('SELECT COUNT(*) AS count FROM budget_events').get() as { count: number })
+          .count,
+      ).toBe(2)
+    } finally {
+      second?.close()
+      store.close()
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/proxy/src/budget/ledger.ts
+++ b/packages/proxy/src/budget/ledger.ts
@@ -1,0 +1,365 @@
+// ---------------------------------------------------------------------------
+// BudgetLedger — SQLite persistence for budget spend (issue #14).
+//
+// Owns the budget_meta / budget_events / budget_bucket_gc tables inside the
+// EXISTING audit database: the ledger receives the AuditStore's open handle,
+// so there is one connection, one WAL domain, and one file-permission
+// hardening pass. Writes are synchronous at record time (money-grade
+// durability, no buffering); commitAll wraps every row of one call in a
+// single transaction — a throw means nothing persisted, matching the
+// BudgetLedgerSink contract the engine enforces its memory-after-commit
+// ordering against.
+//
+// The ledger is storage only: replay policy (window lookback, idle-TTL
+// liveness, epoch bumping) lives in BudgetEngine.hydrate().
+// ---------------------------------------------------------------------------
+
+import Database from 'better-sqlite3'
+import type { Database as DatabaseType, Statement } from 'better-sqlite3'
+import { randomUUID } from 'node:crypto'
+import type {
+  BudgetLedgerRow,
+  BudgetMetaRow,
+  BudgetPersistence,
+  BudgetReplayBucket,
+  BudgetReplayEvent,
+} from './engine.js'
+
+// ---------------------------------------------------------------------------
+// Schema DDL — clean-break convention (store.ts precedent): CREATE IF NOT
+// EXISTS plus a required-column assertion with the delete-the-db recovery
+// message. No migration framework pre-1.0.
+// ---------------------------------------------------------------------------
+
+const CREATE_TABLES_DDL = `
+CREATE TABLE IF NOT EXISTS budget_meta (
+  budget_name  TEXT PRIMARY KEY,
+  limit_amount REAL NOT NULL,
+  currency     TEXT NOT NULL,
+  window       TEXT NOT NULL,
+  key          TEXT NOT NULL,
+  epoch        INTEGER NOT NULL,
+  updated_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS budget_events (
+  id              TEXT PRIMARY KEY,
+  budget_name     TEXT NOT NULL,
+  epoch           INTEGER NOT NULL,
+  bucket_key      TEXT NOT NULL,
+  kind            TEXT NOT NULL,
+  amount          REAL NOT NULL,
+  currency        TEXT NOT NULL,
+  tool_name       TEXT NOT NULL,
+  origin          TEXT NOT NULL,
+  audit_record_id TEXT,
+  timestamp       TEXT NOT NULL,
+  timestamp_ms    INTEGER NOT NULL,
+  created_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS budget_bucket_gc (
+  budget_name  TEXT NOT NULL,
+  bucket_key   TEXT NOT NULL,
+  gc_after_ms  INTEGER NOT NULL,
+  PRIMARY KEY (budget_name, bucket_key)
+);
+`
+
+const CREATE_INDEX_DDL = `
+CREATE INDEX IF NOT EXISTS idx_budget_events_replay
+  ON budget_events (budget_name, epoch, bucket_key, timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_budget_events_timestamp_ms
+  ON budget_events (timestamp_ms);
+`
+
+const BUDGET_TABLES = ['budget_meta', 'budget_events', 'budget_bucket_gc'] as const
+
+/** The `pragma table_info` row shape used by the schema assertion. */
+interface ColumnInfo {
+  readonly name: string
+  readonly type: string
+  readonly notnull: number
+  readonly pk: number
+}
+
+const INSERT_EVENT_SQL = `
+INSERT INTO budget_events (
+  id, budget_name, epoch, bucket_key, kind, amount, currency,
+  tool_name, origin, audit_record_id, timestamp, timestamp_ms, created_at
+) VALUES (
+  @id, @budget_name, @epoch, @bucket_key, @kind, @amount, @currency,
+  @tool_name, @origin, @audit_record_id, @timestamp, @timestamp_ms, @created_at
+)
+`
+
+const UPSERT_META_SQL = `
+INSERT INTO budget_meta (budget_name, limit_amount, currency, window, key, epoch, updated_at)
+VALUES (@budget_name, @limit_amount, @currency, @window, @key, @epoch, @updated_at)
+ON CONFLICT (budget_name) DO UPDATE SET
+  limit_amount = excluded.limit_amount,
+  currency     = excluded.currency,
+  window       = excluded.window,
+  key          = excluded.key,
+  epoch        = excluded.epoch,
+  updated_at   = excluded.updated_at
+`
+
+const UPSERT_GC_SQL = `
+INSERT INTO budget_bucket_gc (budget_name, bucket_key, gc_after_ms)
+VALUES (@budget_name, @bucket_key, @gc_after_ms)
+ON CONFLICT (budget_name, bucket_key) DO UPDATE SET
+  gc_after_ms = excluded.gc_after_ms
+`
+
+const REPLAY_DURATION_SQL = `
+SELECT bucket_key, amount, timestamp_ms
+FROM budget_events
+WHERE budget_name = ? AND epoch = ? AND timestamp_ms > ?
+ORDER BY timestamp_ms ASC, rowid ASC
+`
+
+// Last activity comes from ALL rows of the epoch (MAX timestamp), while the
+// sum counts only rows past the bucket's idle-GC watermark: a pot that was
+// collected and later resurrected under the same key must not re-absorb
+// pre-GC spend on the next restart.
+//
+// The sum bound is calibrated against the engine's in-memory semantics:
+// INCLUSIVE of the watermark millisecond, because a post-GC spend can land
+// in the same tick as the sweep while every pre-GC row is strictly older
+// than the watermark by the idle-TTL inequality (ts <= lastActivity <
+// gcTime - ttl < gcTime). Liveness policy (idle-TTL) is applied by the
+// engine, which is why every bucket of the epoch is returned.
+const REPLAY_SESSION_SQL = `
+SELECT e.bucket_key AS bucket_key,
+       SUM(CASE WHEN e.timestamp_ms >= COALESCE(g.gc_after_ms, 0) THEN e.amount ELSE 0 END) AS total,
+       MAX(e.timestamp_ms) AS last_activity_ms
+FROM budget_events e
+LEFT JOIN budget_bucket_gc g
+  ON g.budget_name = e.budget_name AND g.bucket_key = e.bucket_key
+WHERE e.budget_name = ? AND e.epoch = ?
+GROUP BY e.bucket_key
+ORDER BY e.bucket_key ASC
+`
+
+function describeColumn(column: ColumnInfo): string {
+  return `"${column.type}${column.notnull ? ' NOT NULL' : ''}${column.pk ? ' PRIMARY KEY' : ''}"`
+}
+
+export interface BudgetLedgerOptions {
+  /**
+   * The audit store's open database handle (AuditStore.database). The ledger
+   * co-locates its tables there and never opens, closes, or re-hardens the
+   * connection — that all stays with the store.
+   */
+  readonly database: DatabaseType
+  /** Clock function for testable time (created_at stamps). Defaults to `Date.now`. */
+  readonly now?: () => number
+}
+
+export class BudgetLedger implements BudgetPersistence {
+  private readonly db: DatabaseType
+  private readonly now: () => number
+  private readonly insertEventStmt: Statement
+  private readonly upsertMetaStmt: Statement
+  private readonly upsertGcStmt: Statement
+  private readonly readMetaStmt: Statement
+  private readonly readAllMetaStmt: Statement
+  private readonly maxEventEpochStmt: Statement
+  private readonly replayDurationStmt: Statement
+  private readonly replaySessionStmt: Statement
+  private readonly commitTxn: (rows: readonly BudgetLedgerRow[]) => void
+  private readonly writeMetaTxn: (metas: readonly BudgetMetaRow[]) => void
+  private readonly purgeTxn: (cutoffMs: number) => { events: number; watermarks: number }
+
+  constructor(options: BudgetLedgerOptions) {
+    this.db = options.database
+    this.now = options.now ?? Date.now
+
+    this.db.exec(CREATE_TABLES_DDL)
+    this.assertRequiredSchema()
+    this.db.exec(CREATE_INDEX_DDL)
+
+    this.insertEventStmt = this.db.prepare(INSERT_EVENT_SQL)
+    this.upsertMetaStmt = this.db.prepare(UPSERT_META_SQL)
+    this.upsertGcStmt = this.db.prepare(UPSERT_GC_SQL)
+    this.readMetaStmt = this.db.prepare(
+      'SELECT budget_name, limit_amount, currency, window, key, epoch FROM budget_meta WHERE budget_name = ?',
+    )
+    this.readAllMetaStmt = this.db.prepare(
+      'SELECT budget_name, limit_amount, currency, window, key, epoch FROM budget_meta',
+    )
+    this.maxEventEpochStmt = this.db.prepare(
+      'SELECT COALESCE(MAX(epoch), 0) AS epoch FROM budget_events WHERE budget_name = ?',
+    )
+    this.replayDurationStmt = this.db.prepare(REPLAY_DURATION_SQL)
+    this.replaySessionStmt = this.db.prepare(REPLAY_SESSION_SQL)
+
+    // One transaction for both DELETEs: a crash between them must not be
+    // able to drop a watermark while its guarded rows survive.
+    const purgeEventsStmt = this.db.prepare('DELETE FROM budget_events WHERE timestamp_ms < ?')
+    const purgeGcStmt = this.db.prepare('DELETE FROM budget_bucket_gc WHERE gc_after_ms < ?')
+    this.purgeTxn = this.db.transaction((cutoffMs: number) => ({
+      events: purgeEventsStmt.run(cutoffMs).changes,
+      watermarks: purgeGcStmt.run(cutoffMs).changes,
+    }))
+
+    this.writeMetaTxn = this.db.transaction((metas: readonly BudgetMetaRow[]) => {
+      for (const meta of metas) this.writeMeta(meta)
+    })
+
+    this.commitTxn = this.db.transaction((rows: readonly BudgetLedgerRow[]) => {
+      const createdAt = new Date(this.now()).toISOString()
+      for (const row of rows) {
+        this.insertEventStmt.run({
+          id: randomUUID(),
+          budget_name: row.budget_name,
+          epoch: row.generation,
+          bucket_key: row.bucket_key,
+          kind: row.kind,
+          amount: row.amount,
+          currency: row.currency,
+          tool_name: row.tool_name,
+          origin: row.origin,
+          audit_record_id: row.audit_record_id,
+          timestamp: row.timestamp,
+          timestamp_ms: row.timestamp_ms,
+          created_at: createdAt,
+        })
+      }
+    })
+  }
+
+  /**
+   * Validate the on-disk budget schema against the canonical DDL — column
+   * NAMES, declared TYPES, NOT NULL constraints, and PRIMARY KEYS — with the
+   * same clean-break recovery contract as the audit table (store.ts):
+   * pre-1.0 local databases are deleted, not migrated. Types matter beyond
+   * presence: a `timestamp_ms` with TEXT affinity would make every replay
+   * and retention comparison lexicographic ('900' > '1000'), silently
+   * resurrecting expired spend. The canonical shape is derived by executing
+   * the DDL itself in a scratch database, so the assertion cannot drift
+   * from what the DDL creates. Extra columns in the live table are
+   * tolerated (forward compatibility, matching the audit store's posture).
+   */
+  private assertRequiredSchema(): void {
+    const canonical = new Database(':memory:')
+    let mismatches: string[]
+    try {
+      canonical.exec(CREATE_TABLES_DDL)
+      mismatches = []
+      for (const table of BUDGET_TABLES) {
+        const expected = canonical.pragma(`table_info(${table})`) as ColumnInfo[]
+        const live = new Map(
+          (this.db.pragma(`table_info(${table})`) as ColumnInfo[]).map((col) => [col.name, col]),
+        )
+        for (const column of expected) {
+          const actual = live.get(column.name)
+          if (!actual) {
+            mismatches.push(`${table}.${column.name} (missing)`)
+            continue
+          }
+          if (
+            actual.type !== column.type ||
+            actual.notnull !== column.notnull ||
+            actual.pk !== column.pk
+          ) {
+            mismatches.push(
+              `${table}.${column.name} (found ${describeColumn(actual)}, ` +
+                `expected ${describeColumn(column)})`,
+            )
+          }
+        }
+      }
+    } finally {
+      canonical.close()
+    }
+    if (mismatches.length === 0) return
+
+    const dbPath = this.db.name
+    throw new Error(
+      '[helio] Budget ledger schema mismatch: incompatible columns ' +
+        `${mismatches.join(', ')}. ` +
+        `This local database was created by an older Helio build. ` +
+        `Delete "${dbPath}", "${dbPath}-wal", and "${dbPath}-shm", then restart Helio.`,
+    )
+  }
+
+  // -------------------------------------------------------------------------
+  // BudgetPersistence
+  // -------------------------------------------------------------------------
+
+  /** Persist every row of one call in a single transaction (all or nothing). */
+  commitAll(rows: readonly BudgetLedgerRow[]): void {
+    this.commitTxn(rows)
+  }
+
+  readMeta(budgetName: string): BudgetMetaRow | undefined {
+    return this.readMetaStmt.get(budgetName) as BudgetMetaRow | undefined
+  }
+
+  readAllMeta(): readonly BudgetMetaRow[] {
+    return this.readAllMetaStmt.all() as BudgetMetaRow[]
+  }
+
+  maxEventEpoch(budgetName: string): number {
+    const { epoch } = this.maxEventEpochStmt.get(budgetName) as { epoch: number }
+    return epoch
+  }
+
+  writeMeta(meta: BudgetMetaRow): void {
+    this.upsertMetaStmt.run({
+      budget_name: meta.budget_name,
+      limit_amount: meta.limit_amount,
+      currency: meta.currency,
+      window: meta.window,
+      key: meta.key,
+      epoch: meta.epoch,
+      updated_at: new Date(this.now()).toISOString(),
+    })
+  }
+
+  /** All of one reload's epoch mints in a single transaction (all or nothing). */
+  writeMetaBatch(metas: readonly BudgetMetaRow[]): void {
+    this.writeMetaTxn(metas)
+  }
+
+  replayDurationEvents(
+    budgetName: string,
+    epoch: number,
+    sinceMs: number,
+  ): readonly BudgetReplayEvent[] {
+    return this.replayDurationStmt.all(budgetName, epoch, sinceMs) as BudgetReplayEvent[]
+  }
+
+  replaySessionBuckets(budgetName: string, epoch: number): readonly BudgetReplayBucket[] {
+    return this.replaySessionStmt.all(budgetName, epoch) as BudgetReplayBucket[]
+  }
+
+  recordBucketGc(budgetName: string, bucketKey: string, gcAfterMs: number): void {
+    this.upsertGcStmt.run({
+      budget_name: budgetName,
+      bucket_key: bucketKey,
+      gc_after_ms: gcAfterMs,
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Retention
+  // -------------------------------------------------------------------------
+
+  /**
+   * Purge events past the retention cutoff (event-time milliseconds — the
+   * same axis every replay query filters on, so the retention bound and the
+   * replay bound cannot diverge). Watermarks older than the cutoff prune
+   * with the same statement's cutoff: every row such a watermark could
+   * filter has `timestamp_ms <= gc_after_ms < cutoffMs` and is deleted here
+   * too, so the watermark guards nothing and is safe to drop.
+   *
+   * Called from the audit store's retention sweep (one sweep schedule); the
+   * cutoff is computed once per sweep by the store.
+   */
+  purgeExpired(cutoffMs: number): { events: number; watermarks: number } {
+    return this.purgeTxn(cutoffMs)
+  }
+}

--- a/packages/proxy/src/budget/parser.ts
+++ b/packages/proxy/src/budget/parser.ts
@@ -1,6 +1,6 @@
 import picomatch from 'picomatch'
 import { parseDuration } from '../config/schema.js'
-import type { BudgetConfig } from '../config/schema.js'
+import type { BudgetsConfig } from '../config/schema.js'
 import type { CompiledBudget, CompiledBudgetContributor } from './types.js'
 
 /** Default idle TTL for `window: session` pots when `idle_ttl` is omitted. */
@@ -25,7 +25,7 @@ export class BudgetParseError extends Error {
  *
  * @throws {BudgetParseError} On an invalid contributor glob.
  */
-export function compileBudgets(budgets: readonly BudgetConfig[]): CompiledBudget[] {
+export function compileBudgets(budgets: BudgetsConfig): CompiledBudget[] {
   return budgets.map((budget) => ({
     name: budget.name,
     limit: budget.limit,

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -23,7 +23,7 @@ import {
 } from './approval/index.js'
 import { RateLimiter } from './policy/index.js'
 import { SpendLimiter } from './policy/index.js'
-import { BudgetEngine, compileBudgets } from './budget/index.js'
+import { BudgetEngine, BudgetLedger, compileBudgets } from './budget/index.js'
 import { parseDuration } from './config/schema.js'
 import { createDashboardAppWithLifecycle, DashboardEventBus } from './dashboard/index.js'
 import type { AuditRecord } from './audit/index.js'
@@ -34,7 +34,9 @@ import {
   warnIfSdkSidebandExposed,
   warnIfDashboardOpenMode,
   warnIfNoEnforcement,
+  warnIfBudgetWindowExceedsRetention,
 } from './startup-warnings.js'
+import { closeResources } from './shutdown.js'
 import { drainForCrash, registerCrashDrainHook } from './crash-drain.js'
 
 // ---------------------------------------------------------------------------
@@ -326,6 +328,18 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     retention: config.audit.retention,
     includeResponses: config.audit.include_responses,
   })
+
+  // Budget ledger: co-located in the audit database (one connection, one WAL
+  // domain, one hardening pass) and joined to the store's single retention
+  // sweep. The store's constructor purge ran before this hook could exist,
+  // so one full sweep runs now — budget rows that aged out while the proxy
+  // was down must not wait a day for the timer.
+  const budgetLedger = new BudgetLedger({ database: auditStore.database })
+  auditStore.onRetentionSweep((cutoff) => {
+    budgetLedger.purgeExpired(cutoff.ms)
+  })
+  auditStore.runRetentionSweep()
+
   const auditWriter = new AuditWriter({
     store: auditStore,
     onPersist: (record, id) => {
@@ -418,7 +432,10 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   // One budget engine shared by both doors — one pot, MCP and sideband alike.
   // Constructed even with zero budgets configured so a hot-reload can
   // introduce budgets without a restart; the gate short-circuits when empty.
-  const budgetEngine = new BudgetEngine({ budgets })
+  // Hydration replays persisted spend BEFORE any server starts listening, so
+  // the first governed call already sees the rebuilt pots.
+  const budgetEngine = new BudgetEngine({ budgets, ledger: budgetLedger })
+  budgetEngine.hydrate()
 
   const governedForwarder = new GovernedForwarder(forwarder, policy, {
     environment: config.environment,
@@ -578,6 +595,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   warnIfWebhookChannelUnreachable(config)
   warnIfSdkSidebandExposed(config)
   warnIfDashboardOpenMode(config)
+  warnIfBudgetWindowExceedsRetention(config)
   const channelCount = config.approval.channels.length
   console.error(
     `Approvals: timeout ${config.approval.timeout}, default on timeout: ${config.approval.default_on_timeout}, ${String(channelCount)} channel${channelCount !== 1 ? 's' : ''} configured`,
@@ -605,9 +623,13 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
       configPath,
       initialConfig: config,
       onPolicyReload: (newPolicy, reloadWarnings, restartRequiredPaths, newBudgets) => {
+        // Budgets reconcile FIRST: it persists the reload's epoch mints and
+        // throws when the flush fails, which rejects the whole reload (the
+        // watcher's onError keeps the current config) before any policy
+        // swap — the reload applies all-or-nothing across the file.
+        budgetEngine.reconcile(newBudgets)
         governedForwarder.updatePolicy(newPolicy)
         governanceService?.updatePolicy(newPolicy)
-        budgetEngine.reconcile(newBudgets)
         const budgetTotal = newBudgets.length
         console.error(
           `[helio] Budgets reloaded: ${String(budgetTotal)} budget${budgetTotal !== 1 ? 's' : ''}`,
@@ -632,7 +654,9 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
         }
       },
       onError: (error) => {
-        console.error(`[helio] Config reload failed (keeping current policy): ${error.message}`)
+        console.error(
+          `[helio] Config reload failed (keeping current configuration): ${error.message}`,
+        )
       },
     })
     configWatcher.start()
@@ -845,26 +869,24 @@ function registerShutdown(
     }, SHUTDOWN_TIMEOUT_MS)
     forceShutdownTimer.unref()
 
-    const closeAll = async () => {
-      if (annotationPrime) annotationPrime.stop()
-      if (configWatcher) configWatcher.close()
-      if (closeDashboardApp) closeDashboardApp()
-      if (eventBus) eventBus.close()
-      if (governanceService) governanceService.close()
-      if (rateLimiter) rateLimiter.close()
-      if (spendLimiter) spendLimiter.close()
-      if (budgetEngine) budgetEngine.close()
-      if (approvalRouter) approvalRouter.close()
-      if (approvalQueue) approvalQueue.close()
-      if (dashboardHandle) await dashboardHandle.close()
-      if (sidebandHandle) await sidebandHandle.close()
-      await handle.close()
-      if (evidenceStore) evidenceStore.close()
-      if (auditWriter) auditWriter.close()
-      if (closeForwarder) await closeForwarder()
-    }
-
-    void closeAll()
+    void closeResources({
+      handle,
+      annotationPrime,
+      closeForwarder,
+      auditWriter,
+      configWatcher,
+      sidebandHandle,
+      evidenceStore,
+      approvalRouter,
+      approvalQueue,
+      rateLimiter,
+      spendLimiter,
+      budgetEngine,
+      closeDashboardApp,
+      dashboardHandle,
+      eventBus,
+      governanceService,
+    })
       .then(() => {
         clearTimeout(forceShutdownTimer)
         process.exit(0)

--- a/packages/proxy/src/policy/governed-forwarder.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder.test.ts
@@ -14,6 +14,8 @@ import type { ApprovalChannel } from '../approval/types.js'
 import { RateLimiter } from './rate-limiter.js'
 import { SpendLimiter } from './spend-limiter.js'
 import { BudgetEngine } from '../budget/engine.js'
+import type { BudgetLedgerSink } from '../budget/engine.js'
+import { BudgetLedger } from '../budget/ledger.js'
 import { compileBudgets } from '../budget/parser.js'
 
 // ---------------------------------------------------------------------------
@@ -3742,6 +3744,102 @@ describe('GovernedForwarder', () => {
       const chain = record?.evidence_chain as Record<string, unknown>
       const budgets = chain['budgets'] as Array<Record<string, unknown>>
       expect(budgets[0]?.['ledger_write_failed']).toBe(true)
+    })
+
+    it('persists real ledger rows sharing the pre-generated audit record id (PR 2)', async () => {
+      const inner = mockForwarder()
+      const auditStore = new AuditStore({
+        path: ':memory:',
+        retention: '90d',
+        includeResponses: true,
+        cleanupIntervalMs: 0,
+      })
+      const ledger = new BudgetLedger({ database: auditStore.database })
+      const engine = new BudgetEngine({
+        budgets: compileBudgets([stripeBudget]),
+        cleanupIntervalMs: 0,
+        ledger,
+      })
+      engine.hydrate()
+      const auditWriter = new AuditWriter({ store: auditStore, flushIntervalMs: 0 })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+        auditWriter,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 30 }))
+
+      // Read BEFORE the audit flush: the ledger write is synchronous at
+      // record time, never buffered behind the audit writer.
+      const row = auditStore.database.prepare('SELECT * FROM budget_events').get() as Record<
+        string,
+        unknown
+      >
+      expect(row).toMatchObject({
+        budget_name: 'daily-cap',
+        epoch: 1,
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 30,
+        currency: 'USD',
+        tool_name: 'stripe_charge',
+        origin: 'mcp',
+      })
+
+      // The ledger row references the audit record even though the audit
+      // write itself is buffered: the id is pre-generated at the gate.
+      auditWriter.flush()
+      expect(row['audit_record_id']).toBe(auditStore.list().records[0]?.id)
+      auditStore.close()
+    })
+
+    it('a real-ledger fault blocks the call, persists nothing, and the next call recovers (PR 2)', async () => {
+      const inner = mockForwarder()
+      const auditStore = new AuditStore({
+        path: ':memory:',
+        retention: '90d',
+        includeResponses: true,
+        cleanupIntervalMs: 0,
+      })
+      const ledger = new BudgetLedger({ database: auditStore.database })
+      let failNext = true
+      const failOnce: BudgetLedgerSink = {
+        commitAll: (rows) => {
+          if (failNext) {
+            failNext = false
+            throw new Error('disk full')
+          }
+          ledger.commitAll(rows)
+        },
+      }
+      const engine = new BudgetEngine({
+        budgets: compileBudgets([stripeBudget]),
+        cleanupIntervalMs: 0,
+        ledger: failOnce,
+      })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      const blocked = await governed.forward(toolsCallRequest('stripe_charge', { amount: 5 }))
+      expect(inner.forward).not.toHaveBeenCalled()
+      expect(errorFromResult(blocked).data['failure_class']).toBe('budget_ledger_write_failed')
+      const countRows = () =>
+        (
+          auditStore.database.prepare('SELECT COUNT(*) AS count FROM budget_events').get() as {
+            count: number
+          }
+        ).count
+      expect(countRows()).toBe(0)
+      expect(engine.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+
+      // The fault was transient: the next call commits and forwards.
+      const ok = await governed.forward(toolsCallRequest('stripe_charge', { amount: 5 }))
+      expect(ok.response.status).toBe(200)
+      expect(inner.forward).toHaveBeenCalledTimes(1)
+      expect(countRows()).toBe(1)
+      expect(engine.listStates()[0]?.buckets[0]?.spent).toBe(5)
+      auditStore.close()
     })
 
     it('returns the upstream result even when post-forward bookkeeping throws', async () => {

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -461,7 +461,9 @@ export class GovernedForwarder implements McpForwarder {
             // ledger commits FIRST: a durable-write failure must block the
             // call WITHOUT having consumed the rule counters, and it reports
             // its own failure class instead of masquerading as an upstream
-            // error.
+            // error. INVARIANT: commitRuleLimit below must not throw (it
+            // records with config-validated params) — a throw there would
+            // block the call with the budget spend already durably counted.
             let ledgerBlock: ForwardResult | undefined
             try {
               budgetsChain = budgetGate.commit?.(auditRecordId) ?? budgetsChain

--- a/packages/proxy/src/shutdown.test.ts
+++ b/packages/proxy/src/shutdown.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { closeResources } from './shutdown.js'
+
+function orderedHarness() {
+  const order: string[] = []
+  const sync = (name: string) => ({
+    close: () => {
+      order.push(name)
+    },
+  })
+  const asyncClose = (name: string) => ({
+    close: async () => {
+      // A real server drain crosses the event loop; the sequencing must
+      // hold across genuine await points, not just synchronous calls.
+      await Promise.resolve()
+      order.push(name)
+    },
+  })
+  return { order, sync, asyncClose }
+}
+
+describe('closeResources', () => {
+  it('drains every traffic door before tearing down governance state', async () => {
+    const { order, sync, asyncClose } = orderedHarness()
+
+    await closeResources({
+      handle: asyncClose('handle'),
+      annotationPrime: { stop: () => order.push('annotationPrime') },
+      closeForwarder: async () => {
+        await Promise.resolve()
+        order.push('forwarder')
+      },
+      auditWriter: sync('auditWriter'),
+      configWatcher: sync('configWatcher'),
+      sidebandHandle: asyncClose('sidebandHandle'),
+      evidenceStore: sync('evidenceStore'),
+      approvalRouter: sync('approvalRouter'),
+      approvalQueue: sync('approvalQueue'),
+      rateLimiter: sync('rateLimiter'),
+      spendLimiter: sync('spendLimiter'),
+      budgetEngine: sync('budgetEngine'),
+      closeDashboardApp: () => order.push('dashboardApp'),
+      dashboardHandle: asyncClose('dashboardHandle'),
+      eventBus: sync('eventBus'),
+      governanceService: sync('governanceService'),
+    })
+
+    const position = (name: string) => order.indexOf(name)
+
+    // A request admitted during shutdown must see real pots and counters: a
+    // cleared budget pot reads as full headroom. Every door drains first.
+    for (const door of ['handle', 'sidebandHandle', 'dashboardHandle']) {
+      for (const governance of [
+        'budgetEngine',
+        'rateLimiter',
+        'spendLimiter',
+        'governanceService',
+      ]) {
+        expect(position(door), `${door} must close before ${governance}`).toBeLessThan(
+          position(governance),
+        )
+      }
+    }
+
+    // Approvals resolve BEFORE the doors drain, or requests parked on a
+    // ticket would hang the drain until the force-exit timer.
+    expect(position('approvalRouter')).toBeLessThan(position('handle'))
+    expect(position('approvalQueue')).toBeLessThan(position('handle'))
+
+    // Storage closes last so drained requests could still write audit rows.
+    expect(position('auditWriter')).toBeGreaterThan(position('budgetEngine'))
+    expect(order).toHaveLength(16)
+  })
+
+  it('handles a minimal resource set (only the MCP handle)', async () => {
+    const { order, asyncClose } = orderedHarness()
+    await expect(closeResources({ handle: asyncClose('handle') })).resolves.toBeUndefined()
+    expect(order).toEqual(['handle'])
+  })
+})

--- a/packages/proxy/src/shutdown.ts
+++ b/packages/proxy/src/shutdown.ts
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------
+// Shutdown sequencing. The order is load-bearing for money state: every
+// traffic door must stop accepting and DRAIN before any governance state is
+// torn down, because a request served during shutdown must see real pots and
+// counters — a cleared budget pot or limiter bucket reads as full headroom
+// and would let a final call overspend (and, for budgets, durably ledger the
+// overspend). Structural types keep this module import-light and testable.
+// ---------------------------------------------------------------------------
+
+export interface CloseableResources {
+  /** The MCP server — the primary traffic door. Drained with `await`. */
+  handle: { close(): Promise<void> }
+  annotationPrime?: { stop(): void }
+  closeForwarder?: () => Promise<void>
+  auditWriter?: { close(): void }
+  configWatcher?: { close(): void }
+  sidebandHandle?: { close(): Promise<void> }
+  evidenceStore?: { close(): void }
+  approvalRouter?: { close(): void }
+  approvalQueue?: { close(): void }
+  rateLimiter?: { close(): void }
+  spendLimiter?: { close(): void }
+  budgetEngine?: { close(): void }
+  closeDashboardApp?: () => void
+  dashboardHandle?: { close(): Promise<void> }
+  eventBus?: { close(): void }
+  governanceService?: { close(): void }
+}
+
+/** Close everything the proxy holds, in traffic-safe order. */
+export async function closeResources(resources: CloseableResources): Promise<void> {
+  // Background loops first: nothing may schedule new work mid-shutdown.
+  resources.annotationPrime?.stop()
+  resources.configWatcher?.close()
+
+  // Resolve pending approvals BEFORE draining the doors: requests parked on
+  // a ticket unblock as shutdown-cancelled (fail closed) instead of hanging
+  // the drain on a human who will never answer.
+  resources.approvalRouter?.close()
+  resources.approvalQueue?.close()
+
+  // Disconnect SSE fan-out before its door: open event streams would
+  // otherwise hold the dashboard server's drain until the force-exit timer.
+  resources.closeDashboardApp?.()
+  resources.eventBus?.close()
+
+  // Traffic doors close and drain. Only after these awaits resolve is it
+  // safe to tear down governance state.
+  if (resources.dashboardHandle) await resources.dashboardHandle.close()
+  if (resources.sidebandHandle) await resources.sidebandHandle.close()
+  await resources.handle.close()
+
+  // Governance state, now unreachable by new traffic.
+  resources.governanceService?.close()
+  resources.rateLimiter?.close()
+  resources.spendLimiter?.close()
+  resources.budgetEngine?.close()
+
+  // Storage last: drained requests above may still have flushed audit rows.
+  resources.evidenceStore?.close()
+  resources.auditWriter?.close()
+  if (resources.closeForwarder) await resources.closeForwarder()
+}

--- a/packages/proxy/src/sideband/governance-api.test.ts
+++ b/packages/proxy/src/sideband/governance-api.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
 import { createSidebandApp } from '../evidence/api.js'
 import { EvidenceStore } from '../evidence/store.js'
 import { GovernanceService } from './governance-service.js'
 import { BudgetEngine } from '../budget/engine.js'
+import type { BudgetLedgerSink } from '../budget/engine.js'
+import { BudgetLedger } from '../budget/ledger.js'
 import { compileBudgets } from '../budget/parser.js'
 import { compilePolicies } from '../policy/parser.js'
 import { ApprovalRouter } from '../approval/router.js'
@@ -492,6 +495,69 @@ describe('POST /evaluate — budget_exceeded over HTTP (issue #14)', () => {
     expect(limits.budgets[0]?.['reset_at_ms']).toBeDefined()
     const feedback = body['feedback'] as { message: string }
     expect(feedback.message).toContain('"cap"')
+
+    budgetEngine.close()
+    governance.close()
+    store.close()
+  })
+
+  it('a budget ledger fault maps to a 500 on /audit; the adapter retry gets 201 (PR 2)', async () => {
+    const policy = compilePolicies({ default: 'allow', dry_run: false, rules: [] }).policy
+    const db = new Database(':memory:')
+    const ledger = new BudgetLedger({ database: db })
+    let failNext = true
+    const failOnce: BudgetLedgerSink = {
+      commitAll: (rows) => {
+        if (failNext) {
+          failNext = false
+          throw new Error('disk full')
+        }
+        ledger.commitAll(rows)
+      },
+    }
+    const budgetEngine = new BudgetEngine({
+      budgets: compileBudgets([
+        {
+          name: 'cap',
+          limit: 100,
+          currency: 'USD',
+          window: '24h',
+          key: 'global',
+          on_exceed: 'deny',
+          contributors: [{ tool: 'send', field: '$.amount' }],
+        },
+      ]),
+      cleanupIntervalMs: 0,
+      ledger: failOnce,
+    })
+    const governance = new GovernanceService({ policy, budgetEngine, sweepIntervalMs: 0 })
+    const store = new EvidenceStore()
+    const app = createSidebandApp(store, { governance })
+    const post = (path: string, body: unknown) =>
+      app.request(path, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+    const evalRes = await post('/evaluate', {
+      origin: 'openclaw',
+      tool: { name: 'send' },
+      arguments: { amount: 30 },
+    })
+    const evaluationId = ((await evalRes.json()) as Record<string, unknown>)['evaluation_id']
+
+    // First /audit: the durable write fails → 500, nothing committed, the
+    // pending entry survives for the idempotent retry.
+    const failed = await post('/audit', { evaluation_id: evaluationId, status: 'success' })
+    expect(failed.status).toBe(500)
+    const countRows = () =>
+      (db.prepare('SELECT COUNT(*) AS count FROM budget_events').get() as { count: number }).count
+    expect(countRows()).toBe(0)
+
+    const retry = await post('/audit', { evaluation_id: evaluationId, status: 'success' })
+    expect(retry.status).toBe(201)
+    expect(countRows()).toBe(1)
 
     budgetEngine.close()
     governance.close()

--- a/packages/proxy/src/sideband/governance-service.test.ts
+++ b/packages/proxy/src/sideband/governance-service.test.ts
@@ -7,9 +7,12 @@ import type { PoliciesConfig } from '../config/schema.js'
 import type { CompiledPolicy } from '../policy/types.js'
 import type { AuditRecord } from '../audit/types.js'
 import type { AuditWriter } from '../audit/writer.js'
+import Database from 'better-sqlite3'
 import { RateLimiter } from '../policy/rate-limiter.js'
 import { SpendLimiter } from '../policy/spend-limiter.js'
 import { BudgetEngine } from '../budget/engine.js'
+import type { BudgetLedgerSink } from '../budget/engine.js'
+import { BudgetLedger } from '../budget/ledger.js'
 import { compileBudgets } from '../budget/parser.js'
 import type { BudgetConfig } from '../config/schema.js'
 import { ApprovalRouter } from '../approval/router.js'
@@ -65,6 +68,7 @@ function makeService(opts?: {
   maxSenderKeys?: number
   maxPendingBytes?: number
   budgets?: BudgetConfig[]
+  budgetLedger?: BudgetLedgerSink
 }): ServiceHarness {
   let time = 1_000_000
   const now = () => time
@@ -93,7 +97,12 @@ function makeService(opts?: {
       : undefined
   const evidenceStore = opts?.withEvidence ? new EvidenceStore({ now }) : undefined
   const budgetEngine = opts?.budgets
-    ? new BudgetEngine({ budgets: compileBudgets(opts.budgets), now, cleanupIntervalMs: 0 })
+    ? new BudgetEngine({
+        budgets: compileBudgets(opts.budgets),
+        now,
+        cleanupIntervalMs: 0,
+        ...(opts.budgetLedger && { ledger: opts.budgetLedger }),
+      })
     : undefined
 
   const service = new GovernanceService({
@@ -1999,6 +2008,71 @@ describe('GovernanceService — budget gate (issue #14)', () => {
     const chain = record?.record.evidence_chain as Record<string, unknown>
     const budgets = chain['budgets'] as Array<Record<string, unknown>>
     expect(budgets[0]?.['kind']).toBe('spend')
+  })
+
+  it('persists real ledger rows at /audit sharing the audit record id (PR 2)', () => {
+    const db = new Database(':memory:')
+    const ledger = new BudgetLedger({ database: db })
+    const { service, records } = makeService({
+      budgets: [stripeBudget()],
+      budgetLedger: ledger,
+    })
+
+    const id = service.evaluate(stripeEval(30)).body['evaluation_id'] as string
+    expect(service.audit(auditInput(id), 'h').status).toBe(201)
+
+    const rows = db.prepare('SELECT * FROM budget_events').all() as Array<Record<string, unknown>>
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      budget_name: 'cap',
+      epoch: 1,
+      bucket_key: 'budget:cap:global',
+      kind: 'spend',
+      amount: 30,
+      currency: 'USD',
+      tool_name: 'stripe_charge',
+      origin: 'openclaw',
+    })
+    // The row references the pre-generated id of the call's audit record.
+    const record = records.find((r) => r.record.tool_name === 'stripe_charge')
+    expect(rows[0]?.['audit_record_id']).toBe(record?.id)
+  })
+
+  it('a ledger write failure keeps the entry pending; the adapter retry succeeds (PR 2)', () => {
+    // A REAL SQLite ledger behind a fail-once gate: the first /audit throws
+    // (the route layer maps this to a 500) BEFORE the commit latch is set,
+    // so nothing persists anywhere and the idempotent retry re-attempts the
+    // whole commit cleanly.
+    const db = new Database(':memory:')
+    const ledger = new BudgetLedger({ database: db })
+    let failNext = true
+    const failOnce: BudgetLedgerSink = {
+      commitAll: (rows) => {
+        if (failNext) {
+          failNext = false
+          throw new Error('disk full')
+        }
+        ledger.commitAll(rows)
+      },
+    }
+    const { service, budgetEngine } = makeService({
+      budgets: [stripeBudget()],
+      budgetLedger: failOnce,
+    })
+
+    const id = service.evaluate(stripeEval(30)).body['evaluation_id'] as string
+    expect(() => service.audit(auditInput(id), 'h')).toThrow('disk full')
+
+    // Hard atomicity: no rows, no memory, entry still pending.
+    const countRows = () =>
+      (db.prepare('SELECT COUNT(*) AS count FROM budget_events').get() as { count: number }).count
+    expect(countRows()).toBe(0)
+    expect(budgetEngine?.listStates().flatMap((s2) => s2.buckets)).toEqual([])
+
+    const retry = service.audit(auditInput(id), 'h')
+    expect(retry.status).toBe(201)
+    expect(countRows()).toBe(1)
+    expect(budgetEngine?.listStates()[0]?.buckets[0]?.spent).toBe(30)
   })
 
   it('rejects a post-commit retry that presents a different payload', () => {

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -1354,6 +1354,12 @@ export class GovernanceService {
     // The fallible budget ledger commits FIRST: a throw here propagates out
     // of audit() with the entry still pending and NO limiter state consumed,
     // so the adapter's idempotent retry cannot double-record rate/spend.
+    // INVARIANT: nothing between this recordAll and the commitState latch in
+    // audit() may throw — the rate/spend records below run on inputs already
+    // validated at /evaluate and /audit — because a throw there would make
+    // the retry re-run recordAll and double-commit the budgets. Adding a
+    // fallible step to this window requires latching the budget commit
+    // separately first.
     const budgetPlans = entry.plans.filter((plan): plan is BudgetPlan => plan.kind === 'budget')
     if (budgetPlans.length > 0 && this.budgetEngine) {
       // actual_amount, when supplied, is the call's one true realized cost

--- a/packages/proxy/src/startup-warnings.test.ts
+++ b/packages/proxy/src/startup-warnings.test.ts
@@ -4,6 +4,7 @@ import {
   warnIfSdkSidebandExposed,
   warnIfDashboardOpenMode,
   warnIfNoEnforcement,
+  warnIfBudgetWindowExceedsRetention,
 } from './startup-warnings.js'
 
 describe('warnIfWebhookChannelUnreachable', () => {
@@ -242,5 +243,93 @@ describe('warnIfNoEnforcement', () => {
 
     expect(warned).toBe(false)
     expect(messages).toHaveLength(0)
+  })
+})
+
+describe('warnIfBudgetWindowExceedsRetention', () => {
+  function makeConfig(
+    budgets: Array<{ name: string; window: string; idle_ttl?: string }>,
+    retention = '90d',
+  ) {
+    return { budgets, audit: { retention } }
+  }
+
+  it('warns when a duration window is longer than the retention', () => {
+    const messages: string[] = []
+    const warned = warnIfBudgetWindowExceedsRetention(
+      makeConfig([{ name: 'long-cap', window: '30d' }], '7d'),
+      (m) => messages.push(m),
+    )
+
+    expect(warned).toBe(true)
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toContain('long-cap')
+    expect(messages[0]).toContain('window 30d')
+    expect(messages[0]).toContain('audit.retention 7d')
+  })
+
+  it('warns when a session idle_ttl is longer than the retention', () => {
+    const messages: string[] = []
+    const warned = warnIfBudgetWindowExceedsRetention(
+      makeConfig([{ name: 'sc', window: 'session', idle_ttl: '14d' }], '7d'),
+      (m) => messages.push(m),
+    )
+
+    expect(warned).toBe(true)
+    expect(messages[0]).toContain('idle_ttl 14d')
+  })
+
+  it('uses the 24h default idle_ttl for session windows', () => {
+    const messages: string[] = []
+    const warned = warnIfBudgetWindowExceedsRetention(
+      makeConfig([{ name: 'sc', window: 'session' }], '12h'),
+      (m) => messages.push(m),
+    )
+
+    expect(warned).toBe(true)
+    expect(messages[0]).toContain('idle_ttl 24h')
+  })
+
+  it('does not warn when every horizon fits inside the retention', () => {
+    const messages: string[] = []
+    const warned = warnIfBudgetWindowExceedsRetention(
+      makeConfig([
+        { name: 'daily', window: '24h' },
+        { name: 'sc', window: 'session', idle_ttl: '48h' },
+      ]),
+      (m) => messages.push(m),
+    )
+
+    expect(warned).toBe(false)
+    expect(messages).toHaveLength(0)
+  })
+
+  it('does not warn at exactly the retention bound', () => {
+    const messages: string[] = []
+    const warned = warnIfBudgetWindowExceedsRetention(
+      makeConfig([{ name: 'edge', window: '90d' }], '90d'),
+      (m) => messages.push(m),
+    )
+
+    expect(warned).toBe(false)
+    expect(messages).toHaveLength(0)
+  })
+
+  it('warns once per offending budget', () => {
+    const messages: string[] = []
+    const warned = warnIfBudgetWindowExceedsRetention(
+      makeConfig(
+        [
+          { name: 'a', window: '30d' },
+          { name: 'b', window: '20d' },
+          { name: 'ok', window: '1h' },
+        ],
+        '7d',
+      ),
+      (m) => messages.push(m),
+    )
+
+    expect(warned).toBe(true)
+    expect(messages).toHaveLength(2)
   })
 })

--- a/packages/proxy/src/startup-warnings.ts
+++ b/packages/proxy/src/startup-warnings.ts
@@ -1,7 +1,48 @@
 /* eslint-disable no-console -- surfaces operator-visible startup warnings */
 
+import { parseDuration } from './config/schema.js'
+
 function isLoopbackHost(host: string): boolean {
   return host === '127.0.0.1' || host === 'localhost' || host === '::1'
+}
+
+/**
+ * Emit a startup warning for every budget whose replay horizon exceeds
+ * `audit.retention`. The budget ledger is purged on the audit retention
+ * sweep, so a duration window (or a session pot's `idle_ttl`) longer than
+ * the retention loses its oldest rows while they still matter: a restart
+ * then under-counts the pot and silently re-opens spend the window should
+ * still be holding. Surfaced at boot because the misconfiguration is
+ * otherwise invisible until a restart.
+ */
+export function warnIfBudgetWindowExceedsRetention(
+  config: {
+    budgets: ReadonlyArray<{ name: string; window: string; idle_ttl?: string }>
+    audit: { retention: string }
+  },
+  log: (message: string) => void = console.error,
+): boolean {
+  const retentionMs = parseDuration(config.audit.retention)
+  let warned = false
+  for (const budget of config.budgets) {
+    const horizonMs =
+      budget.window === 'session'
+        ? parseDuration(budget.idle_ttl ?? '24h')
+        : parseDuration(budget.window)
+    const horizonLabel =
+      budget.window === 'session'
+        ? `idle_ttl ${budget.idle_ttl ?? '24h'}`
+        : `window ${budget.window}`
+    if (horizonMs <= retentionMs) continue
+    log(
+      `[helio] Warning: budget "${budget.name}" has ${horizonLabel}, longer than ` +
+        `audit.retention ${config.audit.retention}. The spend ledger is purged on the ` +
+        'retention sweep, so a restart can forget in-window spend and re-open the pot. ' +
+        'Raise audit.retention or shorten the budget window.',
+    )
+    warned = true
+  }
+  return warned
 }
 
 /**


### PR DESCRIPTION
## What

The persistence slice of named budgets (#14): budget spend survives restarts. Every committed charge is written to a ledger inside the existing audit database and replayed at startup, so the pots a call is checked against are the same pots the previous process was holding.

**Ledger.** A new `BudgetLedger` owns three tables in the audit SQLite file. `budget_events` records one row per charge, synchronously and in one transaction per call, stamped with the config epoch it was spent under. `budget_meta` holds each budget's identity tuple (`limit`, `currency`, `window`, `key`) and its epoch: any change the proxy observes — a tuple edit or a removal, live via hot-reload or discovered at startup — bumps the epoch and resets the pot, so rows from older epochs stay queryable as history but never replay. `budget_bucket_gc` keeps idle-collection watermarks so a session key that reappears after its pot was collected cannot re-absorb pre-collection spend, including pots that crossed their TTL while the proxy was down. Epoch minting always consults the highest epoch present in the rows, so an epoch that already has rows is never reused for a different pot.

**Replay.** `BudgetEngine.hydrate()` runs before any server starts: duration windows rebuild from the rows inside the window and resume exactly where they left off (millisecond-calibrated against the in-memory eviction bounds); `session` pots whose last activity is within `idle_ttl` come back with their full accrued spend, watermark-filtered. Hot reloads persist their epoch changes in one batch before any state swap; a failed flush rejects the reload as a whole and the proxy keeps its complete current configuration.

**Shared infrastructure.** The ledger rides the audit store's connection, WAL mode, permission hardening, and retention schedule: an `onRetentionSweep` hook purges budget events and stale watermarks past the same cutoff, with one sweep at startup for rows that aged out while down. The on-disk schema is validated against the canonical DDL — names, types, constraints, keys — under the same pre-1.0 clean-break policy as the audit table.

**Failure semantics.** Ledger write failures fail closed per door: the MCP proxy blocks the call before forwarding without consuming any counters, and the sideband fails the `/audit` report so the evaluation stays pending for the adapter's idempotent retry. Shutdown now drains every traffic door before tearing down governance state, so a request served mid-shutdown cannot observe a cleared pot as full headroom. A startup warning flags budget windows or idle TTLs longer than `audit.retention`.

## Review

Three external review rounds (two REQUEST-CHANGES, final approve) on top of an internal multi-angle pass. The load-bearing findings — dead-pot watermarks for TTLs crossed during downtime, epoch minting against orphaned rows, removal-while-down retirement, persist-before-swap reload rejection, shutdown door-drain ordering, and typed schema validation — are fixed with dedicated regression tests. Follow-ups filed: #147 (index definition validation), #148 (budget_meta tombstone pruning), #149 (expiry after a post-commit audit-write failure), #150 (watcher callback rename).

## Testing

TDD throughout. 1,908 proxy + 309 dashboard + 47 python-sdk tests, including: restart replay for both window types at exact boundary instants, the GC-watermark resurrection sequence across restarts, epoch A→B→A double changes, reload rejection with revert-restart continuity, real-ledger mid-transaction rollback on both doors (HTTP-level 500-then-retry on the sideband), retention purge and watermark churn bounds, shutdown ordering across real await points, and injectable clocks everywhere.

Part of #14.