### PR TITLE
docs: nest every copyable rule snippet under policies.rules

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -447,8 +447,11 @@ Helio watches your configuration file for changes and automatically reloads poli
 On successful reload:
 
 ```
+[helio] Budgets reloaded: 0 budgets
 [helio] Policy reloaded: 5 rules (default: allow)
 ```
+
+The budgets line always prints first, with the count from the reloaded file (`0 budgets` when no `budgets:` section is configured).
 
 If the new configuration is invalid — or its budget epoch changes cannot be durably recorded — Helio rejects the reload as a whole, keeps the complete current configuration (policy rules and budgets alike), and logs the error:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ curl -O https://raw.githubusercontent.com/gethelio/helio/main/examples/_shared/m
 node mcp-echo-server.mjs
 ```
 
-It prints `MCP echo server listening on http://127.0.0.1:8080/mcp` and exposes a handful of demo tools (`get_weather`, `send_email`, `delete_record`, `create_payment`, `create_refund`, `stripe_charge`, `paypal_payout`) with realistic annotations, so the policy examples below have something meaningful to match. Leave it running in its own terminal — the default `upstream.url` (`http://localhost:8080/mcp`) already points at it.
+It prints `MCP echo server listening on http://127.0.0.1:8080` and exposes a handful of demo tools (`get_weather`, `send_email`, `delete_record`, `create_payment`, `create_refund`, `stripe_charge`, `paypal_payout`) with realistic annotations, so the policy examples below have something meaningful to match. Leave it running in its own terminal — the default `upstream.url` (`http://localhost:8080/mcp`) already points at it.
 
 ## Step 1: Install
 
@@ -114,6 +114,7 @@ Dashboard API listening on http://127.0.0.1:3100
 Approvals: timeout 300s, default on timeout: deny, 0 channels configured
 Rate limits: enabled
 Spend limits: enabled
+Budgets: 0 configured
 Config: helio.yaml
 Watching helio.yaml for policy changes
 ```
@@ -197,27 +198,31 @@ The tool call passes through the policy engine, gets forwarded to the upstream s
 
 ## Step 7: Try a Policy Rule
 
-Add a rule to your config and watch hot-reload pick it up. With the proxy still running, edit `helio.yaml` and add a deny rule before the existing rules:
+Add a rule to your config and watch hot-reload pick it up. With the proxy still running, edit `helio.yaml` and add a deny rule at the top of `policies.rules`, before the existing rules:
 
 ```yaml
-rules:
-  - name: block-email
-    match:
-      tool: 'send_email'
-    action: deny
-    feedback:
-      message: 'Email sending is disabled.'
-      suggestion: 'Contact your admin to enable email.'
+policies:
+  default: allow
+  rules:
+    - name: block-email
+      match:
+        tool: 'send_email'
+      action: deny
+      feedback:
+        message: 'Email sending is disabled.'
+        suggestion: 'Contact your admin to enable email.'
 
-  - name: block-destructive
-    # ... existing rules
+    # ... your existing rules (block-destructive, allow-reads) continue here
 ```
 
 Save the file. The proxy detects the change and reloads:
 
 ```
+[helio] Budgets reloaded: 0 budgets
 [helio] Policy reloaded: 3 rules (default: allow)
 ```
+
+Check the rule count. It should now read `3 rules`: the two rules from Step 2 plus the new one. If it still says `2 rules`, the new rule did not land inside `policies.rules`. A `rules:` key at the top level of the file is silently ignored.
 
 Now try calling the blocked tool:
 
@@ -248,11 +253,11 @@ To run Helio in its own container **next to a coding agent or dev container** �
 
 The quickstart above is safe by default on a single-operator workstation. Before running Helio anywhere reachable from other people or machines, work through this checklist:
 
-- **Generate and store a strong `dashboard.api_secret`.** `helio init` writes a fresh 256-bit hex value into `helio.yaml`; if you authored the file by hand, run `openssl rand -hex 32` and paste it into `dashboard.api_secret`. This value is stable until you rotate it. Treat it like a password-manager secret: if you lose it, you must generate a new one, update `helio.yaml`, and restart/reload the proxy.
+- **Generate and store a strong `dashboard.api_secret`.** `helio init` writes a fresh 256-bit hex value into `helio.yaml`; if you authored the file by hand, run `openssl rand -hex 32` and paste it into `dashboard.api_secret`. This value is stable until you rotate it. Treat it like a password-manager secret: if you lose it, you must generate a new one, update `helio.yaml`, and restart the proxy.
 - **Understand browser login behavior.** The dashboard UI now uses a manual secret login screen: enter `dashboard.api_secret` once, then the browser uses a short-lived HttpOnly session cookie. The raw secret is not injected into frontend JS anymore.
 - **Keep `dashboard.host` on `127.0.0.1`.** The dashboard sideband assumes a single trust boundary and has no identity layer of its own. If you need to reach it remotely, put it behind a reverse proxy (nginx, Caddy, Cloudflare Access, Tailscale Serve) that terminates TLS and adds per-user authentication before forwarding to `127.0.0.1:3100`. Do not bind `dashboard.host` to `0.0.0.0` directly.
 - **Keep the audit database on local disk.** Helio's audit sqlite file is created with mode `0600` (owner read/write only) — if you move it to a shared filesystem or back it up into an unencrypted bucket, you lose that isolation. Audit records contain tool inputs and upstream responses, often including PII and credentials.
-- **Rotate secrets deliberately and expect session invalidation.** The proxy reads `dashboard.api_secret` from disk on startup and on config hot-reload. Change the value in `helio.yaml`, then restart/reload to rotate. Existing dashboard sessions are revoked and users must log in again with the new secret.
+- **Rotate secrets deliberately and expect session invalidation.** The proxy reads `dashboard.api_secret` from disk at startup only. If you change it while the proxy is running, Helio logs a restart-required warning and keeps using the startup value (see the [reload boundary](./configuration.md#reload-boundary)). Change the value in `helio.yaml`, then restart to rotate. Existing dashboard sessions are revoked and users must log in again with the new secret.
 - **Keep the main MCP port behind the same trust boundary as the dashboard.** `listen.host` defaults to `127.0.0.1`; if you need remote agents, use a reverse proxy or SSH tunnel rather than binding to `0.0.0.0`. The main port does not carry the dashboard secret — it accepts MCP traffic based on network reachability alone.
 
 ## Next Steps

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -17,29 +17,30 @@ Policy evaluation is synchronous and typically completes in under 1ms.
 Each rule in the `policies.rules` array has this structure:
 
 ```yaml
