### PR TITLE
feat(dashboard): budgets view with live depletion and spend ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,7 @@ Maintainer notes:
   `/audit` only when the call executed. Budgets hot-reload by name identity:
   contributor edits preserve accrued spend; `limit`/`currency`/`window`
   changes reset it. Breach modes are `on_exceed: deny` and
-  `on_exceed: require_approval` (break-glass, below); the dashboard Budgets
-  view lands next in this release train.
+  `on_exceed: require_approval` (break-glass, below).
 - **Break-glass approvals for budget overages (#14).** A budget with
   `on_exceed: require_approval` turns a breach into a human decision instead
   of a denial. One call raises one composite ticket listing every breached
@@ -89,6 +88,26 @@ Maintainer notes:
   store's existing sweep, and a budget window longer than the retention
   draws a startup warning. Rule-level rate/spend limit buckets remain
   in-memory and still reset on restart.
+- **Budgets dashboard view and API (#14).** The dashboard gains a Budgets
+  tab showing every configured pot with per-bucket depletion bars, reset
+  countdowns for duration windows, and an expandable per-budget spend
+  ledger where approved overages carry a distinct badge. Two new sideband
+  endpoints back it: `GET /api/budgets` (every configured budget with live
+  bucket states — configured pots appear at full headroom even before any
+  spend) and `GET /api/budgets/:name/events` (the budget's ledger rows,
+  newest first, paginated and clamped like the other list endpoints;
+  history spans config resets and follows `audit.retention`). The SSE
+  stream gains two events: `budget_update` fires per budget on every
+  committed charge with post-record numbers and the commit `kind` (an
+  approved overage is visible live; the sole exception is a charge
+  committing under a stale config generation after a pot-resetting
+  reload, which is ledgered without an event), and `budget_breached`
+  fires once per genuinely breached budget when a peek denies a call or
+  raises the break-glass ticket — dry-run simulations stay silent, and
+  an invalid-amount failure emits no event of its own, though genuine
+  breaches denied alongside one still do. There is no separate budget
+  warning event; `budget_update.utilization` drives dashboard
+  thresholds.
 
 ### Fixed
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -162,12 +162,13 @@ Navigate to [http://localhost:3100](http://localhost:3100) to open the governanc
 
 ![Dashboard Feed](./images/dashboard-feed.png)
 
-The dashboard has five tabs:
+The dashboard has six tabs:
 
 - **Feed** — Real-time stream of tool calls and policy decisions
 - **Approvals** — Pending approval queue (for `require_approval` rules)
 - **Audit** — Searchable log of every recorded action with filters
 - **Limits** — Current rate and spend limit status per tool
+- **Budgets** — Named cross-tool spend pots with live depletion and the spend ledger
 - **Analytics** — Charts showing action volume, decision breakdown, and top tools
 
 ## Step 6: Send a Test Tool Call

--- a/docs/sideband-api.md
+++ b/docs/sideband-api.md
@@ -36,7 +36,7 @@ Endpoints that return a filtered collection wrap the array in `data` and flatten
 
 For pagination and boolean query fields, the sideband uses tolerant parsing at the boundary: empty or non-numeric `limit` / `offset` values fall back to endpoint defaults, and invalid boolean filter strings are treated as unset rather than causing a 400.
 
-Endpoints in this category: `GET /api/feed`, `GET /api/audit`, `GET /api/approvals`.
+Endpoints in this category: `GET /api/feed`, `GET /api/audit`, `GET /api/approvals`, `GET /api/budgets/:name/events`.
 
 Clients that need a page number compute it as `Math.floor(offset / limit) + 1`.
 
@@ -44,9 +44,9 @@ Clients that need a page number compute it as `Math.floor(offset / limit) + 1`.
 
 Endpoints that return a computed view of in-memory state are not "resources" in the REST sense, and wrapping them in `{ data }` adds ceremony without signal. They return their computed view directly, with shapes specific to each endpoint.
 
-Endpoints in this category: `GET /api/health`, `GET /api/analytics`, `GET /api/limits`, `GET /api/adapters`.
+Endpoints in this category: `GET /api/health`, `GET /api/analytics`, `GET /api/limits`, `GET /api/adapters`, `GET /api/budgets`.
 
-Envelope category does not imply authentication policy: when dashboard auth is enabled, `GET /api/analytics`, `GET /api/limits`, and `GET /api/adapters` still require auth. `GET /api/health` remains the only intentionally unauthenticated probe endpoint.
+Envelope category does not imply authentication policy: when dashboard auth is enabled, `GET /api/analytics`, `GET /api/limits`, `GET /api/adapters`, and `GET /api/budgets` still require auth. `GET /api/health` remains the only intentionally unauthenticated probe endpoint.
 
 `GET /api/health` in particular is preserved in this form so that container orchestrators (Kubernetes, Docker Compose, Nomad) can point healthcheck probes at it without a custom JSON parser: probes only evaluate the HTTP status code, and the flat `status`, `version`, and `uptime` keys stay easy to read for the humans and scripts that hit the same URL.
 
@@ -294,6 +294,93 @@ Per-origin liveness of the adapters driving the [SDK sideband's governance API](
 - `last_seen` — the most recent `/evaluate`, `/install-scan`, or successfully finalized `/audit` from the origin. Entries are sorted most recently seen first.
 
 **Raw-shape endpoint:** this is an RPC-style view.
+
+---
+
+### Budgets
+
+Named cross-tool spend budgets (the `budgets:` config section). See the [Policy Guide](./policies.md) for budget semantics.
+
+#### GET /api/budgets
+
+Every configured budget with its live bucket states. Unlike `GET /api/limits`, which lists only live keys, configured budgets appear even with zero live buckets (`"buckets": []`) — the dashboard shows every pot at full headroom. Zero budgets configured returns `{ "budgets": [] }`.
+
+**Response (200):**
+
+```json
+{
+  "budgets": [
+    {
+      "name": "session-cap",
+      "limit": 50,
+      "currency": "USD",
+      "window": "session",
+      "key": "session",
+      "on_exceed": "require_approval",
+      "buckets": [
+        {
+          "bucket_key": "budget:session-cap:session:abc123",
+          "spent": 12.5,
+          "remaining": 37.5,
+          "reset_at_ms": null,
+          "last_activity_ms": 1783944000000
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `window` — the raw config string: a duration like `"24h"`, or `"session"`.
+- `buckets[].reset_at_ms` — epoch ms at which the bucket's oldest recorded charge ages out of the sliding window; `null` for session windows (the pot never replenishes; idle pots are collected instead).
+- `buckets[].remaining` — headroom before the next charge: `max(0, limit - spent)`. An approved overage can push `spent` past `limit`; `remaining` floors at 0.
+
+**Raw-shape endpoint:** this is an RPC-style view.
+
+#### GET /api/budgets/:name/events
+
+One budget's spend history — the durable ledger rows behind the pot, newest first. This is the "where did the money go" surface: rows survive restarts and config changes (history spans config resets; a `limit`/`currency`/`window`/`key` change resets the live pot but not the listing), and are bounded by the audit `retention` window.
+
+**Query parameters:**
+
+| Param    | Default | Notes                       |
+| -------- | ------- | --------------------------- |
+| `limit`  | 50      | Page size, clamped to 1000. |
+| `offset` | 0       | Pagination offset.          |
+
+An unknown budget name returns `200` with an empty page (budget names are configuration, not secrets, and 404 semantics would race hot-reloads).
+
+**Response (200):**
+
+```json
+{
+  "data": [
+    {
+      "id": "0d9e7c3a-9be2-4de1-a2fc-6f0f4bfae1a2",
+      "budget_name": "session-cap",
+      "bucket_key": "budget:session-cap:session:abc123",
+      "kind": "approved_overage",
+      "amount": 5,
+      "currency": "USD",
+      "tool_name": "stripe_charge",
+      "origin": "mcp",
+      "audit_record_id": "b53a2f8e-6a3d-4a56-8a3c-2f1f9df1c001",
+      "timestamp": "2026-07-13T12:00:00.000Z",
+      "timestamp_ms": 1783944000000,
+      "created_at": "2026-07-13T12:00:00.012Z"
+    }
+  ],
+  "total": 137,
+  "limit": 50,
+  "offset": 0
+}
+```
+
+- `kind` — `spend`, or `approved_overage` for charges committed through a break-glass approval.
+- `audit_record_id` — the audit record of the call that produced the charge. The ledger is the source of truth for spend; the audit trail for calls — the referenced audit row may lag briefly (async audit writer) or be missing after a crash.
+- `origin` — `mcp`, or the adapter origin for sideband-committed charges.
+
+A CSV export of the ledger is not available yet; use the JSON listing.
 
 ---
 
@@ -605,18 +692,20 @@ Server-Sent Events stream of dashboard events. The stream stays open indefinitel
 
 **Event types:**
 
-| Event                          | Payload fields                                                                                                                                                                                                                                                                                                                                                                                                |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `heartbeat`                    | empty `data`. Sent on connect and every `dashboard.sse_heartbeat_interval`.                                                                                                                                                                                                                                                                                                                                   |
-| `action`                       | `id`, `tool_name`, `policy_decision`, `block_reason`, `approval_status`, `session_id`, `agent_id`, `environment`, `timestamp`, `total_duration_ms`, `approval_wait_ms`, `proxy_compute_ms`, `flagged_destructive`, `dry_run`, `matched_rule`, `matched_rule_index`, `origin` (enforcement origin: `mcp` or adapter slug), `record_kind` (`tool_call` / `drift_event` / `install_scan` / `evaluation_expired`) |
-| `approval_requested`           | `ticket_id`, `tool_name`, `channel`, `requested_at`                                                                                                                                                                                                                                                                                                                                                           |
-| `approval_resolved`            | `ticket_id`, `status`, `resolved_by` (optional), `resolved_at`                                                                                                                                                                                                                                                                                                                                                |
-| `approval_notification_failed` | `ticket_id`, `channel`, `phase` (`initial`/`escalation`), `error`                                                                                                                                                                                                                                                                                                                                             |
-| `limit_warning`                | `key`, `type` (`rate`/`spend`), `current`, `limit`, `utilization`                                                                                                                                                                                                                                                                                                                                             |
+| Event                          | Payload fields                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `heartbeat`                    | empty `data`. Sent on connect and every `dashboard.sse_heartbeat_interval`.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `action`                       | `id`, `tool_name`, `policy_decision`, `block_reason`, `approval_status`, `session_id`, `agent_id`, `environment`, `timestamp`, `total_duration_ms`, `approval_wait_ms`, `proxy_compute_ms`, `flagged_destructive`, `dry_run`, `matched_rule`, `matched_rule_index`, `origin` (enforcement origin: `mcp` or adapter slug), `record_kind` (`tool_call` / `drift_event` / `install_scan` / `evaluation_expired`)                                                                    |
+| `approval_requested`           | `ticket_id`, `tool_name`, `channel`, `requested_at`                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `approval_resolved`            | `ticket_id`, `status`, `resolved_by` (optional), `resolved_at`                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `approval_notification_failed` | `ticket_id`, `channel`, `phase` (`initial`/`escalation`), `error`                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `limit_warning`                | `key`, `type` (`rate`/`spend`), `current`, `limit`, `utilization`                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `budget_update`                | `name`, `bucket_key`, `kind` (`spend`/`approved_overage`), `amount`, `spent`, `remaining`, `limit`, `currency`, `utilization`. One event per budget per committed charge — `utilization` drives dashboard thresholds; there is no separate budget warning event. The one exception: a charge that commits under a stale config generation (an in-flight call outliving a pot-resetting reload) is ledgered but fires no event, since the pot it would describe no longer exists. |
+| `budget_breached`              | `name`, `bucket_key`, `on_exceed` (`deny`/`require_approval`), `attempted_amount`, `spent`, `limit`, `currency`. Fired once per genuinely breached budget when a peek denies a call or raises the break-glass ticket. Dry-run peeks never fire it, and an invalid-amount failure emits nothing for itself — though when such a denial also carries genuine breaches on other budgets, those still fire.                                                                          |
 
 For `approval_resolved`, `status` is one of `approved`, `denied`, `timeout`, `break_glass`, `client_disconnected`, `shutdown_cancelled`, or — for adapter-owned tickets — `cancelled`.
 
-Every non-heartbeat event carries a unique `id:` line for client-side de-duplication and debugging. The SSE stream is **live-only** (no replay endpoint): reconnecting clients should backfill from REST endpoints (`/api/feed`, `/api/approvals`, `/api/limits`) before resuming live consumption.
+Every non-heartbeat event carries a unique `id:` line for client-side de-duplication and debugging. The SSE stream is **live-only** (no replay endpoint): reconnecting clients should backfill from REST endpoints (`/api/feed`, `/api/approvals`, `/api/limits`, `/api/budgets`) before resuming live consumption.
 
 **Non-JSON endpoint** — SSE stream, not a single response.
 

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -49,6 +49,7 @@ vi.mock('./pages/FeedPage', () => ({ FeedPage: () => <div>Mock Feed Page</div> }
 vi.mock('./pages/ApprovalsPage', () => ({ ApprovalsPage: () => <div>Mock Approvals Page</div> }))
 vi.mock('./pages/AuditPage', () => ({ AuditPage: () => <div>Mock Audit Page</div> }))
 vi.mock('./pages/LimitsPage', () => ({ LimitsPage: () => <div>Mock Limits Page</div> }))
+vi.mock('./pages/BudgetsPage', () => ({ BudgetsPage: () => <div>Mock Budgets Page</div> }))
 vi.mock('./pages/AnalyticsPage', () => ({ AnalyticsPage: () => <div>Mock Analytics Page</div> }))
 
 describe('App auth gate', () => {
@@ -92,6 +93,22 @@ describe('App auth gate', () => {
 
     expect(await screen.findByText('Mock Feed Page')).toBeTruthy()
     expect(mockSetCsrfToken).toHaveBeenCalledWith('csrf-token')
+  })
+
+  it('renders the budgets route for an authenticated session', async () => {
+    mockFetchAuthSession.mockResolvedValue({
+      auth_required: false,
+      authenticated: true,
+    })
+
+    window.history.pushState({}, '', '/budgets')
+    try {
+      render(<App />)
+      expect(await screen.findByText('Mock Budgets Page')).toBeTruthy()
+      expect(screen.getByText('Mock Layout')).toBeTruthy()
+    } finally {
+      window.history.pushState({}, '', '/')
+    }
   })
 
   it('locks the app when unauthorized handler fires', async () => {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -15,6 +15,7 @@ import { FeedPage } from './pages/FeedPage'
 import { ApprovalsPage } from './pages/ApprovalsPage'
 import { AuditPage } from './pages/AuditPage'
 import { LimitsPage } from './pages/LimitsPage'
+import { BudgetsPage } from './pages/BudgetsPage'
 import { AnalyticsPage } from './pages/AnalyticsPage'
 
 type AppViewState = 'booting' | 'locked' | 'authenticating' | 'ready'
@@ -171,6 +172,7 @@ export function App() {
               <Route path="approvals" element={<ApprovalsPage />} />
               <Route path="audit" element={<AuditPage />} />
               <Route path="limits" element={<LimitsPage />} />
+              <Route path="budgets" element={<BudgetsPage />} />
               <Route path="analytics" element={<AnalyticsPage />} />
             </Route>
           </Routes>

--- a/packages/dashboard/src/api.test.ts
+++ b/packages/dashboard/src/api.test.ts
@@ -15,6 +15,8 @@ import {
   fetchAuditRecord,
   fetchApprovals,
   fetchLimits,
+  fetchBudgets,
+  fetchBudgetEvents,
   fetchAnalytics,
   fetchEvidence,
   approveTicket,
@@ -259,6 +261,44 @@ describe('read endpoints', () => {
     mockFetch.mockReturnValue(okJson({ rate_limits: [], spend_limits: [] }))
     await fetchLimits()
     expect(mockFetch).toHaveBeenCalledWith('/api/limits', { credentials: 'same-origin' })
+  })
+
+  it('fetchBudgets calls /api/budgets', async () => {
+    mockFetch.mockReturnValue(okJson({ budgets: [] }))
+    await fetchBudgets()
+    expect(mockFetch).toHaveBeenCalledWith('/api/budgets', { credentials: 'same-origin' })
+  })
+
+  it('fetchBudgetEvents encodes the name and passes pagination', async () => {
+    mockFetch.mockReturnValue(okJson({ data: [], total: 0, limit: 20, offset: 0 }))
+    await fetchBudgetEvents('team/cap', { limit: 20, offset: 5 })
+    const url = calledUrl()
+    expect(url).toContain('/api/budgets/team%2Fcap/events')
+    expect(url).toContain('limit=20')
+    expect(url).toContain('offset=5')
+  })
+
+  it('fetchBudgetEvents omits pagination when not given', async () => {
+    mockFetch.mockReturnValue(okJson({ data: [], total: 0, limit: 50, offset: 0 }))
+    await fetchBudgetEvents('cap')
+    expect(calledUrl()).toBe('/api/budgets/cap/events')
+  })
+
+  it('fetchBudgets and fetchBudgetEvents forward an abort signal', async () => {
+    mockFetch.mockReturnValue(okJson({ budgets: [] }))
+    const controller = new AbortController()
+    await fetchBudgets({ signal: controller.signal })
+    expect(mockFetch).toHaveBeenCalledWith('/api/budgets', {
+      credentials: 'same-origin',
+      signal: controller.signal,
+    })
+
+    mockFetch.mockReturnValue(okJson({ data: [], total: 0, limit: 50, offset: 0 }))
+    await fetchBudgetEvents('cap', undefined, { signal: controller.signal })
+    expect(mockFetch).toHaveBeenLastCalledWith('/api/budgets/cap/events', {
+      credentials: 'same-origin',
+      signal: controller.signal,
+    })
   })
 
   it('fetchAnalytics passes from and to', async () => {

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -16,6 +16,8 @@ import type {
   ApprovalsResponse,
   ApprovalStatus,
   LimitsResponse,
+  BudgetsResponse,
+  BudgetEventsResponse,
   AnalyticsResponse,
   EvidenceResponse,
 } from './types'
@@ -185,6 +187,27 @@ export function fetchApprovals(
 
 export function fetchLimits(): Promise<LimitsResponse> {
   return apiFetch('/api/limits', getInit())
+}
+
+export function fetchBudgets(options?: { signal?: AbortSignal }): Promise<BudgetsResponse> {
+  return apiFetch('/api/budgets', {
+    ...getInit(),
+    ...(options?.signal ? { signal: options.signal } : {}),
+  })
+}
+
+export function fetchBudgetEvents(
+  name: string,
+  pagination?: { limit?: number; offset?: number },
+  options?: { signal?: AbortSignal },
+): Promise<BudgetEventsResponse> {
+  return apiFetch(
+    '/api/budgets/' +
+      encodeURIComponent(name) +
+      '/events' +
+      qs({ limit: pagination?.limit, offset: pagination?.offset }),
+    { ...getInit(), ...(options?.signal ? { signal: options.signal } : {}) },
+  )
 }
 
 export function fetchAnalytics(from?: string, to?: string): Promise<AnalyticsResponse> {

--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -12,12 +12,13 @@ function renderSidebar(open = true, onClose = vi.fn()) {
 }
 
 describe('Sidebar', () => {
-  it('renders all 5 nav links', () => {
+  it('renders all 6 nav links', () => {
     renderSidebar()
     expect(screen.getByText('Feed')).toBeTruthy()
     expect(screen.getByText('Approvals')).toBeTruthy()
     expect(screen.getByText('Audit')).toBeTruthy()
     expect(screen.getByText('Limits')).toBeTruthy()
+    expect(screen.getByText('Budgets')).toBeTruthy()
     expect(screen.getByText('Analytics')).toBeTruthy()
   })
 

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -89,6 +89,25 @@ const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
+    to: '/budgets',
+    label: 'Budgets',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"
+        />
+      </svg>
+    ),
+  },
+  {
     to: '/analytics',
     label: 'Analytics',
     icon: (

--- a/packages/dashboard/src/pages/BudgetsPage.test.tsx
+++ b/packages/dashboard/src/pages/BudgetsPage.test.tsx
@@ -1,0 +1,1355 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { BudgetsPage } from './BudgetsPage'
+import type { BudgetEventRecord, BudgetState } from '../types'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSubscribe = vi.fn(() => vi.fn())
+
+vi.mock('../EventSourceContext', () => ({
+  useEventSourceContext: () => ({ connected: true, connectionEpoch: 1, subscribe: mockSubscribe }),
+}))
+
+const mockFetchBudgets = vi.fn()
+const mockFetchBudgetEvents = vi.fn()
+
+vi.mock('../api', () => ({
+  fetchBudgets: (...args: unknown[]): unknown => mockFetchBudgets(...args),
+  fetchBudgetEvents: (...args: unknown[]): unknown => mockFetchBudgetEvents(...args),
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function budgetState(overrides: Partial<BudgetState> = {}): BudgetState {
+  return {
+    name: 'daily-cap',
+    limit: 100,
+    currency: 'USD',
+    window: '24h',
+    key: 'global',
+    on_exceed: 'deny',
+    buckets: [
+      {
+        bucket_key: 'budget:daily-cap:global',
+        spent: 40,
+        remaining: 60,
+        reset_at_ms: Date.now() + 60 * 60 * 1_000,
+        last_activity_ms: Date.now(),
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function eventRecord(overrides: Partial<BudgetEventRecord> = {}): BudgetEventRecord {
+  return {
+    id: 'evt-1',
+    budget_name: 'daily-cap',
+    bucket_key: 'budget:daily-cap:global',
+    kind: 'spend',
+    amount: 12.5,
+    currency: 'USD',
+    tool_name: 'stripe_charge',
+    origin: 'mcp',
+    audit_record_id: 'audit-1',
+    timestamp: '2026-07-13T12:00:00.000Z',
+    timestamp_ms: 1_800_000_000_000,
+    created_at: '2026-07-13T12:00:00.001Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockSubscribe.mockClear()
+  mockFetchBudgets.mockReset()
+  mockFetchBudgetEvents.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <BudgetsPage />
+    </MemoryRouter>,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BudgetsPage', () => {
+  it('renders pot cards with name, window, and per-bucket progress', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+      expect(screen.getByText('24h')).toBeTruthy()
+      expect(screen.getByText(/Resets in/)).toBeTruthy()
+    })
+  })
+
+  it('progress bar width matches the bucket usage ratio', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    const { container } = renderPage()
+
+    await waitFor(() => {
+      const bars = container.querySelectorAll('[style*="width"]')
+      const bar = Array.from(bars).find((el) => el.className.includes('rounded-full'))
+      expect(bar?.getAttribute('style')).toContain('40%')
+    })
+  })
+
+  it('renders a configured budget with zero live buckets at full headroom', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState({ buckets: [] })] })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+      expect(screen.getByText(/No spend yet/)).toBeTruthy()
+    })
+  })
+
+  it('shows the session-pot line instead of a countdown for session windows', async () => {
+    mockFetchBudgets.mockResolvedValue({
+      budgets: [
+        budgetState({
+          name: 'session-cap',
+          window: 'session',
+          key: 'session',
+          buckets: [
+            {
+              bucket_key: 'budget:session-cap:session:abc',
+              spent: 10,
+              remaining: 90,
+              reset_at_ms: null,
+              last_activity_ms: Date.now(),
+            },
+          ],
+        }),
+      ],
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/never replenishes/)).toBeTruthy()
+      expect(screen.queryByText(/Resets in/)).toBeNull()
+    })
+  })
+
+  it('expanding recent events fetches and renders them with kind badges', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    mockFetchBudgetEvents.mockResolvedValue({
+      data: [
+        eventRecord(),
+        eventRecord({ id: 'evt-2', kind: 'approved_overage', tool_name: 'paypal_send' }),
+      ],
+      total: 2,
+      limit: 20,
+      offset: 0,
+    })
+    const { container } = renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    expect(mockFetchBudgetEvents).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText(/Recent events/))
+
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledWith('daily-cap', { limit: 20 })
+      expect(screen.getByText('stripe_charge')).toBeTruthy()
+      expect(screen.getByText('paypal_send')).toBeTruthy()
+      // The overage badge is visually distinct (amber) from the gray spend badge.
+      expect(screen.getByText('approved overage')).toBeTruthy()
+      expect(container.querySelector('.bg-amber-100')).toBeTruthy()
+      expect(screen.getByText('spend')).toBeTruthy()
+    })
+  })
+
+  it('renders and expands budgets named after Object prototype keys', async () => {
+    // "__proto__", "toString", "constructor" are schema-valid budget names.
+    // Plain-object panel state would read INHERITED Object properties for
+    // them (truthy functions), crashing EventsPanel and jamming the toggle.
+    mockFetchBudgets.mockResolvedValue({
+      budgets: [
+        budgetState({
+          name: 'toString',
+          buckets: [
+            {
+              bucket_key: 'budget:toString:global',
+              spent: 5,
+              remaining: 95,
+              reset_at_ms: Date.now() + 60_000,
+              last_activity_ms: Date.now(),
+            },
+          ],
+        }),
+        budgetState({ name: '__proto__', buckets: [] }),
+        budgetState({ name: 'constructor', buckets: [] }),
+      ],
+    })
+    mockFetchBudgetEvents.mockResolvedValue({
+      data: [eventRecord({ budget_name: 'toString', tool_name: 'proto_tool' })],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('toString')).toBeTruthy()
+      expect(screen.getByText('__proto__')).toBeTruthy()
+      expect(screen.getByText('constructor')).toBeTruthy()
+    })
+
+    // The toggle must treat these as collapsed (no own entry) and expand.
+    fireEvent.click(screen.getAllByText(/Recent events/)[0] as HTMLElement)
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledWith('toString', { limit: 20 })
+      expect(screen.getByText('proto_tool')).toBeTruthy()
+    })
+  })
+
+  it('collapsing an expanded panel hides the events list', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    mockFetchBudgetEvents.mockResolvedValue({
+      data: [eventRecord()],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(screen.getByText('stripe_charge')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByText(/Hide recent events/))
+    await waitFor(() => {
+      expect(screen.queryByText('stripe_charge')).toBeNull()
+      expect(screen.getByText(/Recent events/)).toBeTruthy()
+    })
+  })
+
+  it('the poll fallback refreshes expanded event panels without any SSE', async () => {
+    // Stale-generation commits are ledgered but deliberately emit no SSE
+    // event — an open ledger panel must still pick them up on the poll.
+    const intervalCallbacks: Array<() => void> = []
+    const setIntervalSpy = vi
+      .spyOn(global, 'setInterval')
+      .mockImplementation((callback: TimerHandler): ReturnType<typeof setInterval> => {
+        if (typeof callback === 'function') {
+          intervalCallbacks.push(callback as () => void)
+        }
+        return 1 as unknown as ReturnType<typeof setInterval>
+      })
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    mockFetchBudgetEvents.mockResolvedValue({
+      data: [eventRecord()],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(1)
+    })
+
+    act(() => {
+      for (const callback of intervalCallbacks) callback()
+    })
+
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(2)
+      // Poll-driven refreshes carry the batch's abort signal.
+      expect(mockFetchBudgetEvents).toHaveBeenLastCalledWith(
+        'daily-cap',
+        { limit: 20 },
+        { signal: expect.any(AbortSignal) as AbortSignal },
+      )
+    })
+    setIntervalSpy.mockRestore()
+  })
+
+  it('an older events success still lands when the newer refresh failed', async () => {
+    // Expand (slow request) + SSE refresh (fails fast): the failed refresh
+    // applies nothing, so the older success — the panel's ONLY data — must
+    // still render.
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    let resolveFirst!: (value: unknown) => void
+    let rejectSecond!: (reason: unknown) => void
+    mockFetchBudgetEvents
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectSecond = reject
+          }),
+      )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(1)
+    })
+
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    act(() => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    })
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      rejectSecond(new Error('transient blip'))
+      await Promise.resolve()
+    })
+    await act(async () => {
+      resolveFirst({
+        data: [eventRecord({ tool_name: 'only_data' })],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('only_data')).toBeTruthy()
+    })
+  })
+
+  it('a refetch failure keeps already-loaded events visible', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    mockFetchBudgetEvents
+      .mockResolvedValueOnce({
+        data: [eventRecord({ tool_name: 'loaded_row' })],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      })
+      .mockRejectedValueOnce(new Error('transient blip'))
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(screen.getByText('loaded_row')).toBeTruthy()
+    })
+
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    act(() => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    })
+
+    // The failed refetch must not hide the rows behind an error message.
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(screen.getByText('loaded_row')).toBeTruthy()
+      expect(screen.queryByText('transient blip')).toBeNull()
+    })
+  })
+
+  it('an out-of-order stale events response never overwrites a fresher one', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+
+    // Two in-flight requests resolving out of order: the FIRST (stale)
+    // resolves after the SECOND (fresh). The panel must keep the fresh page.
+    let resolveFirst!: (value: unknown) => void
+    let resolveSecond!: (value: unknown) => void
+    mockFetchBudgetEvents
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve
+          }),
+      )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(1)
+    })
+
+    // An SSE budget_update triggers a second fetch for the expanded panel.
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    act(() => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    })
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      resolveSecond({
+        data: [eventRecord({ id: 'fresh', tool_name: 'fresh_tool' })],
+        total: 2,
+        limit: 20,
+        offset: 0,
+      })
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('fresh_tool')).toBeTruthy()
+    })
+
+    await act(async () => {
+      resolveFirst({
+        data: [eventRecord({ id: 'stale', tool_name: 'stale_tool' })],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      })
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('fresh_tool')).toBeTruthy()
+      expect(screen.queryByText('stale_tool')).toBeNull()
+    })
+  })
+
+  it('a request outstanding across collapse, removal, and re-add cannot land', async () => {
+    // Collapse leaves no expanded entry for the removal prune to barrier,
+    // so an in-flight pre-collapse request must be invalidated by the
+    // COLLAPSE itself — otherwise it applies first-life data to the
+    // re-added budget's fresh panel.
+    const intervalCallbacks: Array<() => void> = []
+    const setIntervalSpy = vi
+      .spyOn(global, 'setInterval')
+      .mockImplementation((callback: TimerHandler): ReturnType<typeof setInterval> => {
+        if (typeof callback === 'function') {
+          intervalCallbacks.push(callback as () => void)
+        }
+        return 1 as unknown as ReturnType<typeof setInterval>
+      })
+    mockFetchBudgets
+      .mockResolvedValueOnce({ budgets: [budgetState()] })
+      .mockResolvedValueOnce({ budgets: [] })
+      .mockResolvedValue({ budgets: [budgetState()] })
+    const eventResolvers: Array<(value: unknown) => void> = []
+    mockFetchBudgetEvents.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          eventResolvers.push(resolve)
+        }),
+    )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    // First life: expand (request 1 stays in flight), then collapse.
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(1)
+    })
+    fireEvent.click(screen.getByText(/Hide recent events/))
+
+    // Hot reload removes the budget (nothing expanded, nothing to prune)…
+    act(() => {
+      for (const callback of intervalCallbacks) callback()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('No budgets configured')).toBeTruthy()
+    })
+    // …then a later reload re-adds it.
+    act(() => {
+      for (const callback of intervalCallbacks) callback()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+
+    // Second life: expand again (request 2 in flight) — and the FIRST
+    // life's response lands first. It must be discarded.
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(2)
+    })
+    await act(async () => {
+      eventResolvers[0]?.({
+        data: [eventRecord({ id: 'stale', tool_name: 'stale_tool' })],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      })
+      await Promise.resolve()
+    })
+    expect(screen.queryByText('stale_tool')).toBeNull()
+
+    await act(async () => {
+      eventResolvers[1]?.({
+        data: [eventRecord({ id: 'fresh', tool_name: 'fresh_tool' })],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      })
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('fresh_tool')).toBeTruthy()
+      expect(screen.queryByText('stale_tool')).toBeNull()
+    })
+    setIntervalSpy.mockRestore()
+  })
+
+  it('a pre-removal events response cannot land after the budget is re-added', async () => {
+    // Remove/re-add must not let an in-flight request from the budget's
+    // FIRST life reuse a fresh request token and overwrite its second life.
+    const intervalCallbacks: Array<() => void> = []
+    const setIntervalSpy = vi
+      .spyOn(global, 'setInterval')
+      .mockImplementation((callback: TimerHandler): ReturnType<typeof setInterval> => {
+        if (typeof callback === 'function') {
+          intervalCallbacks.push(callback as () => void)
+        }
+        return 1 as unknown as ReturnType<typeof setInterval>
+      })
+    mockFetchBudgets
+      .mockResolvedValueOnce({ budgets: [budgetState()] })
+      .mockResolvedValueOnce({ budgets: [] })
+      .mockResolvedValue({ budgets: [budgetState()] })
+    const eventResolvers: Array<(value: unknown) => void> = []
+    mockFetchBudgetEvents.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          eventResolvers.push(resolve)
+        }),
+    )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    // First life: expand — request from before the removal stays in flight.
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(1)
+    })
+
+    // Hot reload removes the budget (prunes expansion state)…
+    act(() => {
+      for (const callback of intervalCallbacks) callback()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('No budgets configured')).toBeTruthy()
+    })
+    // The poll's own events request settles (only the EXPAND-time request
+    // from the first life stays in flight), releasing the coalescer.
+    await act(async () => {
+      eventResolvers[1]?.({ data: [], total: 0, limit: 20, offset: 0 })
+      await Promise.resolve()
+    })
+    // …and a later reload re-adds it.
+    act(() => {
+      for (const callback of intervalCallbacks) callback()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+
+    // Second life: expand again and land the FRESH response first.
+    fireEvent.click(screen.getByText(/Recent events/))
+    const freshIndex = eventResolvers.length - 1
+    await act(async () => {
+      eventResolvers[freshIndex]?.({
+        data: [eventRecord({ id: 'fresh', tool_name: 'fresh_tool' })],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      })
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('fresh_tool')).toBeTruthy()
+    })
+
+    // The first life's response finally lands — it must be discarded.
+    await act(async () => {
+      eventResolvers[0]?.({
+        data: [eventRecord({ id: 'stale', tool_name: 'stale_tool' })],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      })
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('fresh_tool')).toBeTruthy()
+      expect(screen.queryByText('stale_tool')).toBeNull()
+    })
+    setIntervalSpy.mockRestore()
+  })
+
+  it('an out-of-order stale pot response never overwrites a fresher one', async () => {
+    // Initial fetch (slow) overlaps an SSE-triggered refetch (fast): the
+    // older snapshot resolving last must not roll the pot numbers back.
+    let resolveInitial!: (value: unknown) => void
+    let resolveRefetch!: (value: unknown) => void
+    mockFetchBudgets
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveInitial = resolve
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefetch = resolve
+          }),
+      )
+    renderPage()
+
+    await waitFor(() => {
+      const eventTypes = mockSubscribe.mock.calls.map((c) => (c as unknown[])[0])
+      expect(eventTypes).toContain('budget_update')
+    })
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    act(() => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    })
+    await waitFor(() => {
+      expect(mockFetchBudgets).toHaveBeenCalledTimes(2)
+    })
+
+    const bucketAt = (spent: number) => ({
+      bucket_key: 'budget:daily-cap:global',
+      spent,
+      remaining: 100 - spent,
+      reset_at_ms: Date.now() + 60_000,
+      last_activity_ms: Date.now(),
+    })
+    await act(async () => {
+      resolveRefetch({ budgets: [budgetState({ buckets: [bucketAt(45)] })] })
+      await Promise.resolve()
+    })
+    await act(async () => {
+      resolveInitial({ budgets: [budgetState({ buckets: [bucketAt(40)] })] })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/45\.00/)).toBeTruthy()
+      expect(screen.queryByText(/40\.00/)).toBeNull()
+    })
+  })
+
+  it('a stale initial failure after a fresher success shows no error page', async () => {
+    let rejectInitial!: (reason: unknown) => void
+    let resolveRefetch!: (value: unknown) => void
+    mockFetchBudgets
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectInitial = reject
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefetch = resolve
+          }),
+      )
+    renderPage()
+
+    await waitFor(() => {
+      const eventTypes = mockSubscribe.mock.calls.map((c) => (c as unknown[])[0])
+      expect(eventTypes).toContain('budget_update')
+    })
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    act(() => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    })
+    await waitFor(() => {
+      expect(mockFetchBudgets).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      resolveRefetch({ budgets: [budgetState()] })
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+
+    await act(async () => {
+      rejectInitial(new Error('Connection refused'))
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+      expect(screen.queryByText('Connection refused')).toBeNull()
+      expect(screen.queryByText('Retry')).toBeNull()
+    })
+  })
+
+  it('an older success still lands when every newer refresh failed', async () => {
+    // Initial (slow) + SSE refresh (fails fast): the failed refresh applies
+    // nothing, so the older initial SUCCESS must still populate the page —
+    // otherwise the skeleton never resolves.
+    let resolveInitial!: (value: unknown) => void
+    let rejectRefetch!: (reason: unknown) => void
+    mockFetchBudgets
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveInitial = resolve
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectRefetch = reject
+          }),
+      )
+    renderPage()
+
+    await waitFor(() => {
+      const eventTypes = mockSubscribe.mock.calls.map((c) => (c as unknown[])[0])
+      expect(eventTypes).toContain('budget_update')
+    })
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    act(() => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    })
+    await waitFor(() => {
+      expect(mockFetchBudgets).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      rejectRefetch(new Error('transient blip'))
+      await Promise.resolve()
+    })
+    await act(async () => {
+      resolveInitial({ budgets: [budgetState()] })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+  })
+
+  it('surfaces an error when every request failed and nothing ever loaded', async () => {
+    // The initial request hangs forever; an SSE-triggered refresh fails.
+    // With zero data ever applied, the failure must surface instead of
+    // leaving the skeleton up indefinitely.
+    mockFetchBudgets
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockImplementationOnce(() => Promise.reject(new Error('Connection refused')))
+    renderPage()
+
+    await waitFor(() => {
+      const eventTypes = mockSubscribe.mock.calls.map((c) => (c as unknown[])[0])
+      expect(eventTypes).toContain('budget_update')
+    })
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    act(() => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection refused')).toBeTruthy()
+      expect(screen.getByText('Retry')).toBeTruthy()
+    })
+  })
+
+  it('subscribes to budget_update and budget_breached SSE events', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [] })
+    renderPage()
+
+    await waitFor(() => {
+      const eventTypes = mockSubscribe.mock.calls.map((c) => (c as unknown[])[0])
+      expect(eventTypes).toContain('budget_update')
+      expect(eventTypes).toContain('budget_breached')
+    })
+  })
+
+  it('flashes the affected card and refetches on budget_update', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    const { container } = renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    const fetchesBefore = mockFetchBudgets.mock.calls.length
+
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    act(() => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('.ring-2')).toBeTruthy()
+      expect(mockFetchBudgets.mock.calls.length).toBeGreaterThan(fetchesBefore)
+    })
+  })
+
+  it('coalesces an SSE burst into one in-flight refresh plus one trailing', async () => {
+    const deferredResolvers: Array<(value: unknown) => void> = []
+    mockFetchBudgets.mockResolvedValueOnce({ budgets: [budgetState()] }).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          deferredResolvers.push(resolve)
+        }),
+    )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    expect(mockFetchBudgets).toHaveBeenCalledTimes(1)
+
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    const fire = () => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    }
+
+    // A burst of five events: one refresh goes in flight, the other four
+    // fold into a single trailing refresh.
+    act(() => {
+      fire()
+      fire()
+      fire()
+      fire()
+      fire()
+    })
+    expect(mockFetchBudgets).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      deferredResolvers[0]?.({ budgets: [budgetState()] })
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(mockFetchBudgets).toHaveBeenCalledTimes(3)
+    })
+
+    await act(async () => {
+      deferredResolvers[1]?.({ budgets: [budgetState()] })
+      await Promise.resolve()
+    })
+    // No further trailing work queued.
+    expect(mockFetchBudgets).toHaveBeenCalledTimes(3)
+  })
+
+  it('prunes expansion state when a budget disappears on reload', async () => {
+    const intervalCallbacks: Array<() => void> = []
+    const setIntervalSpy = vi
+      .spyOn(global, 'setInterval')
+      .mockImplementation((callback: TimerHandler): ReturnType<typeof setInterval> => {
+        if (typeof callback === 'function') {
+          intervalCallbacks.push(callback as () => void)
+        }
+        return 1 as unknown as ReturnType<typeof setInterval>
+      })
+    mockFetchBudgets
+      .mockResolvedValueOnce({ budgets: [budgetState()] })
+      .mockResolvedValue({ budgets: [] })
+    mockFetchBudgetEvents.mockResolvedValue({
+      data: [eventRecord()],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(1)
+    })
+
+    // The next poll learns the budget was removed by a hot reload…
+    act(() => {
+      for (const callback of intervalCallbacks) callback()
+    })
+    await waitFor(() => {
+      expect(screen.getByText('No budgets configured')).toBeTruthy()
+    })
+    const callsAfterRemoval = mockFetchBudgetEvents.mock.calls.length
+
+    // …so later polls must no longer fetch the removed budget's events.
+    act(() => {
+      for (const callback of intervalCallbacks) callback()
+    })
+    await waitFor(() => {
+      expect(mockFetchBudgets.mock.calls.length).toBeGreaterThanOrEqual(3)
+    })
+    expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(callsAfterRemoval)
+    setIntervalSpy.mockRestore()
+  })
+
+  it('a trailing batch cannot resurrect expansion state for a removed budget', async () => {
+    // The prune lands via setState, but a trailing refresh executes in the
+    // microtask right after the in-flight batch settles — BEFORE the next
+    // render syncs expandedRef — so it must be gated on the synchronous
+    // live-budget set, not the (stale) expansion ref.
+    const intervalCallbacks: Array<() => void> = []
+    const setIntervalSpy = vi
+      .spyOn(global, 'setInterval')
+      .mockImplementation((callback: TimerHandler): ReturnType<typeof setInterval> => {
+        if (typeof callback === 'function') {
+          intervalCallbacks.push(callback as () => void)
+        }
+        return 1 as unknown as ReturnType<typeof setInterval>
+      })
+    let resolveRemoval!: (value: unknown) => void
+    mockFetchBudgets
+      .mockResolvedValueOnce({ budgets: [budgetState()] })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRemoval = resolve
+          }),
+      )
+      .mockResolvedValue({ budgets: [] })
+    mockFetchBudgetEvents.mockResolvedValue({
+      data: [eventRecord()],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByText(/Recent events/))
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(1)
+    })
+
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+
+    // Batch 1 goes in flight (its pot fetch will report the REMOVAL)…
+    act(() => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    })
+    // …and a poll tick queues a trailing batch naming the expanded budget.
+    act(() => {
+      for (const callback of intervalCallbacks) callback()
+    })
+    const eventCallsBeforeRemoval = mockFetchBudgetEvents.mock.calls.length
+
+    // The removal lands OUTSIDE act: in production, the trailing batch's
+    // microtask runs before React's scheduled re-render syncs expandedRef,
+    // so the stale ref still names the pruned budget.
+    resolveRemoval({ budgets: [] })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await waitFor(() => {
+      expect(screen.getByText('No budgets configured')).toBeTruthy()
+    })
+
+    // The trailing batch must NOT have fetched events for the removed
+    // budget nor resurrected its panel state: a later poll fetches nothing.
+    const eventCallsAfterRemoval = mockFetchBudgetEvents.mock.calls.length
+    expect(eventCallsAfterRemoval).toBe(eventCallsBeforeRemoval)
+    act(() => {
+      for (const callback of intervalCallbacks) callback()
+    })
+    await waitFor(() => {
+      expect(mockFetchBudgets.mock.calls.length).toBeGreaterThanOrEqual(4)
+    })
+    expect(mockFetchBudgetEvents.mock.calls.length).toBe(eventCallsAfterRemoval)
+    setIntervalSpy.mockRestore()
+  })
+
+  it('sustained SSE traffic cannot starve the poll fallback', async () => {
+    // Budget A emitting events more often than the poll interval must not
+    // keep resetting the timer: budget B's stale-generation commits emit no
+    // SSE by design, so the fixed poll is B's ONLY refresh path.
+    const registered: Array<() => void> = []
+    const setIntervalSpy = vi
+      .spyOn(global, 'setInterval')
+      .mockImplementation((callback: TimerHandler): ReturnType<typeof setInterval> => {
+        if (typeof callback === 'function') {
+          registered.push(callback as () => void)
+        }
+        return registered.length as unknown as ReturnType<typeof setInterval>
+      })
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval').mockImplementation(() => undefined)
+    mockFetchBudgets.mockResolvedValue({
+      budgets: [budgetState({ name: 'cap-a' }), budgetState({ name: 'cap-b' })],
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('cap-a')).toBeTruthy()
+    })
+    const timersAtMount = registered.length
+    const clearsAtMount = clearIntervalSpy.mock.calls.length
+
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    act(() => {
+      for (let i = 0; i < 3; i++) {
+        handler({
+          name: 'cap-a',
+          bucket_key: 'budget:cap-a:global',
+          kind: 'spend',
+          amount: 5,
+          spent: 45,
+          remaining: 55,
+          limit: 100,
+          currency: 'USD',
+          utilization: 0.45,
+        })
+      }
+    })
+
+    // The fixed interval stays untouched — no clears, no re-registrations.
+    expect(registered.length).toBe(timersAtMount)
+    expect(clearIntervalSpy.mock.calls.length).toBe(clearsAtMount)
+    setIntervalSpy.mockRestore()
+    clearIntervalSpy.mockRestore()
+  })
+
+  it('a trailing batch merges poll names with SSE names across budgets', async () => {
+    // While budget A's SSE refresh is in flight, a poll tick (naming
+    // expanded budget B) and another A event fold into ONE trailing batch
+    // that must still carry B — otherwise sustained A traffic could delay
+    // B's ledger refresh even with the fixed poll interval.
+    const intervalCallbacks: Array<() => void> = []
+    const setIntervalSpy = vi
+      .spyOn(global, 'setInterval')
+      .mockImplementation((callback: TimerHandler): ReturnType<typeof setInterval> => {
+        if (typeof callback === 'function') {
+          intervalCallbacks.push(callback as () => void)
+        }
+        return 1 as unknown as ReturnType<typeof setInterval>
+      })
+    let resolveInFlight!: (value: unknown) => void
+    const twoBudgets = {
+      budgets: [budgetState({ name: 'cap-a' }), budgetState({ name: 'cap-b', buckets: [] })],
+    }
+    mockFetchBudgets
+      .mockResolvedValueOnce(twoBudgets)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveInFlight = resolve
+          }),
+      )
+      .mockResolvedValue(twoBudgets)
+    mockFetchBudgetEvents.mockResolvedValue({
+      data: [eventRecord({ budget_name: 'cap-b' })],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('cap-b')).toBeTruthy()
+    })
+    // Expand B (its only refresh source besides SSE is the poll).
+    fireEvent.click(screen.getAllByText(/Recent events/)[1] as HTMLElement)
+    await waitFor(() => {
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(1)
+    })
+
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    const fireForA = () => {
+      handler({
+        name: 'cap-a',
+        bucket_key: 'budget:cap-a:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    }
+
+    act(() => {
+      fireForA() // batch 1 in flight (hung pot fetch); A is not expanded
+      for (const callback of intervalCallbacks) callback() // trailing gains {cap-b}
+      fireForA() // merges into the SAME trailing batch
+    })
+    // Nothing new started while batch 1 is in flight.
+    expect(mockFetchBudgets).toHaveBeenCalledTimes(2)
+    expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveInFlight(twoBudgets)
+      await Promise.resolve()
+    })
+
+    // Exactly one trailing batch ran, and it refreshed B's ledger panel.
+    await waitFor(() => {
+      expect(mockFetchBudgets).toHaveBeenCalledTimes(3)
+      expect(mockFetchBudgetEvents).toHaveBeenCalledTimes(2)
+      expect(mockFetchBudgetEvents).toHaveBeenLastCalledWith(
+        'cap-b',
+        { limit: 20 },
+        { signal: expect.any(AbortSignal) as AbortSignal },
+      )
+    })
+    setIntervalSpy.mockRestore()
+  })
+
+  it('a hanging refresh releases after the timeout and later refreshes recover', async () => {
+    // One never-settling request must not wedge the coalescer: the batch
+    // times out, its requests abort, and the queued trailing refresh runs.
+    mockFetchBudgets
+      .mockResolvedValueOnce({ budgets: [budgetState()] })
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValue({ budgets: [budgetState()] })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-cap')).toBeTruthy()
+    })
+    const updateCall = mockSubscribe.mock.calls.find(
+      (c) => (c as unknown[])[0] === 'budget_update',
+    ) as unknown[] | undefined
+    const handler = updateCall?.[1] as (event: unknown) => void
+    const fire = () => {
+      handler({
+        name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend',
+        amount: 5,
+        spent: 45,
+        remaining: 55,
+        limit: 100,
+        currency: 'USD',
+        utilization: 0.45,
+      })
+    }
+
+    // Capture timers only from here so waitFor above keeps real timers.
+    const timeoutCallbacks: Array<{ callback: () => void; delay: number }> = []
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout').mockImplementation(((
+      callback: TimerHandler,
+      delay?: number,
+    ) => {
+      if (typeof callback === 'function') {
+        timeoutCallbacks.push({ callback: callback as () => void, delay: delay ?? 0 })
+      }
+      return timeoutCallbacks.length as unknown as ReturnType<typeof setTimeout>
+    }) as unknown as typeof setTimeout)
+
+    act(() => {
+      fire() // starts the hung refresh (fetchBudgets call 2)
+      fire() // folds into trailing
+    })
+    expect(mockFetchBudgets).toHaveBeenCalledTimes(2)
+
+    // The refresh-release timer fires: the batch aborts and releases.
+    const release = timeoutCallbacks.find((t) => t.delay === 15_000)
+    expect(release).toBeDefined()
+    await act(async () => {
+      release?.callback()
+      await Promise.resolve()
+    })
+
+    // The trailing refresh ran (recovery) and the hung request was aborted.
+    expect(mockFetchBudgets).toHaveBeenCalledTimes(3)
+    const hungOptions = mockFetchBudgets.mock.calls[1]?.[0] as { signal?: AbortSignal } | undefined
+    expect(hungOptions?.signal?.aborted).toBe(true)
+    setTimeoutSpy.mockRestore()
+  })
+
+  it('shows the empty state when no budgets are configured', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [] })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('No budgets configured')).toBeTruthy()
+    })
+  })
+
+  it('shows the error state on fetch failure', async () => {
+    mockFetchBudgets.mockRejectedValue(new Error('Connection refused'))
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection refused')).toBeTruthy()
+      expect(screen.getByText('Retry')).toBeTruthy()
+    })
+  })
+})

--- a/packages/dashboard/src/pages/BudgetsPage.tsx
+++ b/packages/dashboard/src/pages/BudgetsPage.tsx
@@ -1,0 +1,576 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { BudgetEventRecord, BudgetState, BudgetBucketState } from '../types'
+import { fetchBudgets, fetchBudgetEvents } from '../api'
+import { useEventSourceContext } from '../EventSourceContext'
+import { usageColor, usagePercent, formatCountdown, formatCurrency } from '../utils'
+import { PageError } from '../components/PageError'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const POLL_INTERVAL_MS = 5_000
+const COUNTDOWN_INTERVAL_MS = 1_000
+const FLASH_MS = 10_000
+const EVENTS_PAGE_SIZE = 20
+/** A refresh batch that has not settled by then is aborted and released. */
+const REFRESH_TIMEOUT_MS = 15_000
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** The bucket key minus its `budget:<name>:` prefix, e.g. `session:abc123`. */
+function bucketLabel(budgetName: string, bucketKey: string): string {
+  const prefix = `budget:${budgetName}:`
+  return bucketKey.startsWith(prefix) ? bucketKey.slice(prefix.length) : bucketKey
+}
+
+interface EventsPanelState {
+  readonly loading: boolean
+  readonly events: readonly BudgetEventRecord[]
+  readonly total: number
+  readonly error: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function BudgetsPage() {
+  const [budgets, setBudgets] = useState<readonly BudgetState[] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [now, setNow] = useState(Date.now())
+  const [flashedNames, setFlashedNames] = useState<Set<string>>(new Set())
+  // A Map, not a Record: budget names are arbitrary config strings, and a
+  // plain object would surface INHERITED Object.prototype members for names
+  // like "toString" or "__proto__" as phantom panel state.
+  const [expanded, setExpanded] = useState<ReadonlyMap<string, EventsPanelState>>(new Map())
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  /** One RESETTABLE flash timer per budget — an SSE burst extends, not stacks. */
+  const flashTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+  const expandedRef = useRef(expanded)
+  expandedRef.current = expanded
+  /** Pot fetch sequence: issue counter, plus the newest APPLIED response. */
+  const potSeqRef = useRef(0)
+  const potAppliedSeqRef = useRef(0)
+  /**
+   * Per-budget events response ordering. Tokens are minted from one
+   * GLOBALLY monotonic counter (a per-budget counter would restart at 1
+   * after a remove/re-add prune, letting a response from the budget's
+   * first life match its second life's token). A response applies only
+   * when its token beats the newest APPLIED one — guarding on the newest
+   * ISSUED token instead would let a failed newer refresh doom the
+   * panel's only successful (older) response to discard. Pruning a
+   * removed budget writes the current counter as a BARRIER, so every
+   * response from the old life stays unappliable after a re-add.
+   */
+  const eventsSeqCounterRef = useRef(0)
+  const eventsAppliedSeqRef = useRef(new Map<string, number>())
+  /**
+   * The names in the most recent pot response, updated SYNCHRONOUSLY (the
+   * expansion state prunes via setState, so `expandedRef` stays stale
+   * until the next render — a trailing refresh batch runs before that and
+   * must not resurrect a removed budget's panel through the stale ref).
+   */
+  const liveNamesRef = useRef<ReadonlySet<string> | null>(null)
+  /** Refresh coalescer: one in flight, at most one trailing (merged names). */
+  const refreshStateRef = useRef<{ inFlight: boolean; trailing: Set<string> | null }>({
+    inFlight: false,
+    trailing: null,
+  })
+  /** Controllers for in-flight refresh batches, aborted on unmount. */
+  const refreshControllersRef = useRef(new Set<AbortController>())
+  /** Set on unmount so a releasing batch does not start trailing work. */
+  const disposedRef = useRef(false)
+  const { subscribe } = useEventSourceContext()
+
+  // -- Fetch helpers ----------------------------------------------------------
+  const doFetch = useCallback((signal?: AbortSignal): Promise<void> => {
+    // Overlapping fetches (poll vs SSE vs the initial load) can resolve out
+    // of order. A response applies only when it is newer than the last
+    // APPLIED one — comparing against the issue counter instead would let
+    // a failed newer refresh (which applies nothing) doom an older success
+    // to discard and strand the loading skeleton.
+    const seq = ++potSeqRef.current
+    return (signal ? fetchBudgets({ signal }) : fetchBudgets())
+      .then((res) => {
+        if (seq <= potAppliedSeqRef.current) return
+        potAppliedSeqRef.current = seq
+        setBudgets(res.budgets)
+        setError(null)
+        setLoading(false)
+        // A hot reload can remove a budget while its ledger panel is open:
+        // drop the orphaned expansion state so the poll stops fetching
+        // events for a pot that no longer exists. The live set and the
+        // applied-token barriers update SYNCHRONOUSLY so in-flight and
+        // trailing work sees the removal before the next render.
+        const live = new Set(res.budgets.map((budget) => budget.name))
+        liveNamesRef.current = live
+        // Barrier every removed name that could still have a response in
+        // flight — expanded panels included, even ones that never applied.
+        const tracked = new Set([
+          ...expandedRef.current.keys(),
+          ...eventsAppliedSeqRef.current.keys(),
+        ])
+        for (const name of tracked) {
+          if (!live.has(name)) {
+            eventsAppliedSeqRef.current.set(name, eventsSeqCounterRef.current)
+          }
+        }
+        setExpanded((prev) => {
+          if (![...prev.keys()].some((name) => !live.has(name))) return prev
+          const next = new Map(prev)
+          for (const name of prev.keys()) if (!live.has(name)) next.delete(name)
+          return next
+        })
+      })
+      .catch((err: unknown) => {
+        // A success has already landed (before or after this request was
+        // issued): keep the good data, ignore the failure silently.
+        if (potAppliedSeqRef.current > 0) return
+        // Nothing has EVER loaded: surface the failure instead of leaving
+        // the skeleton up; a later success clears it.
+        setError(err instanceof Error ? err.message : 'Failed to load budgets')
+        setLoading(false)
+      })
+  }, [])
+
+  const loadEvents = useCallback((name: string, signal?: AbortSignal): Promise<void> => {
+    // A trailing/in-flight batch can name a budget the last pot response
+    // already removed (expandedRef is stale until the next render): skip
+    // it entirely rather than resurrect its pruned panel state.
+    if (liveNamesRef.current && !liveNamesRef.current.has(name)) {
+      return Promise.resolve()
+    }
+
+    const seq = ++eventsSeqCounterRef.current
+    // A response applies only when newer than the last APPLIED one (see
+    // the ref docs above): stale successes never overwrite fresher pages,
+    // and a failed newer refresh cannot doom an older success to discard.
+    const isApplicable = () => seq > (eventsAppliedSeqRef.current.get(name) ?? 0)
+
+    setExpanded((prev) =>
+      new Map(prev).set(name, {
+        loading: true,
+        events: prev.get(name)?.events ?? [],
+        total: prev.get(name)?.total ?? 0,
+        error: null,
+      }),
+    )
+    return (
+      signal
+        ? fetchBudgetEvents(name, { limit: EVENTS_PAGE_SIZE }, { signal })
+        : fetchBudgetEvents(name, { limit: EVENTS_PAGE_SIZE })
+    )
+      .then((res) => {
+        if (!isApplicable()) return
+        eventsAppliedSeqRef.current.set(name, seq)
+        setExpanded((prev) =>
+          prev.has(name)
+            ? new Map(prev).set(name, {
+                loading: false,
+                events: res.data,
+                total: res.total,
+                error: null,
+              })
+            : prev,
+        )
+      })
+      .catch((err: unknown) => {
+        if (!isApplicable()) return
+        setExpanded((prev) => {
+          const current = prev.get(name)
+          if (!current) return prev
+          // Loaded rows stay visible through a failed refetch — the error
+          // replaces the list only when there is nothing to preserve.
+          return new Map(prev).set(name, {
+            loading: false,
+            events: current.events,
+            total: current.total,
+            error:
+              current.events.length > 0
+                ? null
+                : err instanceof Error
+                  ? err.message
+                  : 'Failed to load events',
+          })
+        })
+      })
+  }, [])
+
+  /**
+   * One coalesced refresh: the pots plus every EXPANDED budget in `names`.
+   * While a refresh is in flight, further requests fold into a single
+   * trailing refresh with their names merged — an SSE burst costs one
+   * in-flight round plus one trailing round, never N.
+   */
+  const runRefresh = useCallback(
+    (names: ReadonlySet<string>) => {
+      const state = refreshStateRef.current
+      if (state.inFlight) {
+        state.trailing = new Set([...(state.trailing ?? []), ...names])
+        return
+      }
+      const execute = (batch: ReadonlySet<string>) => {
+        state.inFlight = true
+        const controller = new AbortController()
+        refreshControllersRef.current.add(controller)
+        const tasks: Array<Promise<unknown>> = [doFetch(controller.signal)]
+        for (const name of batch) {
+          if (expandedRef.current.has(name)) tasks.push(loadEvents(name, controller.signal))
+        }
+        // A request that never settles must not wedge the coalescer: after
+        // the timeout the batch is aborted and released either way, and the
+        // sequence guards make any late-landing response harmless.
+        let releaseTimer: ReturnType<typeof setTimeout> | undefined
+        const releaseTimeout = new Promise<void>((resolve) => {
+          releaseTimer = setTimeout(() => {
+            controller.abort()
+            resolve()
+          }, REFRESH_TIMEOUT_MS)
+        })
+        void Promise.race([Promise.allSettled(tasks), releaseTimeout]).then(() => {
+          if (releaseTimer) clearTimeout(releaseTimer)
+          refreshControllersRef.current.delete(controller)
+          state.inFlight = false
+          const trailing = state.trailing
+          state.trailing = null
+          if (trailing && !disposedRef.current) execute(trailing)
+        })
+      }
+      execute(names)
+    },
+    [doFetch, loadEvents],
+  )
+
+  // One poll tick refreshes the pots AND every expanded ledger panel: some
+  // commits deliberately emit no SSE event (a stale-generation charge after
+  // a pot-resetting reload), so an open panel cannot rely on push alone.
+  const pollTick = useCallback(() => {
+    runRefresh(new Set(expandedRef.current.keys()))
+  }, [runRefresh])
+
+  const toggleEvents = useCallback(
+    (name: string) => {
+      if (expandedRef.current.has(name)) {
+        // Collapsing INVALIDATES every outstanding request for the panel
+        // (barrier = current counter): a collapsed budget has no expanded
+        // entry for the removal prune to barrier, so without this a
+        // request from before collapse → removal → re-add would apply
+        // first-life data to the re-added budget's fresh panel.
+        eventsAppliedSeqRef.current.set(name, eventsSeqCounterRef.current)
+        setExpanded((prev) => {
+          const next = new Map(prev)
+          next.delete(name)
+          return next
+        })
+        return
+      }
+      void loadEvents(name)
+    },
+    [loadEvents],
+  )
+
+  // -- Initial fetch + polling ------------------------------------------------
+  useEffect(() => {
+    // Captured so the cleanup drains the same Set instance the refresh
+    // batches register into (satisfying react-hooks/exhaustive-deps).
+    const controllers = refreshControllersRef.current
+    disposedRef.current = false
+    void doFetch()
+
+    intervalRef.current = setInterval(pollTick, POLL_INTERVAL_MS)
+    return () => {
+      disposedRef.current = true
+      if (intervalRef.current) clearInterval(intervalRef.current)
+      for (const controller of controllers) controller.abort()
+      controllers.clear()
+    }
+  }, [doFetch, pollTick])
+
+  // -- SSE: budget_update / budget_breached → flash + immediate refetch -------
+  useEffect(() => {
+    const timers = flashTimersRef.current
+    const onBudgetEvent = (name: string) => {
+      setFlashedNames((prev) => new Set(prev).add(name))
+      const existing = timers.get(name)
+      if (existing) clearTimeout(existing)
+      const timerId = setTimeout(() => {
+        setFlashedNames((prev) => {
+          const next = new Set(prev)
+          next.delete(name)
+          return next
+        })
+        timers.delete(name)
+      }, FLASH_MS)
+      timers.set(name, timerId)
+
+      // The fixed poll interval is deliberately NOT reset here: it is the
+      // only refresh path for budgets whose commits emit no SSE (a
+      // stale-generation charge), and sustained events on one budget must
+      // not starve another's. A tick landing right after an SSE refresh
+      // just folds into the coalescer's trailing batch.
+      runRefresh(new Set([name]))
+    }
+
+    const unsubUpdate = subscribe('budget_update', (event) => {
+      onBudgetEvent(event.name)
+    })
+    const unsubBreach = subscribe('budget_breached', (event) => {
+      onBudgetEvent(event.name)
+    })
+    return () => {
+      unsubUpdate()
+      unsubBreach()
+      for (const id of timers.values()) clearTimeout(id)
+      timers.clear()
+    }
+  }, [subscribe, runRefresh])
+
+  // -- Countdown timer (1s) ----------------------------------------------------
+  useEffect(() => {
+    const id = setInterval(() => {
+      setNow(Date.now())
+    }, COUNTDOWN_INTERVAL_MS)
+    return () => {
+      clearInterval(id)
+    }
+  }, [])
+
+  // -- Loading state ------------------------------------------------------------
+  if (loading) {
+    return (
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }, (_, i) => (
+          <div key={i} className="h-32 animate-pulse rounded-md bg-gray-100" />
+        ))}
+      </div>
+    )
+  }
+
+  // -- Error state --------------------------------------------------------------
+  if (error) {
+    return <PageError error={error} />
+  }
+
+  const pots = budgets ?? []
+
+  // -- Empty state ----------------------------------------------------------------
+  if (pots.length === 0) {
+    return (
+      <div className="flex h-full flex-col">
+        <div className="mb-4">
+          <h1 className="text-lg font-semibold text-gray-900">Budgets</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Cumulative cross-tool spend against named budgets
+          </p>
+        </div>
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-gray-500">
+          <svg
+            className="h-10 w-10 text-gray-300"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"
+            />
+          </svg>
+          <p className="text-sm font-medium">No budgets configured</p>
+          <p className="text-xs text-gray-400">
+            Add a top-level <code>budgets</code> section to your Helio config
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  // -- Render ---------------------------------------------------------------------
+  return (
+    <div className="flex h-full flex-col gap-6 overflow-y-auto">
+      <div>
+        <h1 className="text-lg font-semibold text-gray-900">Budgets</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Cumulative cross-tool spend against named budgets
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {pots.map((budget) => (
+          <BudgetCard
+            key={budget.name}
+            budget={budget}
+            now={now}
+            highlighted={flashedNames.has(budget.name)}
+            panel={expanded.get(budget.name)}
+            onToggleEvents={() => {
+              toggleEvents(budget.name)
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function BudgetCard({
+  budget,
+  now,
+  highlighted,
+  panel,
+  onToggleEvents,
+}: {
+  budget: BudgetState
+  now: number
+  highlighted: boolean
+  panel: EventsPanelState | undefined
+  onToggleEvents: () => void
+}) {
+  return (
+    <div
+      className={`rounded-md border bg-white p-4 transition-shadow ${
+        highlighted ? 'ring-2 ring-amber-300 border-amber-200' : 'border-gray-200'
+      }`}
+    >
+      {/* Header: name + posture + currency + window */}
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate font-mono text-sm text-gray-900">{budget.name}</span>
+          {budget.on_exceed === 'require_approval' && (
+            <span className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-xs text-amber-700">
+              break-glass
+            </span>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <span className="text-xs font-medium text-gray-400">{budget.currency}</span>
+          <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+            {budget.window}
+          </span>
+        </div>
+      </div>
+
+      {/* Buckets */}
+      {budget.buckets.length === 0 ? (
+        <div className="mb-2">
+          <div className="mb-2 flex items-center gap-3">
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-100" />
+            <span className="shrink-0 text-xs tabular-nums text-gray-600">
+              {formatCurrency(0, budget.currency)} / {formatCurrency(budget.limit, budget.currency)}
+            </span>
+          </div>
+          <p className="text-xs text-gray-500">No spend yet — full headroom</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {budget.buckets.map((bucket) => (
+            <BucketRow key={bucket.bucket_key} budget={budget} bucket={bucket} now={now} />
+          ))}
+        </div>
+      )}
+
+      {/* Recent events (ledger listing) */}
+      <button
+        type="button"
+        onClick={onToggleEvents}
+        className="mt-3 text-xs font-medium text-blue-600 hover:text-blue-500"
+      >
+        {panel ? 'Hide recent events' : 'Recent events'}
+      </button>
+      {panel && <EventsPanel panel={panel} />}
+    </div>
+  )
+}
+
+function BucketRow({
+  budget,
+  bucket,
+  now,
+}: {
+  budget: BudgetState
+  bucket: BudgetBucketState
+  now: number
+}) {
+  const label = bucketLabel(budget.name, bucket.bucket_key)
+  const pct = usagePercent(bucket.spent, budget.limit)
+  const remainingMs = bucket.reset_at_ms === null ? null : bucket.reset_at_ms - now
+
+  return (
+    <div>
+      {label !== 'global' && <p className="mb-1 font-mono text-xs text-gray-400">{label}</p>}
+      <div className="mb-1 flex items-center gap-3">
+        <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+          <div
+            className={`h-full rounded-full transition-all ${usageColor(bucket.spent, budget.limit)}`}
+            style={{ width: `${String(pct)}%` }}
+          />
+        </div>
+        <span className="shrink-0 text-xs tabular-nums text-gray-600">
+          {formatCurrency(bucket.spent, budget.currency)} /{' '}
+          {formatCurrency(budget.limit, budget.currency)}
+        </span>
+      </div>
+      <p className="text-xs text-gray-500">
+        {remainingMs === null
+          ? 'Session pot — never replenishes'
+          : remainingMs > 0
+            ? `Resets in ${formatCountdown(remainingMs)}`
+            : 'Expired'}
+      </p>
+    </div>
+  )
+}
+
+function EventsPanel({ panel }: { panel: EventsPanelState }) {
+  if (panel.loading && panel.events.length === 0) {
+    return <p className="mt-2 text-xs text-gray-400">Loading events…</p>
+  }
+  if (panel.error) {
+    return <p className="mt-2 text-xs text-red-600">{panel.error}</p>
+  }
+  if (panel.events.length === 0) {
+    return <p className="mt-2 text-xs text-gray-400">No spend recorded yet</p>
+  }
+  return (
+    <div className="mt-2 flex flex-col gap-1">
+      {panel.events.map((event) => (
+        <div key={event.id} className="flex items-center justify-between gap-2 text-xs">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate font-mono text-gray-700">{event.tool_name}</span>
+            <KindBadge kind={event.kind} />
+          </div>
+          <div className="flex shrink-0 items-center gap-2 text-gray-500">
+            <span className="tabular-nums">{formatCurrency(event.amount, event.currency)}</span>
+            <span className="text-gray-400">{new Date(event.timestamp).toLocaleTimeString()}</span>
+          </div>
+        </div>
+      ))}
+      {panel.total > panel.events.length && (
+        <p className="mt-1 text-xs text-gray-400">
+          …and {panel.total - panel.events.length} more in the ledger
+        </p>
+      )}
+    </div>
+  )
+}
+
+function KindBadge({ kind }: { kind: BudgetEventRecord['kind'] }) {
+  if (kind === 'approved_overage') {
+    return (
+      <span className="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-800">
+        approved overage
+      </span>
+    )
+  }
+  return <span className="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-gray-600">spend</span>
+}

--- a/packages/dashboard/src/pages/LimitsPage.tsx
+++ b/packages/dashboard/src/pages/LimitsPage.tsx
@@ -3,7 +3,7 @@ import type { LimitsResponse, RateLimitKeyState, SpendLimitKeyState } from '../t
 import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../constants'
 import { fetchLimits } from '../api'
 import { useEventSourceContext } from '../EventSourceContext'
-import { usageColor, usagePercent, formatCountdown } from '../utils'
+import { usageColor, usagePercent, formatCountdown, formatCurrency } from '../utils'
 import { PageError } from '../components/PageError'
 
 // ---------------------------------------------------------------------------
@@ -29,19 +29,6 @@ function formatWindow(ms: number): string {
   }
   const m = Math.round(ms / MS_PER_MINUTE)
   return `${String(m)}m`
-}
-
-function formatCurrency(amount: number, currency: string): string {
-  try {
-    return new Intl.NumberFormat(undefined, {
-      style: 'currency',
-      currency,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(amount)
-  } catch {
-    return `${currency} ${amount.toFixed(2)}`
-  }
 }
 
 function parseKeyLabel(key: string): { type: string; name: string } {

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -144,6 +144,55 @@ export interface LimitsResponse {
   readonly spend_limits: readonly SpendLimitKeyState[]
 }
 
+// -- Budgets (issue #14) -------------------------------------------------------
+
+export interface BudgetBucketState {
+  readonly bucket_key: string
+  readonly spent: number
+  readonly remaining: number
+  /** Epoch ms when the oldest entry ages out; null for session pots. */
+  readonly reset_at_ms: number | null
+  readonly last_activity_ms: number
+}
+
+export interface BudgetState {
+  readonly name: string
+  readonly limit: number
+  readonly currency: string
+  /** Raw config window string: a duration like "24h", or "session". */
+  readonly window: string
+  readonly key: 'global' | 'session' | 'sender_id'
+  readonly on_exceed: 'deny' | 'require_approval'
+  readonly buckets: readonly BudgetBucketState[]
+}
+
+export interface BudgetsResponse {
+  readonly budgets: readonly BudgetState[]
+}
+
+/** One ledger row from GET /api/budgets/:name/events. */
+export interface BudgetEventRecord {
+  readonly id: string
+  readonly budget_name: string
+  readonly bucket_key: string
+  readonly kind: 'spend' | 'approved_overage'
+  readonly amount: number
+  readonly currency: string
+  readonly tool_name: string
+  readonly origin: string
+  readonly audit_record_id: string | null
+  readonly timestamp: string
+  readonly timestamp_ms: number
+  readonly created_at: string
+}
+
+export interface BudgetEventsResponse {
+  readonly data: readonly BudgetEventRecord[]
+  readonly total: number
+  readonly limit: number
+  readonly offset: number
+}
+
 // -- Analytics ---------------------------------------------------------------
 
 export interface TimeBucket {
@@ -241,12 +290,36 @@ export interface LimitWarningEvent {
   readonly utilization: number
 }
 
+export interface BudgetUpdateEvent {
+  readonly name: string
+  readonly bucket_key: string
+  readonly kind: 'spend' | 'approved_overage'
+  readonly amount: number
+  readonly spent: number
+  readonly remaining: number
+  readonly limit: number
+  readonly currency: string
+  readonly utilization: number
+}
+
+export interface BudgetBreachedEvent {
+  readonly name: string
+  readonly bucket_key: string
+  readonly on_exceed: 'deny' | 'require_approval'
+  readonly attempted_amount: number
+  readonly spent: number
+  readonly limit: number
+  readonly currency: string
+}
+
 export type DashboardEventType =
   | 'action'
   | 'approval_requested'
   | 'approval_resolved'
   | 'approval_notification_failed'
   | 'limit_warning'
+  | 'budget_update'
+  | 'budget_breached'
 
 export interface DashboardEventMap {
   action: ActionEvent
@@ -254,4 +327,6 @@ export interface DashboardEventMap {
   approval_resolved: ApprovalResolvedEvent
   approval_notification_failed: ApprovalNotificationFailedEvent
   limit_warning: LimitWarningEvent
+  budget_update: BudgetUpdateEvent
+  budget_breached: BudgetBreachedEvent
 }

--- a/packages/dashboard/src/useEventSource.test.ts
+++ b/packages/dashboard/src/useEventSource.test.ts
@@ -140,6 +140,30 @@ describe('useEventSource', () => {
     expect(listener).toHaveBeenCalledWith({ tool_name: 'test' })
   })
 
+  it('dispatches budget_update and budget_breached events (#14)', () => {
+    const { result } = renderHook(() => useEventSource('/test'))
+    const updates: unknown[] = []
+    const breaches: unknown[] = []
+    act(() => {
+      result.current.subscribe('budget_update', (e) => updates.push(e))
+      result.current.subscribe('budget_breached', (e) => breaches.push(e))
+    })
+
+    act(() => {
+      latestInstance()._simulateEvent(
+        'budget_update',
+        JSON.stringify({ name: 'daily-cap', kind: 'approved_overage', utilization: 1.2 }),
+      )
+      latestInstance()._simulateEvent(
+        'budget_breached',
+        JSON.stringify({ name: 'daily-cap', on_exceed: 'deny', attempted_amount: 50 }),
+      )
+    })
+
+    expect(updates).toEqual([{ name: 'daily-cap', kind: 'approved_overage', utilization: 1.2 }])
+    expect(breaches).toEqual([{ name: 'daily-cap', on_exceed: 'deny', attempted_amount: 50 }])
+  })
+
   it('unsubscribe removes listener', () => {
     const { result } = renderHook(() => useEventSource('/test'))
     const listener = vi.fn()

--- a/packages/dashboard/src/useEventSource.ts
+++ b/packages/dashboard/src/useEventSource.ts
@@ -63,6 +63,8 @@ export function useEventSource(
       'approval_resolved',
       'approval_notification_failed',
       'limit_warning',
+      'budget_update',
+      'budget_breached',
     ]
 
     for (const eventType of eventTypes) {

--- a/packages/dashboard/src/utils.ts
+++ b/packages/dashboard/src/utils.ts
@@ -100,3 +100,17 @@ export function formatCountdown(remainingMs: number): string {
   if (min > 0) return `${String(min)}m ${String(sec)}s`
   return `${String(sec)}s`
 }
+
+/** Format an amount in a currency, falling back to a plain prefix form. */
+export function formatCurrency(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount)
+  } catch {
+    return `${currency} ${amount.toFixed(2)}`
+  }
+}

--- a/packages/proxy/src/budget/engine.test.ts
+++ b/packages/proxy/src/budget/engine.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
 import Database from 'better-sqlite3'
 import { BudgetEngine } from './engine.js'
-import type { BudgetCommitEvent, BudgetLedgerSink, BudgetPersistence } from './engine.js'
+import type {
+  BudgetBreachEvent,
+  BudgetCommitEvent,
+  BudgetLedgerSink,
+  BudgetPersistence,
+} from './engine.js'
 import { BudgetLedger } from './ledger.js'
 import { compileBudgets } from './parser.js'
 import type { BudgetConfig } from '../config/schema.js'
@@ -28,6 +33,7 @@ function createEngine(
   options: {
     ledger?: BudgetLedgerSink
     onCommit?: (event: BudgetCommitEvent) => void
+    onBreach?: (event: BudgetBreachEvent) => void
   } = {},
 ) {
   let time = 1_000_000
@@ -351,6 +357,64 @@ describe('BudgetEngine commit events', () => {
       currency: 'USD',
       utilization: 0.4,
     })
+  })
+})
+
+describe('BudgetEngine breach events (PR 4)', () => {
+  it('reportBreaches fires one onBreach per entry with the wire payload', () => {
+    const onBreach = vi.fn()
+    const { engine } = createEngine([budgetConfig({ on_exceed: 'require_approval' })], {
+      onBreach,
+    })
+    const seed = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 90 }))
+    engine.recordAll(seed.charges, COMMIT_META)
+
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 20 }))
+    const peek = engine.peekAll(charges)
+    expect(peek.allowed).toBe(false)
+
+    engine.reportBreaches(peek.entries.filter((entry) => !entry.allowed))
+
+    expect(onBreach).toHaveBeenCalledTimes(1)
+    expect(onBreach.mock.calls[0]?.[0]).toEqual({
+      name: 'daily-cap',
+      bucket_key: 'budget:daily-cap:global',
+      on_exceed: 'require_approval',
+      attempted_amount: 20,
+      spent: 90,
+      limit: 100,
+      currency: 'USD',
+    })
+  })
+
+  it('isolates a throwing onBreach subscriber and still reports later entries', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const seen: string[] = []
+    const onBreach = (event: BudgetBreachEvent) => {
+      seen.push(event.name)
+      if (event.name === 'a') throw new Error('subscriber bug')
+    }
+    const { engine } = createEngine(
+      [budgetConfig({ name: 'a', limit: 10 }), budgetConfig({ name: 'b', limit: 10 })],
+      { onBreach },
+    )
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 25 }))
+    const peek = engine.peekAll(charges)
+
+    expect(() => {
+      engine.reportBreaches(peek.entries)
+    }).not.toThrow()
+    expect(seen).toEqual(['a', 'b'])
+    consoleSpy.mockRestore()
+  })
+
+  it('reportBreaches is a no-op without an onBreach subscriber', () => {
+    const { engine } = createEngine([budgetConfig({ limit: 10 })])
+    const { charges } = engine.resolveCharges(chargeCtx('stripe_charge', { amount: 25 }))
+    const peek = engine.peekAll(charges)
+    expect(() => {
+      engine.reportBreaches(peek.entries)
+    }).not.toThrow()
   })
 })
 

--- a/packages/proxy/src/budget/engine.ts
+++ b/packages/proxy/src/budget/engine.ts
@@ -224,6 +224,23 @@ export interface BudgetCommitEvent {
   readonly utilization: number
 }
 
+/**
+ * Payload for the per-budget breach callback (dashboard event bus). Fired
+ * via {@link BudgetEngine.reportBreaches} by the DOORS at the moment a peek
+ * actually denies a call or raises the composite break-glass ticket — never
+ * by `peekAll` itself, which is pure and also runs for dry-run.
+ */
+export interface BudgetBreachEvent {
+  readonly name: string
+  readonly bucket_key: string
+  /** The budget's configured posture, even when the outcome was a deny. */
+  readonly on_exceed: 'deny' | 'require_approval'
+  readonly attempted_amount: number
+  readonly spent: number
+  readonly limit: number
+  readonly currency: string
+}
+
 /** Wire-ready bucket state for `GET /api/budgets` (snake_case DTO). */
 export interface BudgetBucketState {
   readonly bucket_key: string
@@ -254,6 +271,8 @@ export interface BudgetEngineOptions {
   readonly ledger?: BudgetLedgerSink
   /** Fired once per committed charge with post-record numbers. */
   readonly onCommit?: (event: BudgetCommitEvent) => void
+  /** Fired once per breached budget when a door denies or raises a ticket. */
+  readonly onBreach?: (event: BudgetBreachEvent) => void
 }
 
 interface BudgetBucket {
@@ -277,6 +296,7 @@ export class BudgetEngine {
   /** The sink again, when it carries the full persistence contract. */
   private readonly persistence: BudgetPersistence | null
   private readonly onCommit: ((event: BudgetCommitEvent) => void) | undefined
+  private readonly onBreach: ((event: BudgetBreachEvent) => void) | undefined
   private timer: ReturnType<typeof setInterval> | null = null
   private closed = false
   private hydrated = false
@@ -286,6 +306,7 @@ export class BudgetEngine {
     this.ledger = options.ledger ?? NOOP_LEDGER
     this.persistence = isBudgetPersistence(this.ledger) ? this.ledger : null
     this.onCommit = options.onCommit
+    this.onBreach = options.onBreach
     for (const budget of options.budgets ?? []) {
       this.budgets.set(budget.name, budget)
       this.generations.set(budget.name, 1)
@@ -459,6 +480,33 @@ export class BudgetEngine {
       }
     }
     return snapshots
+  }
+
+  /**
+   * Fire one `onBreach` event per breached entry. Called by the doors at the
+   * moment a peek outcome actually denies the call or raises the composite
+   * break-glass ticket (never for dry-run peeks, never for invalid-amount
+   * failures — those are input errors, not breaches). Subscriber throws are
+   * isolated: a dashboard bug must never affect a gate outcome.
+   */
+  reportBreaches(entries: readonly BudgetPeekEntry[]): void {
+    if (!this.onBreach) return
+    for (const entry of entries) {
+      try {
+        this.onBreach({
+          name: entry.budget.name,
+          bucket_key: entry.bucketKey,
+          on_exceed: entry.budget.onExceed,
+          attempted_amount: entry.amount,
+          spent: entry.spent,
+          limit: entry.budget.limit,
+          currency: entry.budget.currency,
+        })
+      } catch (err) {
+        // eslint-disable-next-line no-console -- Subscriber bugs must not affect gate outcomes
+        console.error('[helio] budget onBreach subscriber threw:', err)
+      }
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/packages/proxy/src/budget/index.ts
+++ b/packages/proxy/src/budget/index.ts
@@ -1,7 +1,7 @@
 export { compileBudgets, BudgetParseError } from './parser.js'
 export { BudgetEngine } from './engine.js'
 export { BudgetLedger } from './ledger.js'
-export type { BudgetLedgerOptions } from './ledger.js'
+export type { BudgetLedgerOptions, BudgetEventRecord, BudgetEventsPage } from './ledger.js'
 export type {
   BudgetChargeContext,
   BudgetCharge,
@@ -15,6 +15,7 @@ export type {
   BudgetReplayEvent,
   BudgetReplayBucket,
   BudgetCommitEvent,
+  BudgetBreachEvent,
   BudgetBucketState,
   BudgetState,
   BudgetEngineOptions,

--- a/packages/proxy/src/budget/ledger.test.ts
+++ b/packages/proxy/src/budget/ledger.test.ts
@@ -410,6 +410,107 @@ describe('BudgetLedger.readAllMeta', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Dashboard events listing (PR 4)
+// ---------------------------------------------------------------------------
+
+describe('BudgetLedger.listEvents', () => {
+  it('lists a budget name newest first, same-ms ties by insert order', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([
+      ledgerRow({ timestamp_ms: 1_000, tool_name: 'oldest' }),
+      ledgerRow({ timestamp_ms: 3_000, tool_name: 'tie-first' }),
+      ledgerRow({ timestamp_ms: 3_000, tool_name: 'tie-second' }),
+      ledgerRow({ timestamp_ms: 2_000, tool_name: 'middle' }),
+    ])
+
+    const { events, total } = ledger.listEvents('daily-cap', {})
+    expect(total).toBe(4)
+    expect(events.map((e) => e.tool_name)).toEqual(['tie-second', 'tie-first', 'middle', 'oldest'])
+  })
+
+  it('returns exactly the wire columns — no epoch, no generation', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([ledgerRow({ generation: 7 })])
+
+    const { events } = ledger.listEvents('daily-cap', {})
+    expect(Object.keys(events[0] ?? {}).sort()).toEqual([
+      'amount',
+      'audit_record_id',
+      'bucket_key',
+      'budget_name',
+      'created_at',
+      'currency',
+      'id',
+      'kind',
+      'origin',
+      'timestamp',
+      'timestamp_ms',
+      'tool_name',
+    ])
+  })
+
+  it('lists history across epochs — a config reset does not hide old spend', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([
+      ledgerRow({ generation: 1, timestamp_ms: 1_000 }),
+      ledgerRow({ generation: 2, timestamp_ms: 2_000 }),
+    ])
+
+    const { events, total } = ledger.listEvents('daily-cap', {})
+    expect(total).toBe(2)
+    expect(events.map((e) => e.timestamp_ms)).toEqual([2_000, 1_000])
+  })
+
+  it('defaults the page size to 50', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll(Array.from({ length: 60 }, (_, i) => ledgerRow({ timestamp_ms: 10_000 + i })))
+
+    const { events, total } = ledger.listEvents('daily-cap', {})
+    expect(total).toBe(60)
+    expect(events).toHaveLength(50)
+    expect(events[0]?.timestamp_ms).toBe(10_059)
+  })
+
+  it('clamps the page size to LIST_MAX_PAGE_SIZE', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll(
+      Array.from({ length: 1_005 }, (_, i) => ledgerRow({ timestamp_ms: 10_000 + i })),
+    )
+
+    const { events, total } = ledger.listEvents('daily-cap', { limit: 5_000 })
+    expect(total).toBe(1_005)
+    expect(events).toHaveLength(1_000)
+  })
+
+  it('paginates with offset against the same newest-first order', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll(Array.from({ length: 5 }, (_, i) => ledgerRow({ timestamp_ms: 1_000 + i })))
+
+    const page = ledger.listEvents('daily-cap', { limit: 2, offset: 2 })
+    expect(page.total).toBe(5)
+    expect(page.events.map((e) => e.timestamp_ms)).toEqual([1_002, 1_001])
+  })
+
+  it('floors nonsense paging values instead of throwing', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([ledgerRow()])
+
+    const page = ledger.listEvents('daily-cap', { limit: -3, offset: -10 })
+    expect(page.events).toHaveLength(1)
+    expect(page.total).toBe(1)
+  })
+
+  it('returns an empty page for an unknown budget name', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([ledgerRow()])
+
+    const page = ledger.listEvents('no-such-budget', {})
+    expect(page.events).toEqual([])
+    expect(page.total).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // GC watermarks
 // ---------------------------------------------------------------------------
 

--- a/packages/proxy/src/budget/ledger.ts
+++ b/packages/proxy/src/budget/ledger.ts
@@ -17,6 +17,7 @@
 import Database from 'better-sqlite3'
 import type { Database as DatabaseType, Statement } from 'better-sqlite3'
 import { randomUUID } from 'node:crypto'
+import { LIST_MAX_PAGE_SIZE } from '../audit/store.js'
 import type {
   BudgetLedgerRow,
   BudgetMetaRow,
@@ -142,6 +143,51 @@ GROUP BY e.bucket_key
 ORDER BY e.bucket_key ASC
 `
 
+// Newest first on timestamp_ms — the same event-time axis replay and
+// retention filter on — with rowid breaking same-millisecond ties by insert
+// order. No epoch filter: the listing is spend HISTORY ("where did the money
+// go"), and money that moved under a since-retired config tuple still moved;
+// retention bounds the depth.
+const LIST_EVENTS_SQL = `
+SELECT id, budget_name, bucket_key, kind, amount, currency, tool_name,
+       origin, audit_record_id, timestamp, timestamp_ms, created_at
+FROM budget_events
+WHERE budget_name = ?
+ORDER BY timestamp_ms DESC, rowid DESC
+LIMIT ? OFFSET ?
+`
+
+const COUNT_EVENTS_SQL = 'SELECT COUNT(*) AS total FROM budget_events WHERE budget_name = ?'
+
+/** Default page size for {@link BudgetLedger.listEvents}. */
+const LIST_EVENTS_DEFAULT_LIMIT = 50
+
+/**
+ * One `budget_events` row as listed by `GET /api/budgets/:name/events` —
+ * the table columns minus `epoch` (internal replay bookkeeping), snake_case
+ * verbatim. `budget_name` stays in the row so a page is self-describing.
+ */
+export interface BudgetEventRecord {
+  readonly id: string
+  readonly budget_name: string
+  readonly bucket_key: string
+  readonly kind: 'spend' | 'approved_overage'
+  readonly amount: number
+  readonly currency: string
+  readonly tool_name: string
+  readonly origin: string
+  readonly audit_record_id: string | null
+  readonly timestamp: string
+  readonly timestamp_ms: number
+  readonly created_at: string
+}
+
+/** One page of a budget's event history plus the unpaginated total. */
+export interface BudgetEventsPage {
+  readonly events: readonly BudgetEventRecord[]
+  readonly total: number
+}
+
 function describeColumn(column: ColumnInfo): string {
   return `"${column.type}${column.notnull ? ' NOT NULL' : ''}${column.pk ? ' PRIMARY KEY' : ''}"`
 }
@@ -168,6 +214,8 @@ export class BudgetLedger implements BudgetPersistence {
   private readonly maxEventEpochStmt: Statement
   private readonly replayDurationStmt: Statement
   private readonly replaySessionStmt: Statement
+  private readonly listEventsStmt: Statement
+  private readonly countEventsStmt: Statement
   private readonly commitTxn: (rows: readonly BudgetLedgerRow[]) => void
   private readonly writeMetaTxn: (metas: readonly BudgetMetaRow[]) => void
   private readonly purgeTxn: (cutoffMs: number) => { events: number; watermarks: number }
@@ -194,6 +242,8 @@ export class BudgetLedger implements BudgetPersistence {
     )
     this.replayDurationStmt = this.db.prepare(REPLAY_DURATION_SQL)
     this.replaySessionStmt = this.db.prepare(REPLAY_SESSION_SQL)
+    this.listEventsStmt = this.db.prepare(LIST_EVENTS_SQL)
+    this.countEventsStmt = this.db.prepare(COUNT_EVENTS_SQL)
 
     // One transaction for both DELETEs: a crash between them must not be
     // able to drop a watermark while its guarded rows survive.
@@ -342,6 +392,27 @@ export class BudgetLedger implements BudgetPersistence {
       bucket_key: bucketKey,
       gc_after_ms: gcAfterMs,
     })
+  }
+
+  // -------------------------------------------------------------------------
+  // Dashboard read surface
+  // -------------------------------------------------------------------------
+
+  /**
+   * One page of a budget's spend history for the dashboard, newest first.
+   * `limit` defaults to 50 and clamps to `LIST_MAX_PAGE_SIZE`; `offset`
+   * floors at 0. An unknown budget name simply lists nothing (names are
+   * config, not secrets — no 404 semantics on hot-reload races).
+   */
+  listEvents(budgetName: string, page: { limit?: number; offset?: number }): BudgetEventsPage {
+    const limit = Math.min(
+      Math.max(Math.trunc(page.limit ?? LIST_EVENTS_DEFAULT_LIMIT), 1),
+      LIST_MAX_PAGE_SIZE,
+    )
+    const offset = Math.max(Math.trunc(page.offset ?? 0), 0)
+    const events = this.listEventsStmt.all(budgetName, limit, offset) as BudgetEventRecord[]
+    const { total } = this.countEventsStmt.get(budgetName) as { total: number }
+    return { events, total }
   }
 
   // -------------------------------------------------------------------------

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -437,7 +437,16 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   // introduce budgets without a restart; the gate short-circuits when empty.
   // Hydration replays persisted spend BEFORE any server starts listening, so
   // the first governed call already sees the rebuilt pots.
-  const budgetEngine = new BudgetEngine({ budgets, ledger: budgetLedger })
+  const budgetEngine = new BudgetEngine({
+    budgets,
+    ledger: budgetLedger,
+    onCommit: (event) => {
+      eventBus.emit('budget_update', event)
+    },
+    onBreach: (event) => {
+      eventBus.emit('budget_breached', event)
+    },
+  })
   budgetEngine.hydrate()
 
   const governedForwarder = new GovernedForwarder(forwarder, policy, {
@@ -541,6 +550,12 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
         // Adapter liveness for GET /api/adapters (issue #126); undefined
         // unless the SDK sideband is enabled → endpoint serves an empty list.
         adapterLiveness: governanceService,
+        // Budget read surface (issue #14): live pot states from the engine,
+        // spend history from the ledger.
+        budgets: {
+          listStates: () => budgetEngine.listStates(),
+          listEvents: (name, page) => budgetLedger.listEvents(name, page),
+        },
       },
       {
         apiSecret: config.dashboard.api_secret,

--- a/packages/proxy/src/dashboard/api.test.ts
+++ b/packages/proxy/src/dashboard/api.test.ts
@@ -14,6 +14,9 @@ import { QueueChannel } from '../approval/channels.js'
 import { RateLimiter } from '../policy/rate-limiter.js'
 import { SpendLimiter } from '../policy/spend-limiter.js'
 import { EvidenceStore } from '../evidence/store.js'
+import { BudgetEngine } from '../budget/engine.js'
+import { BudgetLedger } from '../budget/ledger.js'
+import { compileBudgets } from '../budget/parser.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,6 +36,7 @@ function at<T>(arr: readonly T[], index: number): T {
 function setup(options?: {
   apiSecret?: string
   adapterLiveness?: DashboardAppDeps['adapterLiveness']
+  budgets?: DashboardAppDeps['budgets']
 }) {
   const auditStore = new AuditStore({
     path: ':memory:',
@@ -63,6 +67,7 @@ function setup(options?: {
       evidenceStore,
       eventBus,
       adapterLiveness: options?.adapterLiveness,
+      budgets: options?.budgets,
     },
     { apiSecret: options?.apiSecret },
   )
@@ -830,6 +835,225 @@ describe('GET /api/adapters', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Budgets (issue #14, PR 4)
+// ---------------------------------------------------------------------------
+
+/** A real engine + real ledger co-located in a fresh :memory: audit db. */
+function budgetFixture(configs: Parameters<typeof compileBudgets>[0]) {
+  const auditStore = new AuditStore({
+    path: ':memory:',
+    retention: '90d',
+    includeResponses: true,
+    cleanupIntervalMs: 0,
+  })
+  const ledger = new BudgetLedger({ database: auditStore.database })
+  const engine = new BudgetEngine({
+    budgets: compileBudgets(configs),
+    cleanupIntervalMs: 0,
+    ledger,
+  })
+  const budgets = {
+    listStates: () => engine.listStates(),
+    listEvents: (name: string, page: { limit: number; offset: number }) =>
+      ledger.listEvents(name, page),
+  }
+  cleanup.push(engine, auditStore)
+  return { engine, ledger, budgets }
+}
+
+const stripeBudgetConfig = {
+  name: 'daily-cap',
+  limit: 100,
+  currency: 'USD',
+  window: '24h',
+  key: 'global' as const,
+  on_exceed: 'deny' as const,
+  contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+}
+
+describe('GET /api/budgets', () => {
+  it('returns configured budgets in a raw envelope, with buckets when live', async () => {
+    const { engine, budgets } = budgetFixture([stripeBudgetConfig])
+    const { charges } = engine.resolveCharges({
+      toolName: 'stripe_charge',
+      toolArguments: { amount: 30 },
+      sessionId: null,
+      senderId: null,
+    })
+    engine.recordAll(charges, {
+      kind: 'spend',
+      auditRecordId: 'audit-1',
+      origin: 'mcp',
+      toolName: 'stripe_charge',
+      timestampIso: new Date().toISOString(),
+    })
+
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { budgets: Array<Record<string, unknown>> }
+    expect(body.budgets).toHaveLength(1)
+    expect(body.budgets[0]).toMatchObject({
+      name: 'daily-cap',
+      limit: 100,
+      currency: 'USD',
+      window: '24h',
+      key: 'global',
+      on_exceed: 'deny',
+    })
+    const buckets = body.budgets[0]?.['buckets'] as Array<Record<string, unknown>>
+    expect(buckets).toHaveLength(1)
+    expect(buckets[0]).toMatchObject({
+      bucket_key: 'budget:daily-cap:global',
+      spent: 30,
+      remaining: 70,
+    })
+    expect(typeof buckets[0]?.['reset_at_ms']).toBe('number')
+  })
+
+  it('lists a configured budget with zero live buckets at full headroom', async () => {
+    const { budgets } = budgetFixture([stripeBudgetConfig])
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets')
+    const body = (await res.json()) as { budgets: Array<Record<string, unknown>> }
+    expect(body.budgets).toHaveLength(1)
+    expect(body.budgets[0]?.['buckets']).toEqual([])
+  })
+
+  it('returns an empty list when zero budgets are configured', async () => {
+    const { budgets } = budgetFixture([])
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ budgets: [] })
+  })
+
+  it('returns an empty list when the budgets dep is absent', async () => {
+    const { get } = setup()
+    const res = await get('/api/budgets')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ budgets: [] })
+  })
+
+  it('requires auth like the other read endpoints when a secret is set', async () => {
+    const { get } = setup({ apiSecret: 'test-secret' })
+    const res = await get('/api/budgets')
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('GET /api/budgets/:name/events', () => {
+  function seedEvents(
+    ledger: BudgetLedger,
+    count: number,
+    overrides: Partial<Record<string, unknown>> = {},
+  ) {
+    ledger.commitAll(
+      Array.from({ length: count }, (_, i) => ({
+        budget_name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend' as const,
+        amount: 5,
+        currency: 'USD',
+        tool_name: `tool-${String(i)}`,
+        origin: 'mcp',
+        audit_record_id: `audit-${String(i)}`,
+        timestamp: new Date(1_000_000 + i).toISOString(),
+        timestamp_ms: 1_000_000 + i,
+        generation: 1,
+        ...overrides,
+      })),
+    )
+  }
+
+  it('lists events newest first in the standard list envelope', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedEvents(ledger, 3)
+
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets/daily-cap/events')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: Array<Record<string, unknown>>
+      total: number
+      limit: number
+      offset: number
+    }
+    expect(body.total).toBe(3)
+    expect(body.limit).toBe(50)
+    expect(body.offset).toBe(0)
+    expect(body.data.map((e) => e['tool_name'])).toEqual(['tool-2', 'tool-1', 'tool-0'])
+    // Wire rows carry no internal epoch/generation column.
+    expect(body.data[0]).not.toHaveProperty('epoch')
+    expect(body.data[0]).not.toHaveProperty('generation')
+    expect(body.data[0]).toMatchObject({ kind: 'spend', amount: 5, currency: 'USD' })
+  })
+
+  it('paginates with limit and offset, echoing them in the envelope', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedEvents(ledger, 5)
+
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets/daily-cap/events?limit=2&offset=2')
+    const body = (await res.json()) as {
+      data: Array<Record<string, unknown>>
+      total: number
+      limit: number
+      offset: number
+    }
+    expect(body.total).toBe(5)
+    expect(body.limit).toBe(2)
+    expect(body.offset).toBe(2)
+    expect(body.data.map((e) => e['tool_name'])).toEqual(['tool-2', 'tool-1'])
+  })
+
+  it('clamps limit to LIST_MAX_PAGE_SIZE', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedEvents(ledger, 1)
+
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets/daily-cap/events?limit=5000')
+    const body = (await res.json()) as { limit: number }
+    expect(body.limit).toBe(1000)
+  })
+
+  it('lists rows from every epoch — history survives config resets', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedEvents(ledger, 1, { generation: 1, timestamp_ms: 1_000, tool_name: 'old-epoch' })
+    seedEvents(ledger, 1, { generation: 2, timestamp_ms: 2_000, tool_name: 'new-epoch' })
+
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets/daily-cap/events')
+    const body = (await res.json()) as { data: Array<Record<string, unknown>>; total: number }
+    expect(body.total).toBe(2)
+    expect(body.data.map((e) => e['tool_name'])).toEqual(['new-epoch', 'old-epoch'])
+  })
+
+  it('returns 200 with an empty page for an unknown budget name', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedEvents(ledger, 1)
+
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets/no-such-budget/events')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ data: [], total: 0, limit: 50, offset: 0 })
+  })
+
+  it('returns an empty page when the budgets dep is absent', async () => {
+    const { get } = setup()
+    const res = await get('/api/budgets/daily-cap/events')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ data: [], total: 0, limit: 50, offset: 0 })
+  })
+
+  it('requires auth like the other read endpoints when a secret is set', async () => {
+    const { get } = setup({ apiSecret: 'test-secret' })
+    const res = await get('/api/budgets/daily-cap/events')
+    expect(res.status).toBe(401)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Analytics
 // ---------------------------------------------------------------------------
 
@@ -977,6 +1201,60 @@ describe('GET /api/events', () => {
     const eventData = await readWithTimeout(1000)
     expect(eventData).toContain('event: action')
     expect(eventData).toContain('test_tool')
+
+    await reader.cancel()
+  })
+
+  it('streams budget_update and budget_breached to connected clients (#14)', async () => {
+    const { app, eventBus } = setup()
+
+    const res = await app.request('/api/events')
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- SSE body always streams
+    const reader = res.body!.getReader()
+    const decoder = new TextDecoder()
+    const readWithTimeout = async (ms: number): Promise<string> => {
+      return Promise.race([
+        reader
+          .read()
+          .then((chunk) => (chunk.value ? decoder.decode(chunk.value as Uint8Array) : '')),
+        new Promise<string>((_resolve, reject) => {
+          setTimeout(() => {
+            reject(new Error('timeout'))
+          }, ms)
+        }),
+      ])
+    }
+
+    const initial = await readWithTimeout(1000)
+    expect(initial).toContain('event: heartbeat')
+
+    eventBus.emit('budget_update', {
+      name: 'daily-cap',
+      bucket_key: 'budget:daily-cap:global',
+      kind: 'approved_overage',
+      amount: 30,
+      spent: 120,
+      remaining: 0,
+      limit: 100,
+      currency: 'USD',
+      utilization: 1.2,
+    })
+    const update = await readWithTimeout(1000)
+    expect(update).toContain('event: budget_update')
+    expect(update).toContain('approved_overage')
+
+    eventBus.emit('budget_breached', {
+      name: 'daily-cap',
+      bucket_key: 'budget:daily-cap:global',
+      on_exceed: 'deny',
+      attempted_amount: 50,
+      spent: 90,
+      limit: 100,
+      currency: 'USD',
+    })
+    const breach = await readWithTimeout(1000)
+    expect(breach).toContain('event: budget_breached')
+    expect(breach).toContain('attempted_amount')
 
     await reader.cancel()
   })

--- a/packages/proxy/src/dashboard/api.ts
+++ b/packages/proxy/src/dashboard/api.ts
@@ -23,6 +23,8 @@ import { formatZodErrors } from '../util/format-zod-errors.js'
 import type { DashboardEventBus } from './event-bus.js'
 import { DashboardSessionStore } from './session.js'
 import type { AdapterLivenessEntry } from '../sideband/governance-service.js'
+import type { BudgetState } from '../budget/engine.js'
+import type { BudgetEventsPage } from '../budget/ledger.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -43,6 +45,17 @@ export interface DashboardAppDeps {
    * sideband is disabled; the endpoint then serves an empty list.
    */
   readonly adapterLiveness?: { listAdapters(): AdapterLivenessEntry[] }
+  /**
+   * Budget read surface for `GET /api/budgets` and
+   * `GET /api/budgets/:name/events` (issue #14) — narrow views of the
+   * BudgetEngine (live pot states) and BudgetLedger (spend history).
+   * Optional on the adapterLiveness pattern: absent (direct embedders),
+   * both endpoints serve empty lists with 200.
+   */
+  readonly budgets?: {
+    listStates(): BudgetState[]
+    listEvents(name: string, page: { limit: number; offset: number }): BudgetEventsPage
+  }
 }
 
 /** Options for the dashboard API. */
@@ -132,6 +145,11 @@ const auditQuerySchema = z.object({
   record_kind: optionalQueryString,
   channel_id: optionalQueryString,
   sender_id: optionalQueryString,
+})
+
+const budgetEventsQuerySchema = z.object({
+  limit: clampedQueryInt(50, 1, LIST_MAX_PAGE_SIZE),
+  offset: clampedQueryInt(0, 0, Number.MAX_SAFE_INTEGER),
 })
 
 const analyticsQuerySchema = z.object({
@@ -242,6 +260,7 @@ export function createDashboardAppWithLifecycle(
     evidenceStore,
     eventBus,
     adapterLiveness,
+    budgets,
   } = deps
   const apiSecret = options?.apiSecret
   const sessionStore = apiSecret
@@ -556,6 +575,33 @@ export function createDashboardAppWithLifecycle(
   // (not 404/503) without the SDK sideband, so dashboards need no probe.
   app.get('/api/adapters', (c) => {
     return c.json({ adapters: adapterLiveness?.listAdapters() ?? [] })
+  })
+
+  // -------------------------------------------------------------------------
+  // Budgets (issue #14) — named cross-tool spend pots
+  // -------------------------------------------------------------------------
+
+  // Raw envelope like /api/limits, but configured budgets appear even with
+  // zero live buckets — the dashboard shows every pot at full headroom.
+  app.get('/api/budgets', (c) => {
+    return c.json({ budgets: budgets?.listStates() ?? [] })
+  })
+
+  // One budget's spend history (ledger rows), newest first. An unknown name
+  // lists nothing with 200: names are config, not secrets, and 404 semantics
+  // would race hot-reloads.
+  app.get('/api/budgets/:name/events', (c) => {
+    const query = budgetEventsQuerySchema.parse(c.req.query())
+    const page = budgets?.listEvents(c.req.param('name'), {
+      limit: query.limit,
+      offset: query.offset,
+    }) ?? { events: [], total: 0 }
+    return c.json({
+      data: page.events,
+      total: page.total,
+      limit: query.limit,
+      offset: query.offset,
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/packages/proxy/src/dashboard/event-bus.test.ts
+++ b/packages/proxy/src/dashboard/event-bus.test.ts
@@ -126,13 +126,69 @@ describe('DashboardEventBus', () => {
       phase: 'initial',
       error: 'connection refused',
     })
+    bus.emit('budget_update', {
+      name: 'daily-cap',
+      bucket_key: 'budget:daily-cap:global',
+      kind: 'spend',
+      amount: 5,
+      spent: 45,
+      remaining: 55,
+      limit: 100,
+      currency: 'USD',
+      utilization: 0.45,
+    })
+    bus.emit('budget_breached', {
+      name: 'daily-cap',
+      bucket_key: 'budget:daily-cap:global',
+      on_exceed: 'deny',
+      attempted_amount: 80,
+      spent: 45,
+      limit: 100,
+      currency: 'USD',
+    })
 
-    expect(received).toHaveLength(5)
+    expect(received).toHaveLength(7)
     expect(received[0]).toMatchObject({ event: 'action' })
     expect(received[1]).toMatchObject({ event: 'approval_requested' })
     expect(received[2]).toMatchObject({ event: 'approval_resolved' })
     expect(received[3]).toMatchObject({ event: 'limit_warning' })
     expect(received[4]).toMatchObject({ event: 'approval_notification_failed' })
+    expect(received[5]).toMatchObject({ event: 'budget_update' })
+    expect(received[6]).toMatchObject({ event: 'budget_breached' })
+  })
+
+  it('budget events round-trip typed payloads (#14 PR 4)', () => {
+    bus = new DashboardEventBus()
+    const updates: unknown[] = []
+    const breaches: unknown[] = []
+    bus.on('budget_update', (e) => updates.push(e))
+    bus.on('budget_breached', (e) => breaches.push(e))
+
+    const update = {
+      name: 'daily-cap',
+      bucket_key: 'budget:daily-cap:global',
+      kind: 'approved_overage' as const,
+      amount: 30,
+      spent: 120,
+      remaining: 0,
+      limit: 100,
+      currency: 'USD',
+      utilization: 1.2,
+    }
+    const breach = {
+      name: 'daily-cap',
+      bucket_key: 'budget:daily-cap:global',
+      on_exceed: 'require_approval' as const,
+      attempted_amount: 30,
+      spent: 90,
+      limit: 100,
+      currency: 'USD',
+    }
+    bus.emit('budget_update', update)
+    bus.emit('budget_breached', breach)
+
+    expect(updates).toEqual([update])
+    expect(breaches).toEqual([breach])
   })
 
   it('onAny() returns an unsubscribe function', () => {

--- a/packages/proxy/src/dashboard/event-bus.ts
+++ b/packages/proxy/src/dashboard/event-bus.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events'
 import type { AuditRecord } from '../audit/types.js'
+import type { BudgetBreachEvent, BudgetCommitEvent } from '../budget/engine.js'
 
 // ---------------------------------------------------------------------------
 // DashboardEventBus — typed event emitter for real-time dashboard updates.
@@ -65,6 +66,21 @@ export interface ApprovalNotificationFailedEvent {
   readonly error: string
 }
 
+/**
+ * Payload for a budget_update event: one committed charge with post-record
+ * numbers (issue #14). The engine's commit-event DTO is already snake_case
+ * wire shape, so it is emitted verbatim. `utilization` drives dashboard
+ * thresholds — there is no separate budget warning event.
+ */
+export type BudgetUpdateEvent = BudgetCommitEvent
+
+/**
+ * Payload for a budget_breached event: a peek denied the call or raised the
+ * composite break-glass ticket (issue #14). Emitted verbatim from the
+ * engine's breach-event DTO.
+ */
+export type BudgetBreachedEvent = BudgetBreachEvent
+
 /** Map of event type names to their payload types. */
 export interface DashboardEvents {
   action: ActionEvent
@@ -72,6 +88,8 @@ export interface DashboardEvents {
   approval_resolved: ApprovalResolvedEvent
   limit_warning: LimitWarningEvent
   approval_notification_failed: ApprovalNotificationFailedEvent
+  budget_update: BudgetUpdateEvent
+  budget_breached: BudgetBreachedEvent
 }
 
 /** Union of all dashboard event type names. */
@@ -84,6 +102,8 @@ const EVENT_TYPES: readonly DashboardEventType[] = [
   'approval_resolved',
   'limit_warning',
   'approval_notification_failed',
+  'budget_update',
+  'budget_breached',
 ]
 
 /**

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -27,6 +27,9 @@ export type {
   BudgetLedgerSink,
   BudgetLedgerRow,
   BudgetCommitEvent,
+  BudgetBreachEvent,
+  BudgetEventRecord,
+  BudgetEventsPage,
 } from './budget/index.js'
 export type {
   CompiledPolicy,

--- a/packages/proxy/src/policy/governed-forwarder.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder.test.ts
@@ -4757,6 +4757,273 @@ describe('GovernedForwarder', () => {
     })
   })
 
+  // -------------------------------------------------------------------------
+  // budget breach/commit events (issue #14, PR 4)
+  // -------------------------------------------------------------------------
+
+  describe('budget breach events (issue #14)', () => {
+    function createEventedEngine(
+      configs: Parameters<typeof compileBudgets>[0],
+      callbacks: {
+        onBreach?: (event: unknown) => void
+        onCommit?: (event: unknown) => void
+      },
+    ) {
+      return new BudgetEngine({
+        budgets: compileBudgets(configs),
+        cleanupIntervalMs: 0,
+        ...callbacks,
+      })
+    }
+
+    function createApproval() {
+      const queue = new ApprovalQueue({ cleanupIntervalMs: 0 })
+      const channels = new Map<string, ApprovalChannel>([['dashboard', new QueueChannel()]])
+      const approvalRouter = new ApprovalRouter({
+        defaultTimeoutMs: 300_000,
+        defaultOnTimeout: 'deny',
+        channels,
+        queue,
+      })
+      return { queue, approvalRouter }
+    }
+
+    async function pendingTicket(queue: ApprovalQueue) {
+      await vi.waitFor(() => {
+        expect(queue.listPending().length).toBeGreaterThan(0)
+      })
+      return queue.listPending()[0] as NonNullable<ReturnType<ApprovalQueue['get']>>
+    }
+
+    const smallDeny = {
+      name: 'small',
+      limit: 10,
+      currency: 'USD',
+      window: '24h',
+      key: 'global' as const,
+      on_exceed: 'deny' as const,
+      contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+    }
+
+    it('a deny breach emits budget_breached for the breached budget only', async () => {
+      const inner = mockForwarder()
+      const onBreach = vi.fn()
+      const engine = createEventedEngine([{ ...smallDeny, name: 'big', limit: 1000 }, smallDeny], {
+        onBreach,
+      })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+
+      expect(inner.forward).not.toHaveBeenCalled()
+      expect(onBreach).toHaveBeenCalledTimes(1)
+      expect(onBreach.mock.calls[0]?.[0]).toEqual({
+        name: 'small',
+        bucket_key: 'budget:small:global',
+        on_exceed: 'deny',
+        attempted_amount: 50,
+        spent: 0,
+        limit: 10,
+        currency: 'USD',
+      })
+    })
+
+    it('a break-glass breach emits budget_breached when the ticket is raised', async () => {
+      const inner = mockForwarder()
+      const onBreach = vi.fn()
+      const engine = createEventedEngine([{ ...smallDeny, on_exceed: 'require_approval' }], {
+        onBreach,
+      })
+      const { queue, approvalRouter } = createApproval()
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+        approvalRouter,
+      })
+
+      const pending = governed.forward(toolsCallRequest('stripe_charge', { amount: 20 }))
+      const ticket = await pendingTicket(queue)
+
+      // The breach is a fact the moment the ticket is raised — the event must
+      // not wait for the human's decision.
+      expect(onBreach).toHaveBeenCalledTimes(1)
+      expect(onBreach.mock.calls[0]?.[0]).toMatchObject({
+        name: 'small',
+        on_exceed: 'require_approval',
+        attempted_amount: 20,
+      })
+
+      approvalRouter.deny(ticket.id, 'bob')
+      await pending
+      expect(onBreach).toHaveBeenCalledTimes(1)
+      approvalRouter.close()
+      queue.close()
+    })
+
+    it('an approved overage emits budget_update with kind approved_overage', async () => {
+      const inner = mockForwarder()
+      const onCommit = vi.fn()
+      const engine = createEventedEngine([{ ...smallDeny, on_exceed: 'require_approval' }], {
+        onCommit,
+      })
+      const { queue, approvalRouter } = createApproval()
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+        approvalRouter,
+      })
+
+      const pending = governed.forward(toolsCallRequest('stripe_charge', { amount: 20 }))
+      const ticket = await pendingTicket(queue)
+      expect(onCommit).not.toHaveBeenCalled()
+
+      approvalRouter.approve(ticket.id, 'alice')
+      await pending
+
+      expect(onCommit).toHaveBeenCalledTimes(1)
+      expect(onCommit.mock.calls[0]?.[0]).toEqual({
+        name: 'small',
+        bucket_key: 'budget:small:global',
+        kind: 'approved_overage',
+        amount: 20,
+        spent: 20,
+        remaining: 0,
+        limit: 10,
+        currency: 'USD',
+        utilization: 2,
+      })
+      approvalRouter.close()
+      queue.close()
+    })
+
+    it('a mixed deny + break-glass breach emits both and raises no ticket', async () => {
+      const inner = mockForwarder()
+      const onBreach = vi.fn()
+      const engine = createEventedEngine(
+        [smallDeny, { ...smallDeny, name: 'soft', on_exceed: 'require_approval' as const }],
+        { onBreach },
+      )
+      const { queue, approvalRouter } = createApproval()
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+        approvalRouter,
+      })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+
+      // The deny-breach wins outright; the require_approval breach still
+      // happened and both are facts worth an event.
+      expect(errorFromResult(result).data['reason']).toBe('budget_exceeded')
+      expect(queue.listPending()).toHaveLength(0)
+      expect(onBreach).toHaveBeenCalledTimes(2)
+      const names = onBreach.mock.calls.map((c) => (c[0] as { name: string }).name).sort()
+      expect(names).toEqual(['small', 'soft'])
+      approvalRouter.close()
+      queue.close()
+    })
+
+    it('a throwing onBreach subscriber never changes the gate outcome', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const inner = mockForwarder()
+      const engine = createEventedEngine([smallDeny], {
+        onBreach: () => {
+          throw new Error('dashboard bug')
+        },
+      })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+
+      // Still a clean budget denial — not an internal error, nothing forwarded.
+      expect(inner.forward).not.toHaveBeenCalled()
+      expect(errorFromResult(result).code).toBe(-32001)
+      expect(errorFromResult(result).data['reason']).toBe('budget_exceeded')
+      consoleSpy.mockRestore()
+    })
+
+    it('dry-run emits nothing even when the peek would breach', async () => {
+      const inner = mockForwarder()
+      const onBreach = vi.fn()
+      const onCommit = vi.fn()
+      const engine = createEventedEngine([smallDeny], { onBreach, onCommit })
+      const governed = new GovernedForwarder(
+        inner,
+        compile({ default: 'allow', dry_run: true, rules: [] }),
+        { budgetEngine: engine },
+      )
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+
+      expect(onBreach).not.toHaveBeenCalled()
+      expect(onCommit).not.toHaveBeenCalled()
+    })
+
+    it('an invalid-amount denial emits no budget_breached', async () => {
+      const inner = mockForwarder()
+      const onBreach = vi.fn()
+      const engine = createEventedEngine([smallDeny], { onBreach })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      const result = await governed.forward(toolsCallRequest('stripe_charge', { note: 'no amt' }))
+
+      // The call is denied (fail closed), but an unreadable amount is an
+      // input error, not a breach — there is no truthful attempted_amount.
+      expect(errorFromResult(result).data['reason']).toBe('budget_exceeded')
+      expect(onBreach).not.toHaveBeenCalled()
+    })
+
+    it('a genuine breach still emits when an invalid amount co-denies the call', async () => {
+      const inner = mockForwarder()
+      const onBreach = vi.fn()
+      const engine = createEventedEngine(
+        [
+          smallDeny,
+          {
+            ...smallDeny,
+            name: 'unreadable',
+            contributors: [{ tool: 'stripe_*', field: '$.missing' }],
+          },
+        ],
+        { onBreach },
+      )
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 50 }))
+
+      // The invalid-amount failure emits nothing for itself, but the
+      // simultaneously breached budget is a fact and fires.
+      expect(onBreach).toHaveBeenCalledTimes(1)
+      expect(onBreach.mock.calls[0]?.[0]).toMatchObject({ name: 'small', attempted_amount: 50 })
+    })
+
+    it('an allowed call emits budget_update only', async () => {
+      const inner = mockForwarder()
+      const onBreach = vi.fn()
+      const onCommit = vi.fn()
+      const engine = createEventedEngine([smallDeny], { onBreach, onCommit })
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 4 }))
+
+      expect(onBreach).not.toHaveBeenCalled()
+      expect(onCommit).toHaveBeenCalledTimes(1)
+      expect(onCommit.mock.calls[0]?.[0]).toMatchObject({
+        name: 'small',
+        kind: 'spend',
+        amount: 4,
+        utilization: 0.4,
+      })
+    })
+  })
+
   describe('spend_limit action', () => {
     function createSpendLimiter() {
       let time = 1_000_000

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -858,6 +858,14 @@ export class GovernedForwarder implements McpForwarder {
     const anyHardDeny =
       failures.length > 0 || breaches.some((entry) => entry.budget.onExceed === 'deny')
 
+    // Breach events fire here, the moment the gate's outcome is a fact:
+    // every breach-carrying path below either denies the call or raises the
+    // composite ticket, and this function never runs for dry-run
+    // (handleDryRun peeks on its own). Invalid-amount failures never emit —
+    // an unreadable amount is an input error with no truthful
+    // attempted_amount, not a breach.
+    if (breaches.length > 0) engine.reportBreaches(breaches)
+
     if (anyHardDeny) {
       if (failures.length > 0) {
         // eslint-disable-next-line no-console -- Intentional operational warning

--- a/packages/proxy/src/sideband/governance-service.test.ts
+++ b/packages/proxy/src/sideband/governance-service.test.ts
@@ -69,6 +69,8 @@ function makeService(opts?: {
   maxPendingBytes?: number
   budgets?: BudgetConfig[]
   budgetLedger?: BudgetLedgerSink
+  onBudgetBreach?: (event: unknown) => void
+  onBudgetCommit?: (event: unknown) => void
 }): ServiceHarness {
   let time = 1_000_000
   const now = () => time
@@ -102,6 +104,8 @@ function makeService(opts?: {
         now,
         cleanupIntervalMs: 0,
         ...(opts.budgetLedger && { ledger: opts.budgetLedger }),
+        ...(opts.onBudgetBreach && { onBreach: opts.onBudgetBreach }),
+        ...(opts.onBudgetCommit && { onCommit: opts.onBudgetCommit }),
       })
     : undefined
 
@@ -2702,5 +2706,270 @@ describe('GovernanceService — budget break-glass (issue #14)', () => {
     const audit = harness.service.audit(auditInput(body.evaluation_id), 'h')
     expect(audit.status).toBe(201)
     expect(harness.budgetEngine?.listStates()[0]?.buckets[0]?.spent).toBe(50)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// budget breach/commit events (issue #14, PR 4)
+// ---------------------------------------------------------------------------
+
+describe('GovernanceService — budget breach/commit events (issue #14)', () => {
+  const evBudget = (overrides: Partial<BudgetConfig> = {}): BudgetConfig => ({
+    name: 'cap',
+    limit: 10,
+    currency: 'USD',
+    window: '24h',
+    key: 'global',
+    on_exceed: 'deny',
+    contributors: [{ tool: 'stripe_*', field: '$.amount' }],
+    ...overrides,
+  })
+  const stripeEval = (amount: unknown, extra: Partial<Parameters<typeof evalInput>[0]> = {}) =>
+    evalInput({ tool: { name: 'stripe_charge' }, arguments: { amount }, ...extra })
+
+  it('a deny-breach at /evaluate emits budget_breached and no budget_update', () => {
+    const onBudgetBreach = vi.fn()
+    const onBudgetCommit = vi.fn()
+    const { service } = makeService({
+      budgets: [evBudget()],
+      onBudgetBreach,
+      onBudgetCommit,
+    })
+
+    const res = service.evaluate(stripeEval(50))
+
+    expect(res.body['decision']).toBe('budget_exceeded')
+    expect(onBudgetBreach).toHaveBeenCalledTimes(1)
+    expect(onBudgetBreach.mock.calls[0]?.[0]).toEqual({
+      name: 'cap',
+      bucket_key: 'budget:cap:global',
+      on_exceed: 'deny',
+      attempted_amount: 50,
+      spent: 0,
+      limit: 10,
+      currency: 'USD',
+    })
+    expect(onBudgetCommit).not.toHaveBeenCalled()
+  })
+
+  it('an invalid-amount denial emits no budget_breached', () => {
+    const onBudgetBreach = vi.fn()
+    const { service } = makeService({ budgets: [evBudget()], onBudgetBreach })
+
+    const res = service.evaluate(stripeEval('not-a-number'))
+
+    expect(res.body['decision']).toBe('budget_exceeded')
+    expect(onBudgetBreach).not.toHaveBeenCalled()
+  })
+
+  it('a genuine breach still emits when an invalid amount co-denies the call', () => {
+    const onBudgetBreach = vi.fn()
+    const { service } = makeService({
+      budgets: [
+        evBudget(),
+        evBudget({
+          name: 'unreadable',
+          contributors: [{ tool: 'stripe_*', field: '$.missing' }],
+        }),
+      ],
+      onBudgetBreach,
+    })
+
+    const res = service.evaluate(stripeEval(50))
+
+    // The invalid-amount failure emits nothing for itself, but the
+    // simultaneously breached budget is a fact and fires.
+    expect(res.body['decision']).toBe('budget_exceeded')
+    expect(onBudgetBreach).toHaveBeenCalledTimes(1)
+    expect(onBudgetBreach.mock.calls[0]?.[0]).toMatchObject({ name: 'cap', attempted_amount: 50 })
+  })
+
+  it('a budget-only break-glass ticket emits budget_breached when raised', () => {
+    const onBudgetBreach = vi.fn()
+    const { service } = makeService({
+      withApprovals: true,
+      budgets: [evBudget({ on_exceed: 'require_approval' })],
+      onBudgetBreach,
+    })
+
+    const res = service.evaluate(stripeEval(50))
+
+    expect(res.body['decision']).toBe('require_approval')
+    expect(res.body['approval']).toBeDefined()
+    expect(onBudgetBreach).toHaveBeenCalledTimes(1)
+    expect(onBudgetBreach.mock.calls[0]?.[0]).toMatchObject({
+      name: 'cap',
+      on_exceed: 'require_approval',
+      attempted_amount: 50,
+    })
+  })
+
+  it('a merged rule+budget ticket emits budget_breached', () => {
+    const onBudgetBreach = vi.fn()
+    const policy = compile({
+      default: 'allow',
+      rules: [{ name: 'gate', match: { tool: 'stripe_*' }, action: 'require_approval' }],
+    })
+    const { service } = makeService({
+      policy,
+      withApprovals: true,
+      budgets: [evBudget({ on_exceed: 'require_approval' })],
+      onBudgetBreach,
+    })
+
+    const res = service.evaluate(stripeEval(50))
+
+    expect(res.body['decision']).toBe('require_approval')
+    expect(onBudgetBreach).toHaveBeenCalledTimes(1)
+  })
+
+  it('the byte-cap 503 after planning emits nothing — no ticket was raised', () => {
+    // Same tuning as the orphan-ticket test: the cap sits between each
+    // call's base size (passes the early admission check) and the
+    // long-sender call's base + plans + frozen budget snapshot — only the
+    // post-planning re-check refuses it. The breach was detected, but the
+    // call was refused for capacity: no deny, no ticket, so no event. The
+    // short-sender call goes through the SAME service and emits exactly one.
+    const onBudgetBreach = vi.fn()
+    const { service } = makeService({
+      withApprovals: true,
+      budgets: [evBudget({ on_exceed: 'require_approval', key: 'sender_id' })],
+      maxSenderKeys: 1,
+      maxPendingBytes: 450,
+      onBudgetBreach,
+    })
+
+    const refused = service.evaluate(
+      stripeEval(50, {
+        metadata: { sender_id: 'sender-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+      }),
+    )
+    expect(refused.status).toBe(503)
+    expect(refused.body['error']).toBe('evaluation_backlog_full')
+    expect(onBudgetBreach).not.toHaveBeenCalled()
+
+    const admitted = service.evaluate(stripeEval(50, { metadata: { sender_id: 'B' } }))
+    expect(admitted.status).toBe(200)
+    expect(admitted.body['decision']).toBe('require_approval')
+    expect(onBudgetBreach).toHaveBeenCalledTimes(1)
+  })
+
+  it('sideband dry-run emits nothing even when the peek would breach', () => {
+    const onBudgetBreach = vi.fn()
+    const onBudgetCommit = vi.fn()
+    const policy = compile({ default: 'allow', dry_run: true, rules: [] })
+    const { service } = makeService({
+      policy,
+      budgets: [evBudget()],
+      onBudgetBreach,
+      onBudgetCommit,
+    })
+
+    const res = service.evaluate(stripeEval(50))
+
+    expect(res.body['decision']).toBe('dry_run')
+    expect(onBudgetBreach).not.toHaveBeenCalled()
+    expect(onBudgetCommit).not.toHaveBeenCalled()
+  })
+
+  it('a denied ticket and its not_executed /audit emit no second breach event', () => {
+    const onBudgetBreach = vi.fn()
+    const onBudgetCommit = vi.fn()
+    const { service } = makeService({
+      withApprovals: true,
+      budgets: [evBudget({ on_exceed: 'require_approval' })],
+      onBudgetBreach,
+      onBudgetCommit,
+    })
+
+    const res = service.evaluate(stripeEval(50))
+    const approval = res.body['approval'] as { id: string }
+    const id = res.body['evaluation_id'] as string
+    expect(onBudgetBreach).toHaveBeenCalledTimes(1)
+
+    service.resolveApproval(approval.id, { resolution: 'denied', resolved_by: 'bob' })
+    const audit = service.audit(auditInput(id, { status: 'not_executed' }), 'h')
+
+    expect(audit.status).toBe(201)
+    // The breach event fired once at ticket time; the resolution and the
+    // compliant not_executed report add nothing, and nothing committed.
+    expect(onBudgetBreach).toHaveBeenCalledTimes(1)
+    expect(onBudgetCommit).not.toHaveBeenCalled()
+  })
+
+  it('evaluation expiry emits no breach or commit events', () => {
+    const onBudgetBreach = vi.fn()
+    const onBudgetCommit = vi.fn()
+    const { service, advance } = makeService({
+      budgets: [evBudget({ limit: 100 })],
+      ttlMs: 1_000,
+      onBudgetBreach,
+      onBudgetCommit,
+    })
+
+    const id = service.evaluate(stripeEval(30)).body['evaluation_id'] as string
+    advance(1_001)
+    service.sweep()
+    expect(service.audit(auditInput(id), 'h').status).toBe(404)
+
+    expect(onBudgetBreach).not.toHaveBeenCalled()
+    expect(onBudgetCommit).not.toHaveBeenCalled()
+  })
+
+  it('an allowed call emits budget_update at /audit commit time, not at /evaluate', () => {
+    const onBudgetCommit = vi.fn()
+    const { service } = makeService({
+      budgets: [evBudget({ limit: 100 })],
+      onBudgetCommit,
+    })
+
+    const res = service.evaluate(stripeEval(30))
+    expect(res.body['decision']).toBe('allow')
+    expect(onBudgetCommit).not.toHaveBeenCalled()
+
+    service.audit(auditInput(res.body['evaluation_id'] as string), 'h')
+
+    expect(onBudgetCommit).toHaveBeenCalledTimes(1)
+    expect(onBudgetCommit.mock.calls[0]?.[0]).toEqual({
+      name: 'cap',
+      bucket_key: 'budget:cap:global',
+      kind: 'spend',
+      amount: 30,
+      spent: 30,
+      remaining: 70,
+      limit: 100,
+      currency: 'USD',
+      utilization: 0.3,
+    })
+  })
+
+  it('an approved overage emits budget_update with kind approved_overage', () => {
+    const onBudgetCommit = vi.fn()
+    const { service } = makeService({
+      withApprovals: true,
+      budgets: [evBudget({ on_exceed: 'require_approval' })],
+      onBudgetCommit,
+    })
+
+    const res = service.evaluate(stripeEval(50))
+    const approval = res.body['approval'] as { id: string }
+    const id = res.body['evaluation_id'] as string
+    service.resolveApproval(approval.id, { resolution: 'approved', resolved_by: 'alice' })
+    expect(onBudgetCommit).not.toHaveBeenCalled()
+
+    service.audit(auditInput(id), 'h')
+
+    expect(onBudgetCommit).toHaveBeenCalledTimes(1)
+    expect(onBudgetCommit.mock.calls[0]?.[0]).toEqual({
+      name: 'cap',
+      bucket_key: 'budget:cap:global',
+      kind: 'approved_overage',
+      amount: 50,
+      spent: 50,
+      remaining: 0,
+      limit: 10,
+      currency: 'USD',
+      utilization: 5,
+    })
   })
 })

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -509,6 +509,12 @@ export class GovernanceService {
     let budgetDenial: { breached: string[]; invalid: string[] } | undefined
     /** Set when require_approval breaches ride the call's native ticket. */
     let budgetBreachContexts: BudgetBreachContext[] | undefined
+    /**
+     * The raw breach entries behind budgetBreachContexts, held for the
+     * breach event: it fires only AFTER the native ticket exists (the
+     * byte-cap 503 below refuses the call without raising one).
+     */
+    let budgetBreachEntries: BudgetPeekEntry[] | undefined
     /** Break-glass timeout for BUDGET-ONLY tickets (first-breached-wins). */
     let budgetTicketTimeoutMs: number | undefined
     /** True when budgets alone flipped an allow into require_approval. */
@@ -553,6 +559,10 @@ export class GovernanceService {
               breached: breaches.map((entry) => entry.budget.name),
               invalid: failures.map((failure) => failure.budget.name),
             }
+            // The peek denied for real (never for dry-run, whose guard we
+            // are inside). Invalid-amount failures never emit — an
+            // unreadable amount is an input error, not a breach.
+            if (breaches.length > 0) this.budgetEngine.reportBreaches(breaches)
           }
         } else {
           if (breaches.length > 0) budgetDryRunOk = false
@@ -572,6 +582,7 @@ export class GovernanceService {
               })
             }
             if (breaches.length > 0) {
+              budgetBreachEntries = breaches
               budgetBreachContexts = breaches.map((entry) => ({
                 name: entry.budget.name,
                 limit: entry.budget.limit,
@@ -737,6 +748,10 @@ export class GovernanceService {
         timeout_ms: timeoutMs,
         resolve_path: `/approval/${ticket.id}/resolve`,
       }
+      // Breach events fire only now that the composite ticket exists —
+      // covers budget-only AND merged tickets, and stays silent for the
+      // byte-cap 503 refusal above (breach detected, no ticket raised).
+      if (budgetBreachEntries) this.budgetEngine?.reportBreaches(budgetBreachEntries)
     }
 
     const entry: PendingEvaluation = {


### PR DESCRIPTION
Part of #14 (does not close it). PR 4 of the named-budgets release train, on top of #143, #145, #151, and #154: the dashboard surface for budgets.

## What this adds

**Two read endpoints on the dashboard sideband:**

- `GET /api/budgets`: every configured budget with its live bucket states, raw envelope like `/api/limits`. Configured pots appear at full headroom with `buckets: []` even before any spend. `reset_at_ms` is epoch ms for duration windows and `null` for session pots.
- `GET /api/budgets/:name/events`: the budget's ledger rows, newest first, in the standard `{data, total, limit, offset}` envelope (default 50, clamped to 1000). The listing is history: it spans config resets (no epoch filter) and follows `audit.retention`. Unknown names return an empty page with 200, since names are configuration and hot reloads would race 404 semantics.

Both sit behind the blanket `/api/*` auth middleware, served through one optional `budgets` dependency (absent in direct embedders, both endpoints then return empty lists).

**Two SSE events**, registered across the bus, the frontend unions, the `useEventSource` list, and the docs table:

- `budget_update`: once per budget per committed charge, with post-record numbers and the commit `kind`, so an approved overage is visible live. Sole exception: a charge committed under a stale config generation is ledgered without an event; the poll covers it.
- `budget_breached`: once per genuinely breached budget when a peek denies a call or raises the break-glass ticket, on both doors. Dry-run peeks emit nothing. An invalid-amount failure emits nothing for itself, though genuine breaches denied alongside one still fire.

The engine holds the callbacks (`onCommit`/`onBreach`) but never self-fires; the doors call the new `reportBreaches()` only once the outcome is a fact. On the sideband that means after the native ticket exists, so a call refused by the byte cap after planning emits no event. Subscriber throws are isolated and can never affect a gate outcome.

**The Budgets view:** pot cards with per-bucket depletion bars, reset countdowns for duration windows, a session-pot line for pots that never replenish, an `on_exceed: require_approval` chip, and an expandable per-budget ledger where approved overages carry a distinct badge. SSE events flash the affected card and refetch; a fixed 5s poll covers commits that emit no event and is deliberately never reset by SSE traffic.

## Refresh-path hardening (from the review rounds)

The page's refresh machinery went through several adversarial rounds and now guarantees: responses apply only when newer than the last applied one (pots and per-panel events alike, with globally monotonic tokens and prune/collapse barriers so remove/re-add and collapse/re-expand lifecycles cannot let a first-life response land on a second-life panel); SSE bursts coalesce into one in-flight refresh plus one trailing refresh with merged budget names; refresh batches carry an AbortController and a 15s release timeout so a hanging request cannot wedge the pipeline; panel state lives in a `Map`, so schema-valid budget names like `__proto__` or `toString` render and expand safely; and expansion state for budgets removed by a hot reload is pruned synchronously.

## Docs

`sideband-api.md` gains the Budgets section (both endpoints, envelope categories, auth note, SSE table rows, backfill list), `getting-started.md` lists the sixth tab, and the CHANGELOG entry describes the surface. CSV export of the ledger stays out of this release and is now tracked in #155; the listing query's index tradeoff is tracked in #156.

## Review provenance

Implemented TDD throughout. Internal five-angle parallel review (zero confirmed defects, flags addressed), then six external review rounds: three merge-blockers (prototype-key names, out-of-order pot responses, the collapse/remove/re-add token bypass), nine should-fixes, and one nit, every one fixed with a regression test that reproduced the failure first. Final round: APPROVE.

Full local gate at commit: format, lint, typecheck, 2053 proxy + 344 dashboard + 47 python tests, docs-drift.