### PR TITLE
fix(config): reject unknown top-level keys in helio.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Changed
+
+- **Unknown top-level keys in `helio.yaml` are now hard errors (#167).** The
+  top level of the config silently dropped unknown keys: a misplaced or
+  misspelled section — `rules:` at the top level, `policy:`, `budget:` — was
+  discarded without a word, so the proxy started healthy while enforcing none
+  of it. A typo'd `budgets:` key silently disabled spend enforcement; that
+  fail-open is what this closes. Now `helio validate` fails with an error
+  naming the key, `helio start` refuses to boot, and a hot reload that
+  introduces such a key is rejected while the proxy keeps its current
+  configuration. If your proxy refuses to start after upgrading, read the
+  error: fix the named key's spelling or nesting (`rules:` belongs under
+  `policies:`), or delete it. Top-level keys beginning with `x-` remain
+  available as holders for YAML anchors. `helio validate` now also reports
+  the budgets count alongside the policy rule count, and config failures on
+  every CLI surface (start, validate, export, hot reload) name the offending
+  paths on schema errors.
+
 ### Removed
 
 - **MCP self-repair feedback no longer emits `ruleIndex` (#144).** v0.10.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -430,7 +430,7 @@ helio validate -c production.yaml
 On success:
 
 ```
-Config is valid: helio.yaml (3 policy rules)
+Config is valid: helio.yaml (3 policy rules, 0 budgets)
 ```
 
 On failure, Helio reports the exact path and error:
@@ -439,6 +439,33 @@ On failure, Helio reports the exact path and error:
 Invalid config: Invalid configuration (1 error)
   upstream.url: Invalid input: expected string, received undefined
 ```
+
+The top level of the file is strict: an unknown or misplaced top-level key — a `rules:` block at the top level instead of nested under `policies:`, or a singular `policy:` or `budget:` typo — is a hard error naming the key, not a silently ignored no-op. `helio start` refuses to boot on such a config, and a hot reload that introduces one is rejected while the proxy keeps its current configuration (see [Hot Reload](#hot-reload)).
+
+```
+Invalid config: Invalid configuration (1 error)
+  (top level): Unrecognized key: "rules"
+```
+
+The one exception is top-level keys beginning with lowercase `x-`. They are reserved as extension keys — holders for reusable YAML anchors, in the docker-compose style — and are ignored by the schema:
+
+```yaml
+x-defaults: &deny-defaults
+  action: deny
+
+policies:
+  rules:
+    - <<: *deny-defaults
+      name: block-delete
+      match:
+        tool: 'delete_*'
+    - <<: *deny-defaults
+      name: block-drop
+      match:
+        tool: 'drop_*'
+```
+
+`${VAR}` references inside an `x-` block are interpolated like everywhere else, so the variables must be set even though the block itself is ignored.
 
 ## Hot Reload
 
@@ -457,6 +484,13 @@ If the new configuration is invalid — or its budget epoch changes cannot be du
 
 ```
 [helio] Config reload failed (keeping current configuration): YAML parse error in helio.yaml: ...
+```
+
+Schema errors also print the offending paths, one per line:
+
+```
+[helio] Config reload failed (keeping current configuration): Invalid configuration (1 error)
+[helio]   (top level): Unrecognized key: "rules"
 ```
 
 ### Limit reconciliation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -222,7 +222,7 @@ Save the file. The proxy detects the change and reloads:
 [helio] Policy reloaded: 3 rules (default: allow)
 ```
 
-Check the rule count. It should now read `3 rules`: the two rules from Step 2 plus the new one. If it still says `2 rules`, the new rule did not land inside `policies.rules`. A `rules:` key at the top level of the file is silently ignored.
+Check the rule count. It should now read `3 rules`: the two rules from Step 2 plus the new one. If the proxy instead prints `Config reload failed (keeping current configuration)` with `Unrecognized key: "rules"`, the rule did not land inside `policies.rules` — a `rules:` key at the top level of the file is rejected, and the proxy keeps enforcing the previous 2 rules until you fix the nesting.
 
 Now try calling the blocked tool:
 

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -446,6 +446,79 @@ dashboard:
       expect(stderr.length).toBeGreaterThan(0)
     })
 