-rules:
-  - name: rule-name # Optional label for audit and error messages
-    match: # Conditions (all must be true)
-      tool: 'send_*' # Glob pattern on tool name
-      annotations: # MCP annotation hints
-        destructiveHint: true
-      input: # Conditions on tool arguments
-        '$.amount':
-          gt: 1000
-      environment: production # Match environment label
-    action: deny # What to do: allow | deny | require_approval | rate_limit | spend_limit | dry_run
-    approval: # Optional; if omitted, falls back to dashboard + global timeout
-      channel: slack
-      timeout: '600s'
-    evidence: # Require evidence before allowing
-      requires: ['order_lookup']
-    requires: ['verify_customer'] # Require prior tool calls
-    limits: # Rate or spend limit config
-      max_calls: 100
-      window: '1h'
-    feedback: # Custom message for blocked and gated actions
-      message: 'This action is blocked.'
-      suggestion: 'Try a different approach.'
+policies:
+  rules:
+    - name: rule-name # Optional label for audit and error messages
+      match: # Conditions (all must be true)
+        tool: 'send_*' # Glob pattern on tool name
+        annotations: # MCP annotation hints
+          destructiveHint: true
+        input: # Conditions on tool arguments
+          '$.amount':
+            gt: 1000
+        environment: production # Match environment label
+      action: deny # What to do: allow | deny | require_approval | rate_limit | spend_limit | dry_run
+      approval: # Optional; if omitted, falls back to dashboard + global timeout
+        channel: slack
+        timeout: '600s'
+      evidence: # Require evidence before allowing
+        requires: ['order_lookup']
+      requires: ['verify_customer'] # Require prior tool calls
+      limits: # Rate or spend limit config
+        max_calls: 100
+        window: '1h'
+      feedback: # Custom message for blocked and gated actions
+        message: 'This action is blocked.'
+        suggestion: 'Try a different approach.'
 ```
 
 ## Match Conditions
@@ -648,19 +649,20 @@ In dry-run mode:
 Since Helio uses first-match-wins, the order of rules determines behavior. Consider this example:
 
 ```yaml
-rules:
-  # Rule 1: Deny destructive tools
-  - name: block-destructive
-    match:
-      annotations:
-        destructiveHint: true
-    action: deny
+policies:
+  rules:
+    # Rule 1: Deny destructive tools
+    - name: block-destructive
+      match:
+        annotations:
+          destructiveHint: true
+      action: deny
 
-  # Rule 2: Allow all tools
-  - name: allow-all
-    match:
-      tool: '*'
-    action: allow
+    # Rule 2: Allow all tools
+    - name: allow-all
+      match:
+        tool: '*'
+      action: allow
 ```
 
 A destructive tool like `delete_record` matches **Rule 1** first and is denied. A non-destructive tool like `send_email` does not match Rule 1, falls through to **Rule 2**, and is allowed.

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -116,6 +116,7 @@ Where the Helio proxy listens. Point your MCP client here instead of directly at
 dashboard:
   enabled: true
   port: 3100
+  # Local demo mode: allow unauthenticated dashboard access on loopback only.
   allow_open_mode: true
 ```
 
@@ -125,33 +126,28 @@ The web dashboard for real-time visibility. Served on a separate port. This exam
 policies:
   default: allow
   flag_destructive: log
