### PR TITLE
refactor(policy): remove the deprecated ruleIndex self-repair alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ Helio sits in the critical path between AI agents and external systems. A vulner
 - **Named exports by default in product code.** Runtime/source modules should prefer named exports; default exports are acceptable in tooling/config files where ecosystem conventions expect them (for example Vite/Vitest/ESLint/tsup configs).
 - **JSDoc on public runtime APIs**: exported functions, classes, and externally-consumed types should be documented, especially in the proxy package. For internal UI-only types, keep naming/section structure clear and add JSDoc where behavior is non-obvious.
 - **2-space indentation**, single quotes, trailing commas, no semicolons (configured in Prettier).
-- **Error handling**: return structured errors, never throw unhandled. Blocked actions return self-repair feedback JSON — a discriminated union keyed on `reason` (`policy_denied`, `evidence_missing`, `evidence_expired`, `dependency_missing`, `rate_limited`, `spend_limited`, `approval_denied`, `approval_timeout`, `client_disconnected`, `shutdown_cancelled`) with a common base `{ blocked: true, reason, rule, rule_index, suggestion, retry_allowed }` (plus `ruleIndex`, a deprecated alias of `rule_index` emitted for one release only — new builders emit both via the `ruleInfo` helper) plus reason-specific fields (e.g. `missing_evidence`, `policy_reason`, `denial_reason`). Builders live in `packages/proxy/src/feedback/self-repair.ts`.
+- **Error handling**: return structured errors, never throw unhandled. Blocked actions return self-repair feedback JSON — a discriminated union keyed on `reason` (`policy_denied`, `evidence_missing`, `evidence_expired`, `dependency_missing`, `rate_limited`, `spend_limited`, `approval_denied`, `approval_timeout`, `client_disconnected`, `shutdown_cancelled`) with a common base `{ blocked: true, reason, rule, rule_index, suggestion, retry_allowed }` (every builder takes `rule` and `rule_index` from the shared `ruleInfo` helper) plus reason-specific fields (e.g. `missing_evidence`, `policy_reason`, `denial_reason`). Builders live in `packages/proxy/src/feedback/self-repair.ts`.
 - **Async audit writes**: audit records are buffered and flushed in batches. NEVER block the request path for audit writes.
 - **`readonly` on all interface fields and array types.** Mutability must be explicit and justified.
 - **Prefer `const` over `let`.** Never use `var`.
@@ -317,7 +317,6 @@ The following are planned for future releases and should not be built into the c
 - PostgreSQL or S3 audit backends
 - Email approval channel
 - SSO / SCIM / multi-user auth
-- Cross-tool spend limits
 - Rollback or compensating actions
 - Compliance report generation
 - SIEM export (Datadog, Splunk)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Removed
+
+- **MCP self-repair feedback no longer emits `ruleIndex` (#144).** v0.10.0
+  renamed the field to `rule_index` (#109) and kept `ruleIndex` as a
+  deprecated alias carrying the same value for that one release. The window
+  is closed: `error.data` on blocked calls now carries `rule_index` only.
+  Agent self-repair handlers still reading `ruleIndex` must switch to
+  `rule_index`. No other wire surface changes — audit records and
+  `/evaluate` keep `matched_rule_index`, approval tickets keep `rule_index`,
+  neither ever carried the alias.
+
 ## [0.10.0] - 2026-07-14
 
 ### Added

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -221,7 +221,7 @@ When `default_on_timeout: deny`, the agent receives self-repair feedback:
 }
 ```
 
-The `data` object also carries `blocked`, `rule`, `rule_index`, and `action`; the fields above are the ones agents typically act on. (`ruleIndex` is still emitted as a deprecated alias of `rule_index` for this release and will be removed in the next.)
+The `data` object also carries `blocked`, `rule`, `rule_index`, and `action`; the fields above are the ones agents typically act on.
 
 If the downstream client disconnects while a request is pending approval, Helio resolves the ticket as `client_disconnected` and does not forward the request upstream.
 
@@ -239,7 +239,7 @@ If the proxy receives SIGTERM while requests are still waiting for approval, Hel
 }
 ```
 
-As with the timeout example, the `data` object also carries `blocked`, `rule`, `rule_index` (plus its deprecated alias `ruleIndex`), and `action`.
+As with the timeout example, the `data` object also carries `blocked`, `rule`, `rule_index`, and `action`.
 
 This shutdown path is intentionally fail-closed and does not use `default_on_timeout`.
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -234,7 +234,7 @@ The request is blocked immediately. No upstream request is made. The response is
 }
 ```
 
-The `data` object also carries `rule_index` and `policy_reason`; the fields shown above are the ones an agent typically acts on. (`ruleIndex` is still emitted as a deprecated alias of `rule_index` for this release and will be removed in the next.)
+The `data` object also carries `rule_index` and `policy_reason`; the fields shown above are the ones an agent typically acts on.
 
 ### require_approval
 
@@ -474,7 +474,6 @@ A denial returns structured feedback with `reason: budget_exceeded` and a `budge
       "reason": "budget_exceeded",
       "rule": null,
       "rule_index": null,
