### PR TITLE
docs(readme): say what Helio enforces, not what it tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ pip-delete-this-directory.txt
 
 
 .gstack/
+
+# Page snapshots written by the Playwright MCP browser tool. Untracked and
+# unformatted, so without this they break `prettier --check .` in the format gate.
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ---
 
-Helio is an MCP proxy that sits between your AI agents and the tools they use. Every tool call passes through Helio, which enforces policies, checks evidence, routes approvals, tracks spend, and records everything - **without changing your agent code or your MCP servers.**
+Helio is an MCP proxy that sits between your AI agents and the tools they use. Every tool call passes through Helio, which enforces policies, checks evidence, routes approvals, caps cumulative spend, and records everything - **without changing your agent code or your MCP servers.**
 
 ```bash
 npx @gethelio/proxy init
@@ -274,7 +274,7 @@ Route sensitive actions to Slack, webhook, or the Helio dashboard. Configurable 
 
 ### Transaction Controls
 
-Rate limits per tool and per session. Spend limits with cumulative tracking. Irreversible action detection. Dry-run mode that executes the full pipeline without forwarding to the MCP server.
+Rate limits per tool and per session. Per-rule spend limits that block a matched tool at its own cap - for a cumulative cap that spans tools, see [Named Budgets](#named-budgets). Irreversible action detection. Dry-run mode that executes the full pipeline without forwarding to the MCP server.
 
 ### Audit Trail
 


### PR DESCRIPTION
Two README lines still describe the pre-v0.10.0 product, where Helio *observed*
spend rather than enforcing a cap on it. Named budgets changed that, and the
copy should say so.

## Changes

**The summary line (line 18).** "tracks spend" → "caps cumulative spend". Helio
now denies the call, or holds it for a break-glass approval, when a cumulative
cross-tool budget is breached. Tracking is what it did before.

**Transaction Controls (line 277).** "Spend limits with cumulative tracking" was
both vague and duplicative of the `### Named Budgets` section above it: a reader
could not tell whether the two describe the same feature. It now names the
per-rule mechanism for what it is (a cap on one matched tool) and points at
Named Budgets for the cross-tool case.

## Rider: ignore Playwright MCP page snapshots

`.playwright-mcp/` holds page snapshots written by the Playwright MCP browser
tool. They are untracked and unformatted, so `prettier --check .` sweeps them
into the format gate and fails the pre-commit hook for anyone who has driven a
browser in this repo. It failed on this very PR's first commit attempt.

Verified: with a deliberately unformatted snapshot present in that directory,
`prettier --check .` now passes.

## Notes

Docs and tooling config only. No code, no config schema, no behavior change. The
`#named-budgets` anchor resolves to the existing section at line 194.

Deliberately not included here, because it is tracked in #164: the budgets block
missing from the README's quickstart config. That lands with the `helio init`
scaffold fix, since it is the same gap on the same class of surface.

The GitHub repo description carried the same "track spend" wording and has been
updated separately (it is a repo setting, not a file).