+    it('rejects an unknown top-level key, naming it (issue #167)', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+      const configPath = join(dir, 'helio.yaml')
+
+      // The shape a user naturally writes: rules: at the top level instead
+      // of nested under policies:.
+      writeFileSync(
+        configPath,
+        `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+dashboard:
+  enabled: false
+rules:
+  - match:
+      tool: "delete_*"
+    action: deny
+`,
+      )
+
+      try {
+        const { code, stderr } = await runCli(['validate', '-c', configPath])
+        expect(code).toBe(1)
+        expect(stderr).toContain('Invalid config: Invalid configuration (1 error)')
+        expect(stderr).toContain('(top level): Unrecognized key: "rules"')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('reports the budgets count alongside the policy rule count', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+      const configPath = join(dir, 'helio.yaml')
+
+      writeFileSync(
+        configPath,
+        `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+dashboard:
+  enabled: false
+policies:
+  rules:
+    - name: block-delete
+      match:
+        tool: "delete_*"
+      action: deny
+    - name: block-drop
+      match:
+        tool: "drop_*"
+      action: deny
+budgets:
+  - name: openai-daily
+    limit: 25
+    currency: USD
+    window: 1d
+    contributors:
+      - tool: "openai_*"
+        field: "$.usage.total_cost"
+`,
+      )
+
+      try {
+        const { code, stderr } = await runCli(['validate', '-c', configPath])
+        expect(code).toBe(0)
+        expect(stderr).toContain('(2 policy rules, 1 budget)')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
     it('fails fast when a ${VAR} secret reference is unset', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
       const configPath = join(dir, 'helio.yaml')
@@ -490,6 +563,7 @@ dashboard:
       const validate = await runCli(['validate', '-c', configPath])
       expect(validate.code).toBe(0)
       expect(validate.stderr).toContain('Config is valid')
+      expect(validate.stderr).toContain('(0 policy rules, 0 budgets)')
 
       const contents = readFileSync(configPath, 'utf-8')
       expect(contents).toMatch(/dashboard:[\s\S]*?api_secret:\s*"[a-f0-9]{64}"/)
@@ -522,6 +596,21 @@ dashboard:
         })
         expect(stderr).toContain('Hot-reload disabled')
         expect(stderr).not.toContain(`Watching ${configPath} for policy changes`)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('refuses to boot when the config has an unknown top-level key (issue #167)', async () => {
+      const { dir, configPath } = writeStartConfig()
+      try {
+        // The money-gate scenario: a typo'd budget: key. The proxy must exit
+        // before listening, not boot with the budget silently dropped.
+        const original = readFileSync(configPath, 'utf-8')
+        writeFileSync(configPath, original + 'budget:\n  - name: openai-daily\n')
+        await expect(startAndCaptureStderr(['-c', configPath])).rejects.toThrow(
+          /Unrecognized key: "budget"/,
+        )
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }
@@ -1348,6 +1437,32 @@ audit:
 
       return { dir, configPath }
     }
+
+    it('names the offending key when the config is invalid (issue #167)', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+      const configPath = join(dir, 'helio.yaml')
+
+      writeFileSync(
+        configPath,
+        `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+dashboard:
+  enabled: false
+budget:
+  - name: openai-daily
+`,
+      )
+
+      try {
+        const { code, stderr } = await runCli(['export', '-c', configPath, '-f', 'json'])
+        expect(code).toBe(1)
+        expect(stderr).toContain('(top level): Unrecognized key: "budget"')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
 
     it('exports records as JSON', async () => {
       const { dir, configPath } = setupExport([

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -163,6 +163,18 @@ dashboard:
 // Commands
 // ---------------------------------------------------------------------------
 
+/**
+ * Print a ConfigError's per-field detail lines. Every surface that reports a
+ * config failure (start, validate, export, hot reload) goes through this so
+ * the offending path is always named, in one format.
+ */
+function printConfigErrorDetails(error: ConfigError, prefix = ''): void {
+  if (!error.details) return
+  for (const detail of error.details) {
+    console.error(`${prefix}  ${detail.path}: ${detail.message}`)
+  }
+}
+
 interface StartOptions {
   config: string
   /** When true, do not start the config file watcher. Overrides the YAML. */
@@ -290,11 +302,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   } catch (err) {
     if (err instanceof ConfigError) {
       console.error(`Error: ${err.message}`)
-      if (err.details) {
-        for (const detail of err.details) {
-          console.error(`  ${detail.path}: ${detail.message}`)
-        }
-      }
+      printConfigErrorDetails(err)
       process.exit(1)
     }
     throw err
@@ -691,6 +699,9 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
         console.error(
           `[helio] Config reload failed (keeping current configuration): ${error.message}`,
         )
+        if (error instanceof ConfigError) {
+          printConfigErrorDetails(error, '[helio] ')
+        }
       },
     })
     configWatcher.start()
@@ -761,17 +772,15 @@ async function validateCommand(configPath: string): Promise<void> {
     }
 
     const ruleCount = config.policies.rules.length
+    const budgetCount = config.budgets.length
     console.error(
-      `Config is valid: ${configPath} (${String(ruleCount)} policy rule${ruleCount !== 1 ? 's' : ''})`,
+      `Config is valid: ${configPath} (${String(ruleCount)} policy rule${ruleCount !== 1 ? 's' : ''}, ` +
+        `${String(budgetCount)} budget${budgetCount !== 1 ? 's' : ''})`,
     )
   } catch (err) {
     if (err instanceof ConfigError) {
       console.error(`Invalid config: ${err.message}`)
-      if (err.details) {
-        for (const detail of err.details) {
-          console.error(`  ${detail.path}: ${detail.message}`)
-        }
-      }
+      printConfigErrorDetails(err)
       process.exit(1)
     }
     if (err instanceof PolicyParseError) {
@@ -817,6 +826,7 @@ async function exportCommand(opts: ExportOptions): Promise<void> {
   } catch (err) {
     if (err instanceof ConfigError) {
       console.error(`Error: ${err.message}`)
+      printConfigErrorDetails(err)
       process.exit(1)
     }
     throw err

--- a/packages/proxy/src/config/loader.test.ts
+++ b/packages/proxy/src/config/loader.test.ts
@@ -151,6 +151,52 @@ upstream:
     await expect(loadConfig(filePath)).rejects.toThrow('YAML parse error')
   })
 
+  it('rejects an unknown top-level key with a (top level) detail naming it', async () => {
+    const yaml = `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+dashboard:
+  enabled: false
+budget:
+  - name: openai-daily
+`
+    const filePath = await writeTempYaml('top-level-typo.yaml', yaml)
+
+    try {
+      await loadConfig(filePath)
+      expect.fail('Should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError)
+      const configErr = err as ConfigError
+      expect(configErr.details).toEqual([
+        { path: '(top level)', message: 'Unrecognized key: "budget"' },
+      ])
+    }
+  })
+
+  it('loads a config that parks a YAML anchor in a top-level x- key', async () => {
+    const yaml = `
+x-shared: &tool-glob "delete_*"
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+dashboard:
+  enabled: false
+policies:
+  rules:
+    - name: block-delete
+      match:
+        tool: *tool-glob
+      action: deny
+`
+    const filePath = await writeTempYaml('anchor-holder.yaml', yaml)
+
+    const config = await loadConfig(filePath)
+    expect(config.policies.rules[0]?.match.tool).toBe('delete_*')
+    expect('x-shared' in config).toBe(false)
+  })
+
   it('throws ConfigError with details for schema validation errors', async () => {
     const yaml = `
 version: "2"

--- a/packages/proxy/src/config/loader.ts
+++ b/packages/proxy/src/config/loader.ts
@@ -100,7 +100,12 @@ export async function loadConfig(
   // 4. Validate with Zod
   const result = helioConfigSchema.safeParse(interpolated)
   if (!result.success) {
-    const details = formatZodErrors(result.error)
+    // A root-level issue (e.g. an unrecognized top-level key) has an empty
+    // zod path, which would render as a bare ": message" line. Label it here
+    // rather than in formatZodErrors, which also shapes API error responses.
+    const details = formatZodErrors(result.error).map((d) =>
+      d.path === '' ? { ...d, path: '(top level)' } : d,
+    )
     const count = details.length
     throw new ConfigError(
       `Invalid configuration (${String(count)} error${count === 1 ? '' : 's'})`,

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -1618,4 +1618,78 @@ describe('helioConfigSchema', () => {
       expect(result.success).toBe(false)
     })
   })
+
+  describe('unknown top-level keys (issue #167)', () => {
+    it('rejects a top-level rules: key, naming it', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ rules: [{ match: { tool: 'delete_*' }, action: 'deny' }] }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues).toHaveLength(1)
+      expect(result.error.issues[0]?.code).toBe('unrecognized_keys')
+      expect(result.error.issues[0]?.path).toEqual([])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "rules"')
+    })
+
+    it('rejects policy: (singular typo for policies:)', () => {
+      const result = helioConfigSchema.safeParse(minimalConfig({ policy: { default: 'allow' } }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "policy"')
+    })
+
+    it('rejects budget: (singular typo for budgets:)', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          budget: [
+            {
+              name: 'openai-daily',
+              limit: 25,
+              currency: 'USD',
+              window: '1d',
+              contributors: [{ tool: 'openai_*', field: '$.usage.total_cost' }],
+            },
+          ],
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "budget"')
+    })
+
+    it('names every unknown key in a single issue', () => {
+      const result = helioConfigSchema.safeParse(minimalConfig({ rules: [], budget: [] }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues).toHaveLength(1)
+      expect(result.error.issues[0]?.message).toBe('Unrecognized keys: "rules", "budget"')
+    })
+
+    it('allows top-level x- extension keys as anchor holders and drops them', () => {
+      const result = helioConfigSchema.safeParse(minimalConfig({ 'x-defaults': { window: '1h' } }))
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect('x-defaults' in result.data).toBe(false)
+    })
+
+    it('does not strip x- keys inside sections (root-only escape hatch)', () => {
+      // policies is a strict subtree, so the un-stripped key is rejected
+      // there. Non-strict sections handle unknown keys their own way — the
+      // pin here is only that the strip never descends past the root.
+      const result = helioConfigSchema.safeParse(minimalConfig({ policies: { 'x-shared': true } }))
+      expect(result.success).toBe(false)
+    })
+
+    it('still rejects unknown keys one level down with the section path', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ policies: { default_action: 'allow' } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.code).toBe('unrecognized_keys')
+      expect(result.error.issues[0]?.path).toEqual(['policies'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "default_action"')
+    })
+  })
 })

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -458,23 +458,39 @@ const sdkSchema = z.object({
 // Root config
 // ---------------------------------------------------------------------------
 
-const helioConfigBaseSchema = z.object({
-  version: z.literal('1'),
-  upstream: upstreamSchema,
-  listen: listenSchema.prefault({}),
-  dashboard: dashboardSchema.prefault({}),
-  environment: z.string().optional(),
-  policies: policiesSchema.prefault({}),
-  // Budgets sit beside policies deliberately: they are the second half of the
-  // governance declaration (policy decision → budget gate), not plumbing.
-  budgets: z.array(budgetSchema).default([]),
-  approval: approvalSchema.prefault({}),
-  audit: auditSchema.prefault({}),
-  sdk: sdkSchema.prefault({}),
-})
+const helioConfigBaseSchema = z
+  .object({
+    version: z.literal('1'),
+    upstream: upstreamSchema,
+    listen: listenSchema.prefault({}),
+    dashboard: dashboardSchema.prefault({}),
+    environment: z.string().optional(),
+    policies: policiesSchema.prefault({}),
+    // Budgets sit beside policies deliberately: they are the second half of the
+    // governance declaration (policy decision → budget gate), not plumbing.
+    budgets: z.array(budgetSchema).default([]),
+    approval: approvalSchema.prefault({}),
+    audit: auditSchema.prefault({}),
+    sdk: sdkSchema.prefault({}),
+  })
+  .strict()
 
-/** Zod schema for the complete `helio.yaml` configuration file. */
-export const helioConfigSchema = helioConfigBaseSchema.superRefine((cfg, ctx) => {
+/**
+ * Top-level keys matching `^x-` are extension keys: schema-ignored holders
+ * for YAML anchors (docker-compose precedent). js-yaml has already resolved
+ * the anchors by the time zod sees the document, so the holders' job is done
+ * and they are dropped before the strict parse. Root level only — the strip
+ * never descends into sections, whose own schemas decide how unknown keys
+ * are handled.
+ */
+function stripRootExtensionKeys(value: unknown): unknown {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(([key]) => !key.startsWith('x-')),
+  )
+}
+
+const helioConfigRefinedSchema = helioConfigBaseSchema.superRefine((cfg, ctx) => {
   const hasConfiguredEnvironment =
     typeof cfg.environment === 'string' && cfg.environment.trim().length > 0
 
@@ -765,6 +781,9 @@ export const helioConfigSchema = helioConfigBaseSchema.superRefine((cfg, ctx) =>
     }
   }
 })
+
+/** Zod schema for the complete `helio.yaml` configuration file. */
+export const helioConfigSchema = z.preprocess(stripRootExtensionKeys, helioConfigRefinedSchema)
 
 // ---------------------------------------------------------------------------
 // Inferred types

--- a/packages/proxy/src/config/watcher.test.ts
+++ b/packages/proxy/src/config/watcher.test.ts
@@ -374,6 +374,34 @@ budgets:
     expect(errors[0]?.message).toBeTruthy()
   })
 
+  it('calls onError and keeps old policy when a reload introduces an unknown top-level key', async () => {
+    await writeFile(configPath, configWithDenyRule())
+
+    const reloads: CompiledPolicy[] = []
+    const errors: Error[] = []
+
+    watcher = new ConfigWatcher({
+      configPath,
+      onReload: (policy) => reloads.push(policy),
+      onError: (err) => errors.push(err),
+      debounceMs: 50,
+    })
+    watcher.start()
+    await wait(100)
+
+    // The reload is rejected as a whole: the typo'd budget: key must not be
+    // dropped while the rest of the file applies.
+    await writeFile(configPath, configWithDenyRule() + 'budget:\n  - name: openai-daily\n')
+    await wait(500)
+
+    expect(reloads).toHaveLength(0)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBeInstanceOf(ConfigError)
+    expect((errors[0] as ConfigError).details).toEqual([
+      { path: '(top level)', message: 'Unrecognized key: "budget"' },
+    ])
+  })
+
   it('calls onError when policy has invalid regex', async () => {
     await writeFile(configPath, validConfig())
 


### PR DESCRIPTION
## Description

Unknown top-level keys in `helio.yaml` were silently dropped: the root schema was the one lenient layer, so a misplaced `rules:` block or a typo like `budget:` validated cleanly and the proxy booted healthy while enforcing none of it. For a governance proxy that is a fail-open path: a typo'd `budgets:` key silently disabled spend enforcement.

The root schema is now strict. `helio validate` and `helio start` fail naming the offending key, and a hot reload that introduces one is rejected while the proxy keeps its current configuration. Top-level keys beginning with `x-` are stripped before validation as holders for YAML anchors (docker-compose style); the strip never descends into sections.

Rider fixes from review: `helio export` previously swallowed the per-field detail lines on config errors (all four CLI surfaces now share one printer), root-path errors render as `(top level)` instead of a bare colon, and `helio validate` reports the budgets count alongside the policy rule count.

Closes #167

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode - no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `pnpm build`, then write a config with a top-level `rules:` block (or `policy:` / `budget:`) and run `node packages/proxy/dist/cli.js validate -c <file>`: it exits 1 with `(top level): Unrecognized key: "rules"`. On v0.10.0 the same file validates as `0 policy rules`.
2. `helio start` on the same file refuses to boot with the same error; fix the key and it boots.
3. With a proxy running, add an unknown top-level key to the config: the reload is rejected (`Config reload failed (keeping current configuration)` plus the key-naming line) and the running rules keep enforcing. Fix the nesting and the reload applies cleanly.
4. Park an anchor in a top-level `x-` key (`x-defaults: &d`, `<<: *d` inside a rule): the config validates and boots.

## Additional Context

The breaking surface is deliberate and documented in the CHANGELOG under Unreleased: a config that only "worked" because a key was silently ignored now refuses to load until the key is fixed or removed. The nine nested non-strict section schemas are a separate follow-up issue (the docs deliberately claim strictness for the top level only).