-      "ruleIndex": null,
       "action": "budget",
       "suggestion": "Budget \"daily-cap\" would be exceeded by this call. Wait for the window to reset or reduce the amount.",
       "retry_allowed": true,
@@ -496,7 +495,7 @@ A denial returns structured feedback with `reason: budget_exceeded` and a `budge
 }
 ```
 
-`rule`/`rule_index` name the matched policy rule when one matched — a budget denial can shadow an `allow` rule, since budgets gate after the decision (`ruleIndex` is a deprecated alias of `rule_index`, emitted for this release only). `retry_allowed` is `true` only when every breached budget has a duration window (session pots never replenish, so retrying cannot help). `reset_at` is `null` for session windows; an invalid-amount failure carries `reason: "invalid_amount"` inside its block with `attempted_amount: null`. On the MCP door the reset field is ISO-8601 `reset_at`; the sideband's `limits.budgets` blocks and `GET /api/budgets` use epoch `reset_at_ms` instead — a deliberate per-surface idiom (each door keeps its existing reset-field convention), not drift.
+`rule`/`rule_index` name the matched policy rule when one matched — a budget denial can shadow an `allow` rule, since budgets gate after the decision. `retry_allowed` is `true` only when every breached budget has a duration window (session pots never replenish, so retrying cannot help). `reset_at` is `null` for session windows; an invalid-amount failure carries `reason: "invalid_amount"` inside its block with `attempted_amount: null`. On the MCP door the reset field is ISO-8601 `reset_at`; the sideband's `limits.budgets` blocks and `GET /api/budgets` use epoch `reset_at_ms` instead — a deliberate per-surface idiom (each door keeps its existing reset-field convention), not drift.
 
 ### Break-glass overages
 
