### PR TITLE
test(cli): wait for the asserted line in the config-watcher tests

### DIFF
--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -504,7 +504,9 @@ dashboard:
     it('watches the config file for policy changes by default', async () => {
       const { dir, configPath } = writeStartConfig()
       try {
-        const stderr = await startAndCaptureStderr(['-c', configPath])
+        const stderr = await startAndCaptureStderr(['-c', configPath], {
+          readyMarker: /for policy changes/,
+        })
         expect(stderr).toContain(`Watching ${configPath} for policy changes`)
         expect(stderr).not.toContain('Hot-reload disabled')
       } finally {
@@ -515,7 +517,9 @@ dashboard:
     it('disables the config watcher when --no-hot-reload is set', async () => {
       const { dir, configPath } = writeStartConfig()
       try {
-        const stderr = await startAndCaptureStderr(['-c', configPath, '--no-hot-reload'])
+        const stderr = await startAndCaptureStderr(['-c', configPath, '--no-hot-reload'], {
+          readyMarker: /Hot-reload disabled/,
+        })
         expect(stderr).toContain('Hot-reload disabled')
         expect(stderr).not.toContain(`Watching ${configPath} for policy changes`)
       } finally {


### PR DESCRIPTION
## Problem

The two config-watcher tests in `cli.test.ts` wait for the `Helio proxy
listening` ready marker, then assert on `Watching ... for policy changes` and
`Hot-reload disabled` — lines the CLI emits *later*. The only guarantee that
those lines had arrived is the capture helper's fixed **50ms** flush window
(`cli.test.ts:88`), so a loaded machine can close the window before the line
lands and fail a run in which the watcher started perfectly.

This is a marker mismatch: the test waits for one line and asserts on another.
It surfaced as a failure during the v0.10.0 pre-flight gauntlet, under the CPU
load of a full build-plus-2053-test run.

## The app is not affected

Verified against the real CLI before touching the test:

- `cli.ts` emits `Config:` (line 630) and `Watching ...` (line 697) in the same
  synchronous block — there is no `await` between them. Measured gap: **1ms**.
- Instrumenting a real proxy: the watcher starts and hot-reload fires
  end to end (edit config → `Policy reloaded: 1 rule`).
- Under full CPU saturation, the real CLI started its watcher and fired
  hot-reload on 8/8 runs.

## Fix

Wait for the line the test actually asserts on, via the helper's existing
`readyMarker` option — the same thing the annotation-cache and adapter-token
tests in this file already do (`cli.test.ts:767`, `:1095`, `:1144`).

Regression detection is preserved and improved: a watcher that never starts now
fails on the helper's 8s timeout with `Timed out waiting for helio start to
reach ready marker`, instead of a confusing missed-window assertion. Confirmed
by running the new marker against a CLI started with `--no-hot-reload` — it
fails loudly rather than hanging or passing.

## Verification

- Both fixed tests pass under a load average of 180–300, where the original
  failed at a load of ~6.
- Full gate green: 2053 proxy + 344 dashboard + 47 Python, plus lint,
  format:check, and typecheck.

## Follow-up

`cli.test.ts` has siblings with the same class of wall-clock assumption — the
SIGINT health-poll test (2s) and `export > rejects a malformed --limit` (5s),
which fail only under extreme artificial load. Those are tracked separately and
are deliberately out of scope here.