### PR TITLE
build(pnpm): upgrade to pnpm 11 to restore the dependency audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Supporting directories: `examples/`, `docs/`, `docker/`, `scripts/`, `.github/`
 
 ## Tech Stack
 
-- **Runtime:** Node.js 22+, TypeScript 5.x (strict mode), pnpm 10 workspaces
+- **Runtime:** Node.js 22+, TypeScript 5.x (strict mode), pnpm 11 workspaces
 - **HTTP:** Hono (`@hono/node-server`)
 - **Validation:** Zod v4 (single source of truth for helio.yaml schema)
 - **YAML:** js-yaml
@@ -303,7 +303,7 @@ sdk:
 
 ## Useful Context
 
-- `better-sqlite3` (and `esbuild`) native builds are approved via `onlyBuiltDependencies` in `pnpm-workspace.yaml` — no manual rebuild needed. `pnpm-workspace.yaml` also pins a few transitive `overrides`.
+- `better-sqlite3` (and `esbuild`) native builds are approved via `allowBuilds` in `pnpm-workspace.yaml` — no manual rebuild needed. `pnpm-workspace.yaml` also pins a few transitive `overrides` and the audit ignore list (`auditConfig.ignoreGhsas`).
 - CI runs on the Node version in `.nvmrc` and Python 3.12; the E2E Python SDK test does `pip install ./packages/python-sdk`.
 - The proxy depends on the official `@modelcontextprotocol/sdk` pinned to an exact version (`devDependencies` in `packages/proxy`) — monitor it for breaking changes.
 - MCP session tracking via `Mcp-Session-Id` header — pass through transparently and use as the key for evidence/dependency state.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 ### Prerequisites
 
 - **Node.js** 22 or later
-- **pnpm** 10 or later (`npm install -g pnpm`)
+- **pnpm** 11 or later (`corepack enable` picks up the pinned version automatically, or `npm install -g pnpm`)
 - **Python** 3.10 or later (`python3 --version`)
 - **Git**
 - **gitleaks** (recommended) or **Docker** (used as fallback by secret scan scripts)
@@ -201,7 +201,7 @@ Our audit posture reflects that:
   immediately (upgrade, or remove), do not ignore.
 - A **benign vulnerability with no exploit path in our usage** (e.g. a dev-server
   SSRF or ReDoS in a build tool we only invoke on trusted input) may be **time-boxed
-  ignored** via `pnpm.auditConfig.ignoreGhsas`, but **only** with a tracking issue to
+  ignored** via `auditConfig.ignoreGhsas` in `pnpm-workspace.yaml`, but **only** with a tracking issue to
   remove it. Prefer a real upgrade over an ignore.
 
 Current dev-only ignores (each tracked for removal):

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,8 +55,13 @@ RUN pnpm --filter @gethelio/proxy build
 # ===========================================================================
 FROM deps AS prod-deps
 
-# Reinstall with production-only deps (no devDependencies)
-RUN pnpm install --frozen-lockfile --prod
+# Reinstall with production-only deps (no devDependencies). CI=true because
+# pnpm 11 prompts before purging the modules dir inherited from the deps
+# stage, and docker build has no TTY to answer it. --ignore-scripts because
+# pnpm 11 runs the root prepare script (husky) even on --prod installs, and
+# husky is pruned with the dev deps; nothing new installs in this stage, so
+# no build scripts are needed (better-sqlite3 is already built in deps).
+RUN CI=true pnpm install --frozen-lockfile --prod --ignore-scripts
 
 # ===========================================================================
 # Stage 4: Slim runtime image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@
 FROM node:22-slim AS deps
 
 # Enable corepack for pnpm
-RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Install native build tools for better-sqlite3
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -64,7 +64,7 @@ RUN pnpm install --frozen-lockfile --prod
 FROM node:22-slim AS runtime
 
 # Enable corepack for pnpm workspace resolution
-RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Install tini for proper PID 1 signal handling
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "helio",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@11.13.0",
   "engines": {
     "node": ">=22"
   },
@@ -29,17 +29,5 @@
     "prettier": "3.8.1",
     "typescript": "5.9.3",
     "typescript-eslint": "8.57.1"