+  rules:
+    - name: block-destructive
+      match:
+        annotations:
+          destructiveHint: true
+      action: deny
+      feedback:
+        message: 'Destructive operations are blocked by policy.'
+        suggestion: 'Use a non-destructive alternative or request manual action.'
+
+    - name: allow-reads
+      match:
+        annotations:
+          readOnlyHint: true
+      action: allow
 ```
 
 `default: allow` means any tool call that doesn't match a rule is permitted. `flag_destructive: log` adds an audit flag when tools have `destructiveHint: true` (even if they're explicitly denied by a rule).
 
-```yaml
-rules:
-  - name: block-destructive
-    match:
-      annotations:
-        destructiveHint: true
-    action: deny
-    feedback:
-      message: 'Destructive operations are blocked by policy.'
-      suggestion: 'Use a non-destructive alternative or request manual action.'
-```
+The `rules:` array is nested inside the `policies:` section. The first rule, `block-destructive`, denies any tool with `destructiveHint: true` in its MCP annotations; its `feedback` block provides structured self-repair information to the calling agent.
 
-First rule evaluated. Any tool with `destructiveHint: true` in its MCP annotations is denied. The `feedback` block provides structured self-repair information to the calling agent.
-
-```yaml
-- name: allow-reads
-  match:
-    annotations:
-      readOnlyHint: true
-  action: allow
-```
-
-Explicitly allows read-only tools. This is redundant with `default: allow` but demonstrates the pattern — in production you'd typically use `default: deny` and explicitly allow specific tools.
+The `allow-reads` rule explicitly allows read-only tools. This is redundant with `default: allow` but demonstrates the pattern — in production you'd typically use `default: deny` and explicitly allow specific tools.
 
 ```yaml
 approval:


### PR DESCRIPTION
Closes #168

## What this fixes

Step 7 of `docs/getting-started.md` told readers to add a policy rule as a
top-level `rules:` key, which the config schema silently drops (#167 is that
root cause). The reload succeeds at 2 rules with no warning, and the tool the
doc promises to block keeps working. This is the first enforcement moment in
onboarding, and it has shipped broken since v0.1.0.

- Step 7 now shows the rule nested at the top of `policies.rules`, with a
  comment eliding the reader's existing rules by name. The fence is valid YAML
  on its own and validates as 1 rule when spliced under a minimal header.
- The reload transcript now shows both lines the proxy prints (`Budgets
  reloaded` first, unconditionally), and a new paragraph tells the reader to
  check the rule count, since that count is the only signal of a stray
  top-level key.
- The same de-indented shape is nested in `docs/policies.md` (rule anatomy and
  rule ordering fences).
- `examples/basic/README.md`'s walkthrough now quotes the shipped
  `examples/basic/helio.yaml` exactly: every YAML fence is a contiguous
  verbatim substring of that file (checked by script, not by eye). The policies
  section appears as one merged fence because prettier's embedded-YAML
  formatter re-prints parseable fences at column 0, so indented continuation
  fences cannot survive the format gate.

## Accuracy fixes from walking the whole doc live

Per the post-release findings doc, configs and transcripts here were verified
by execution against a local build, not by reading. That pass found and fixed:

- `:20` — the echo server prints `MCP echo server listening on
  http://127.0.0.1:8080`, without the `/mcp` suffix the doc quoted.
- Step 3 — the startup banner was missing the unconditional
  `Budgets: 0 configured` line.
- Production Checklist — two bullets claimed hot-reload rotates
  `dashboard.api_secret`. It does not: `dashboard.*` is startup-bound, the
  proxy logs a restart-required warning, and the old bearer keeps
  authenticating (verified live: old secret 200, new secret 401). The scaffold
  comment making the same claim in proxy source is filed as #179.
- `docs/configuration.md` — the canonical Hot Reload transcript showed only the
  policy line; it now shows the budgets line the proxy always prints first.

## Verification

- Reproduced the bug first: Step 2's config plus the old Step 7 paste
  validates and hot-reloads at 2 rules with no warning; `send_email` was
  forwarded. With the new snippet: reload prints 3 rules and `send_email`
  returns the documented structured denial.
- Every touched fragment spliced under a minimal valid header and run through
  `helio validate`, asserting the reported rule count (a zero exit code proves
  nothing while #167 stands).
- Full local gate green: format, lint, typecheck, tests (2056+344+47), docs
  drift.
- One external review round: APPROVE, with every quoted transcript re-verified
  byte-for-byte against a live run by the reviewer.

## Interlock with #170

#170's design note names these fragments as the reason a CI guard might need a
skip marker. After this PR the Step 7, anatomy, and ordering fences are rooted
and splice-validate, so the guard may not need one. Two facts for that design:
the anatomy fence needs context to validate (top-level `environment:` plus a
slack channel entry, both cross-reference checks), and prettier reformats any
fence whose content parses as YAML, so a verbatim-fence check must assume
rooted fences. The col-0 fence in `examples/spend-limits/README.md` is left
alone: a bare list item at top level fails loudly rather than silently, a
different class.

No CHANGELOG entry, matching the two prior doc-correction PRs (#166, #169).