### PR TITLE
docs(changelog): roll unreleased entries into 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Maintainer notes:
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-14
+
 ### Added
 
 - **Named budgets: cumulative cross-tool spend enforcement (#14).** A new
@@ -544,7 +546,8 @@ Helio's first public release.
 - Secret scanning is now part of the default quality gate (pre-commit + CI),
   designed to prevent accidental credential commits before merge.
 
-[Unreleased]: https://github.com/gethelio/helio/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/gethelio/helio/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/gethelio/helio/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/gethelio/helio/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/gethelio/helio/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/gethelio/helio/compare/v0.6.0...v0.7.0


### PR DESCRIPTION
Roll the accumulated `Unreleased` entries into a `0.10.0` section dated
2026-07-14, ahead of tagging v0.10.0. Add the `0.10.0` compare link to the
footer and repoint the `Unreleased` link at v0.10.0.

This is the changelog roll for the named-budgets release (issue #14, now
closed): the six-PR train landed as #143, #145, #151, #154, #157, and #158.
No entries were rewritten — the five budget entries already read as the
release narrative, in order: umbrella, break-glass, persistence, dashboard,
docs/example/demo.

## Operator-visible changes in this release

Three entries are behavior changes, not just features, and the release notes
lead with them:

- **Approval channel references now validate against the runtime registry.**
  Previously-accepted configs with dangling channel-type references are
  rejected at startup. A budget routing break-glass tickets to the dashboard
  channel now also requires `dashboard.enabled: true`.
- **Spend bucket keys carry a `:rule:<index>` suffix.** Bucket labels change
  in `GET /api/limits`, `limit_warning` events, and denial messages, and a
  config edit that reorders spend rules evicts the bucket, so the rule starts
  a fresh window. Rate bucket keys are unchanged.
- **`ruleIndex` is deprecated.** The MCP self-repair `error.data` field is now
  `rule_index`; `ruleIndex` is emitted as an alias for this release only and
  is removed in the next (#144). The one-release dual-key window is the compat
  contract.

## Release scope

Nothing else rides. Every other open issue is explicitly deferred, including
the train's own follow-ups (#146, #147, #148, #149, #152, #153, #155, #156,
#159) and #144, which is pinned to the release *after* this one by the
dual-key contract above.

Adapter note for the announcement: `@gethelio/helio-openclaw` 0.1.0 fails
closed on the new `budget_exceeded` decision with degraded messaging. That is
documented and expected until the adapter 0.2.0 batch adds first-class
handling.