-  },
-  "pnpm": {
-    "auditConfig": {
-      "ignoreGhsas": [
-        "GHSA-gv7w-rqvm-qjhr",
-        "GHSA-fx2h-pf6j-xcff",
-        "GHSA-vmh5-mc38-953g"
-      ]
-    },
-    "overrides": {
-      "form-data@>=4.0.0 <4.0.6": ">=4.0.6"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  path-to-regexp: 8.4.2
+  axios: 1.17.0
+  fast-uri: 3.1.2
+  follow-redirects: 1.16.0
+  brace-expansion@1.1.12: 1.1.13
+  brace-expansion@5.0.4: 5.0.5
+  postcss@8.5.8: 8.5.10
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'
 
 importers:
@@ -735,66 +742,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -882,24 +902,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -1927,24 +1951,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2167,7 +2195,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: 8.5.10
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -2532,7 +2560,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: 8.5.10
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,6 @@
 packages:
   - 'packages/*'
 
-onlyBuiltDependencies:
-  - better-sqlite3
-  - esbuild
-
 overrides:
   path-to-regexp: 8.4.2
   axios: 1.17.0
@@ -13,3 +9,18 @@ overrides:
   brace-expansion@1.1.12: 1.1.13
   brace-expansion@5.0.4: 5.0.5
   postcss@8.5.8: 8.5.10
+  'form-data@>=4.0.0 <4.0.6': '>=4.0.6'
+
+# pnpm 11 reads settings from this file only; the package.json "pnpm" field
+# is ignored. The GHSAs below are triaged and tracked (esbuild/vite: #64).
+auditConfig:
+  ignoreGhsas:
+    - GHSA-gv7w-rqvm-qjhr
+    - GHSA-fx2h-pf6j-xcff
+    - GHSA-vmh5-mc38-953g
+
+# Native build scripts approved to run at install (pnpm 11 renamed
+# onlyBuiltDependencies to allowBuilds).
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true


### PR DESCRIPTION
Restores `pnpm audit` everywhere it gates: the push-to-main CI audit, the daily security audit (the failure that auto-filed #171), the release workflow's CI gate, and the local pre-flight gauntlet.

## Root cause

npm retired the legacy audit endpoints (`/-/npm/v1/security/audits`, now HTTP 410 pointing at the bulk advisory endpoint). The retirement browned out in April (pnpm/pnpm#11265), then landed for good this morning: the daily audit failed at 09:20 UTC and auto-filed #171, and the first push to main after that went red at the same step. PR runs stayed green because the per-PR audit only runs when a dependency manifest changes. Nothing on our side changed; every `pnpm audit` on the pnpm 10 line now fails on any commit.

pnpm ships the bulk-endpoint client in v11 only (pnpm/pnpm#11268) and declined a v10 backport, so this upgrades the repo from pnpm 10.11.0 to 11.13.0.

## What changed

- `packageManager: pnpm@11.13.0`; both `docker/Dockerfile` corepack pins bumped to match. CI workflows need no edits (`pnpm/action-setup@v4` reads `packageManager`).
- pnpm 11 no longer reads the package.json `pnpm` field, so the audit ignore list (`auditConfig.ignoreGhsas`, all three GHSAs moved verbatim, esbuild/vite tracking unchanged in #64) and the `form-data` override moved to `pnpm-workspace.yaml`. Without the move the form-data pin would have silently dropped.
- `onlyBuiltDependencies` renamed to pnpm 11's `allowBuilds` (better-sqlite3 and esbuild, the only packages with build scripts).
- Lockfile regenerated under v11: the `overrides:` header now records the full set and platform packages gain `libc` metadata. No resolved package versions change, so the installed tree, the Docker image contents, and the npm package are byte-identical.
- The prod-deps Docker stage prunes with `CI=true` and `--ignore-scripts`: pnpm 11 prompts before purging the modules dir inherited from the deps stage (no TTY in docker build) and runs the root prepare script (husky) even on `--prod` installs, where husky is already pruned. Nothing new installs in that stage, so no build scripts are needed. Full image build and a container smoke run verified locally.
- Contributor docs updated where they named the old locations (CONTRIBUTING prerequisites and advisory-triage path, AGENTS.md tech stack and native-builds note).

## Verification

- `pnpm audit --audit-level=high` passes again: 8 vulnerabilities (2 low, 5 moderate, 1 high ignored per #64) — the same baseline as the v0.10.0 pre-flight gauntlet.
- Full gate green under pnpm 11.13.0: frozen-lockfile install (native builds run, better-sqlite3 verified loading), build, lint, format, typecheck, 2056 proxy + 344 dashboard + 47 python tests, docs-drift.
- One latent ecosystem note: corepack signature verification on stale `node:22-slim` layers can reject newer pnpm releases; this PR's Docker Build job exercises exactly that path.

Closes #171