@@ -540,7 +539,7 @@ When evidence is missing, the proxy returns self-repair feedback telling the age
 }
 ```
 
-The `data` object also carries `rule`, `rule_index` (plus its deprecated alias `ruleIndex`), `action`, `expired_evidence`, and `missing_dependencies`.
+The `data` object also carries `rule`, `rule_index`, `action`, `expired_evidence`, and `missing_dependencies`.
 
 Evidence entries have a configurable TTL (default: 300 seconds). If evidence has expired, the response includes `"reason": "evidence_expired"` with a suggestion to refresh it.
 

--- a/packages/proxy/src/feedback/self-repair.test.ts
+++ b/packages/proxy/src/feedback/self-repair.test.ts
@@ -731,10 +731,10 @@ describe('buildToolDriftFeedback', () => {
 })
 
 // ---------------------------------------------------------------------------
-// rule_index dual-key window (issue #109)
+// rule_index emission (issue #109 rename; issue #144 removed the alias)
 // ---------------------------------------------------------------------------
 
-describe('rule_index dual-key window (issue #109)', () => {
+describe('rule_index emission (issue #144 removed the ruleIndex alias)', () => {
   const drift: ToolDriftEvent = {
     toolName: 'send_email',
     changes: [
@@ -744,6 +744,31 @@ describe('rule_index dual-key window (issue #109)', () => {
         current: { destructiveHint: true },
       },
     ],
+  }
+
+  const breached = {
+    budget: {
+      name: 'cap',
+      limit: 100,
+      currency: 'USD',
+      window: { kind: 'duration' as const, windowMs: 60_000 },
+      windowRaw: '1m',
+      key: 'global' as const,
+      onExceed: 'deny' as const,
+      contributors: [],
+    },
+    bucketKey: 'budget:cap:global',
+    amount: 5,
+    allowed: false,
+    spent: 100,
+    remaining: 0,
+    resetAtMs: 60_000,
+  }
+
+  // Break-glass builders only ever see budgets that raised a ticket.
+  const breachedRequireApproval = {
+    ...breached,
+    budget: { ...breached.budget, onExceed: 'require_approval' as const },
   }
 
   const matchedRuleBuilders: ReadonlyArray<[name: string, build: () => Record<string, unknown>]> = [
@@ -815,15 +840,31 @@ describe('rule_index dual-key window (issue #109)', () => {
         ),
       }),
     ],
+    [
+      'buildBudgetExceededFeedback',
+      () => ({ ...buildBudgetExceededFeedback(denyDecision(), [breached], []) }),
+    ],
+    [
+      'buildBudgetApprovalDeniedFeedback',
+      () => ({
+        ...buildBudgetApprovalDeniedFeedback(denyDecision(), [breachedRequireApproval], 'alice'),
+      }),
+    ],
+    [
+      'buildBudgetApprovalTimeoutFeedback',
+      () => ({
+        ...buildBudgetApprovalTimeoutFeedback(denyDecision(), [breachedRequireApproval], 120_000),
+      }),
+    ],
   ]
 
-  it.each(matchedRuleBuilders)('%s emits rule_index beside ruleIndex', (_name, build) => {
+  it.each(matchedRuleBuilders)('%s emits rule_index and no ruleIndex alias', (_name, build) => {
     const feedback = build()
     expect(feedback).toHaveProperty('rule_index', 0)
-    expect(feedback).toHaveProperty('ruleIndex', 0)
+    expect(feedback).not.toHaveProperty('ruleIndex')
   })
 
-  it('buildSpendLimitedFeedback invalid-amount variant emits both keys', () => {
+  it('buildSpendLimitedFeedback invalid-amount variant emits rule_index only', () => {
     const feedback = buildSpendLimitedFeedback(
       denyDecision({ action: 'spend_limit' }),
       {
@@ -837,13 +878,13 @@ describe('rule_index dual-key window (issue #109)', () => {
       'USD',
     )
     expect(feedback).toHaveProperty('rule_index', 0)
-    expect(feedback).toHaveProperty('ruleIndex', 0)
+    expect(feedback).not.toHaveProperty('ruleIndex')
   })
 
-  it('emits null under both keys when no rule matched', () => {
+  it('emits null rule_index and no alias when no rule matched', () => {
     const feedback = buildPolicyDeniedFeedback(defaultDenyDecision())
     expect(feedback).toHaveProperty('rule_index', null)
-    expect(feedback).toHaveProperty('ruleIndex', null)
+    expect(feedback).not.toHaveProperty('ruleIndex')
   })
 
   it('budget_exceeded is not retryable when a session breach rides with an invalid amount', () => {
@@ -892,10 +933,10 @@ describe('rule_index dual-key window (issue #109)', () => {
     expect(feedback.retry_allowed).toBe(false)
   })
 
-  it('buildToolDriftFeedback emits null under both keys', () => {
+  it('buildToolDriftFeedback emits null rule_index and no alias', () => {
     const feedback = buildToolDriftFeedback(drift, 'deny')
     expect(feedback).toHaveProperty('rule_index', null)
-    expect(feedback).toHaveProperty('ruleIndex', null)
+    expect(feedback).not.toHaveProperty('ruleIndex')
   })
 })
 
@@ -947,7 +988,7 @@ describe('budget break-glass feedback builders', () => {
     })
     expect(feedback.retry_allowed).toBe(false)
     expect(feedback).toHaveProperty('rule_index', 0)
-    expect(feedback).toHaveProperty('ruleIndex', 0)
+    expect(feedback).not.toHaveProperty('ruleIndex')
   })
 
   it('denied: null denial_reason when the approver gave none', () => {

--- a/packages/proxy/src/feedback/self-repair.ts
+++ b/packages/proxy/src/feedback/self-repair.ts
@@ -34,12 +34,6 @@ interface SelfRepairFeedbackBase {
   readonly blocked: true
   readonly reason: BlockReason
   readonly rule: string | null
-  /**
-   * @deprecated Emitted for one release as a compatibility alias of
-   * `rule_index` (issue #109) and removed in the next release. The camelCase
-   * name was the lone outlier in this otherwise snake_case wire family.
-   */
-  readonly ruleIndex: number | null
   /** Index of the matched rule in `policies.rules`, or null (issue #109). */
   readonly rule_index: number | null
   readonly suggestion: string
@@ -204,20 +198,18 @@ export type SelfRepairFeedback =
 /**
  * Extract rule name and index from a compiled rule.
  *
- * Emits the index under BOTH keys for the issue #109 dual-key window: this
- * helper is the single alias site, so next release's removal of the
- * deprecated `ruleIndex` touches only this return and the base interface.
+ * Every builder spreads this return, so the base `rule`/`rule_index` fields
+ * have exactly one emission site. The deprecated `ruleIndex` alias from the
+ * issue #109 rename lived here for its one-release window and was removed in
+ * issue #144.
  */
 export function ruleInfo(rule?: CompiledPolicyRule): {
   rule: string | null
-  ruleIndex: number | null
   rule_index: number | null
 } {
-  const index = rule?.index ?? null
   return {
     rule: rule?.name ?? null,
-    ruleIndex: index,
-    rule_index: index,
+    rule_index: rule?.index ?? null,
   }
 }
 
@@ -536,8 +528,7 @@ export function buildSpendLimitedFeedback(
  *
  * Lists every breached budget (all-or-nothing gate: one breach denies the
  * call and nothing is recorded anywhere) and every fail-closed invalid-amount
- * contributor. Born snake_case with `rule_index` only where the alias story
- * applies via ruleInfo.
+ * contributor. The rule fields come from the shared `ruleInfo` helper.
  */
 /** Map a breached peek entry to its wire block (shared by every budget builder). */
 function breachBlock(entry: BudgetPeekEntry): BudgetBreachBlock {

--- a/packages/proxy/src/policy/governed-forwarder.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder.test.ts
@@ -189,7 +189,8 @@ describe('GovernedForwarder', () => {
       const result = await governed.forward(toolsCallRequest('delete_record'))
       const error = errorFromResult(result)
       expect(error.data['rule']).toBeNull()
-      expect(error.data['ruleIndex']).toBe(0)
+      expect(error.data['rule_index']).toBe(0)
+      expect(error.data).not.toHaveProperty('ruleIndex')
     })
 
     it('uses feedback message when rule has one', async () => {
@@ -650,7 +651,7 @@ describe('GovernedForwarder', () => {
       },
     )
 
-    it('emits rule_index beside ruleIndex on the unsupported error (issue #109)', async () => {
+    it('emits rule_index and no ruleIndex alias on the unsupported error (issue #144)', async () => {
       const inner = mockForwarder()
       const policy = compile({
         default: 'allow',
@@ -661,8 +662,8 @@ describe('GovernedForwarder', () => {
       const result = await governed.forward(toolsCallRequest('test_tool'))
 
       const error = errorFromResult(result)
-      expect(error.data['ruleIndex']).toBe(0)
       expect(error.data['rule_index']).toBe(0)
+      expect(error.data).not.toHaveProperty('ruleIndex')
     })
   })
 


### PR DESCRIPTION
Removes the deprecated `ruleIndex` alias from MCP self-repair feedback, closing the one-release migration window v0.10.0 opened when the field was renamed to `rule_index` (#109, PR #143). The v0.10.0 changelog and docs told operators the alias would be removed in the next release, so this rides v0.11.0.

## What changed

- `feedback/self-repair.ts`: `SelfRepairFeedbackBase` and the shared `ruleInfo()` helper drop `ruleIndex`. The helper is the single emission site (consolidated in #143 for exactly this removal), so the wire change is one file.
- Tests flipped from presence to absence assertions, test-first: the inverted assertions were observed failing (16 failures) before the field was removed. The per-builder `it.each` sweep is now exhaustive: it gained the three budget builders it previously missed, so every matched-rule builder is pinned against the alias creeping back.
- Docs: the alias parentheticals are gone from `policies.md` and `approvals.md`, the `"ruleIndex": null` line is gone from the budget-denial JSON example, and the `AGENTS.md` base-shape sentence now just names the shared helper. The changelog gains an Unreleased "Removed" entry with migration guidance.
- Rider: the stale "Cross-tool spend limits" line is removed from the `AGENTS.md` Post-v1 Roadmap; that shipped as cross-tool spend budgets in v0.10.0.

Internal camelCase `ruleIndex` identifiers (policy parser, errors, spend-limiter reconcile, CLI warning labels) are deliberately untouched; they never cross a JSON boundary.

## Verification

- Full gate green on the final tree: build, format, lint, typecheck, 2056 proxy + 344 dashboard + 47 python tests, docs-drift.
- Live wire check from a local build: `policy_denied` and `rate_limited` denials through the MCP door carry `rule_index` with the correct value and no `ruleIndex`; allowed calls forward normally; the run's audit records carry `matched_rule_index` as before.
- No other wire surface changes: audit records and `/evaluate` keep `matched_rule_index`, approval tickets keep `rule_index`; neither ever carried the alias.
- Repo-wide greps confirm nothing reads `ruleIndex` off a wire payload (dashboard, python-sdk, examples, fixtures all clean), and `@gethelio/helio-openclaw` never read it.
- Internal multi-angle review plus one external review round (APPROVE, no findings).

Closes #144
