### PR TITLE
feat(cli): add budgets to the init scaffold and quickstart configs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,10 +173,12 @@ has never been executed, assume it is broken.
   is not Helio config YAML (say, a docker-compose file), put
   `<!-- helio-config-guard: skip -->` on the line above it. Never use the marker
   to silence a failing Helio sample; fix the sample instead.
-- Two additional checks are implemented but not yet enforced: canonical
-  section order (`--enforce-order`, arms with #163) and root-key completeness of
-  the `helio init` scaffold and `docs/configuration.md` (`--enforce-completeness`,
-  arms with #164). They report loudly in the meantime.
+- Root-key completeness of the `helio init` scaffold and `docs/configuration.md`
+  (`--enforce-completeness`) is enforced: every top-level section must appear
+  (the scaffold may satisfy it with a commented stub; `docs/configuration.md`
+  needs the key live in a fence). One further check is implemented but not yet
+  enforced: canonical section order (`--enforce-order`, arms with #163). It
+  reports loudly in the meantime.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This single package includes the built-in dashboard UI bundle.
 
 > **Heads up — Helio starts in audit-only mode.** `init` scaffolds the `policies` section **commented out**, so out of the box Helio runs with `default: allow` and **zero rules**: it records every tool call to the audit trail but **blocks nothing**. Uncomment and edit `policies` (or paste your own rules) to start enforcing. See the [Policy Guide](./docs/policies.md) for rule syntax.
 
-The block below is an **illustrative target** — not the file `init` writes — showing policies, audit, and a dashboard secret:
+The block below is an **illustrative target** — not the file `init` writes — showing policies, budgets, audit, and a dashboard secret:
 
 ```yaml
 version: '1'
@@ -109,6 +109,20 @@ policies:
           limit: 5000
           currency: 'GBP'
           window: 24h
+
+budgets:
+  # One depleting pot shared by every tool that spends.
+  - name: agent-payments
+    limit: 50
+    currency: USD
+    window: session
+    key: session
+    on_exceed: deny # or require_approval for a break-glass ticket
+    contributors:
+      - tool: 'stripe_*'
+        field: '$.amount'
+      - tool: 'paypal_*'
+        field: '$.total'
 
 audit:
   storage: sqlite

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,7 +82,7 @@ dashboard:
   api_secret: '${HELIO_DASHBOARD_SECRET}'
 ```
 
-Omitted fields like `listen.host`, `dashboard.host`, and `audit.path` fall back to safe defaults (`127.0.0.1` for both hosts — loopback only — and `./helio-audit.db`). The section order here (`upstream → listen → policies → audit → dashboard`) matches what `helio init` scaffolds and the [Configuration Reference](./configuration.md).
+Omitted fields like `listen.host`, `dashboard.host`, and `audit.path` fall back to safe defaults (`127.0.0.1` for both hosts — loopback only — and `./helio-audit.db`). The section order here (`upstream → listen → policies → audit → dashboard`) follows the canonical order of the [Configuration Reference](./configuration.md) and the `helio init` scaffold (which also stubs the remaining sections: `environment`, `budgets`, `approval`, and `sdk`).
 
 This example configuration blocks any tool marked as destructive, explicitly allows read-only tools, and falls through to `default: allow` for everything else. Every tool call is recorded to a local SQLite database. (Until you uncomment a `policies` block like this one, the scaffolded config blocks nothing.)
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "format:check": "prettier --check .",
     "secrets:scan": "bash ./scripts/secret-scan-ci.sh",
     "secrets:scan:staged": "bash ./scripts/secret-scan-staged.sh",
-    "docs:check:ci": "bash ./scripts/check-docs-drift-ci.sh && node ./scripts/validate-config-samples.mjs",
-    "docs:check:samples": "node ./scripts/validate-config-samples.mjs",
+    "docs:check:ci": "bash ./scripts/check-docs-drift-ci.sh && node ./scripts/validate-config-samples.mjs --enforce-completeness",
+    "docs:check:samples": "node ./scripts/validate-config-samples.mjs --enforce-completeness",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -113,6 +113,20 @@ policies:
           currency: 'GBP'
           window: 24h
 
+budgets:
+  # One depleting pot shared by every tool that spends.
+  - name: agent-payments
+    limit: 50
+    currency: USD
+    window: session
+    key: session
+    on_exceed: deny # or require_approval for a break-glass ticket
+    contributors:
+      - tool: 'stripe_*'
+        field: '$.amount'
+      - tool: 'paypal_*'
+        field: '$.total'
+
 audit:
   storage: sqlite
   retention: 90d

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -367,6 +367,43 @@ describe('CLI', () => {
         rmSync(dir, { recursive: true, force: true })
       }
     })
+
+    it('scaffolds every top-level section in canonical order', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+      const outPath = join(dir, 'helio.yaml')
+
+      try {
+        const { code } = await runCli(['init', '-o', outPath])
+        expect(code).toBe(0)
+
+        const contents = readFileSync(outPath, 'utf-8')
+        expect(contents).toContain('\n# environment: production\n')
+        expect(contents).toContain('\n# budgets:\n')
+
+        const canonicalOrder = [
+          'version',
+          'upstream',
+          'listen',
+          'environment',
+          'policies',
+          'budgets',
+          'approval',
+          'audit',
+          'dashboard',
+          'sdk',
+        ]
+        let cursor = -1
+        for (const key of canonicalOrder) {
+          const match = new RegExp(`^(?:#\\s*)?${key}:`, 'm').exec(contents)
+          expect(match, `top-level \`${key}:\` stub missing from the scaffold`).not.toBeNull()
+          const index = match?.index ?? -1
+          expect(index, `\`${key}:\` is out of canonical order`).toBeGreaterThan(cursor)
+          cursor = index
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
   })
 
   // --- helio validate ---
@@ -567,6 +604,34 @@ dashboard:
 
       const contents = readFileSync(configPath, 'utf-8')
       expect(contents).toMatch(/dashboard:[\s\S]*?api_secret:\s*"[a-f0-9]{64}"/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('uncommenting only the budgets stub yields a config with one budget', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+    const configPath = join(dir, 'helio.yaml')
+
+    try {
+      const init = await runCli(['init', '-o', configPath])
+      expect(init.code).toBe(0)
+
+      const contents = readFileSync(configPath, 'utf-8')
+      const stub = /^# budgets:\n(?:#.*\n)*/m.exec(contents)?.[0] ?? ''
+      expect(stub, 'commented `# budgets:` stub missing from the scaffold').not.toBe('')
+      expect(stub, 'stub capture must stop at the end of the budgets block').toMatch(
+        /field: '\$\.total'\n$/,
+      )
+      writeFileSync(
+        configPath,
+        contents.replace(stub, () => stub.replace(/^# ?/gm, '')),
+      )
+
+      const validate = await runCli(['validate', '-c', configPath])
+      expect(validate.code).toBe(0)
+      expect(validate.stderr).toContain('Config is valid')
+      expect(validate.stderr).toContain('(0 policy rules, 1 budget)')
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -121,10 +121,26 @@ upstream:
 #   port: 3000
 #   host: 127.0.0.1
 
+# environment: production
+
 # policies:
 #   default: allow
 #   dry_run: false
 #   rules: []
+
+# budgets:
+#   # One depleting pot shared by every tool that spends.
+#   - name: agent-payments
+#     limit: 50
+#     currency: USD
+#     window: session
+#     key: session
+#     on_exceed: deny # or require_approval for a break-glass ticket
+#     contributors:
+#       - tool: 'stripe_*'
+#         field: '$.amount'
+#       - tool: 'paypal_*'
+#         field: '$.total'
 
 # approval:
 #   timeout: 300s
@@ -142,7 +158,7 @@ upstream:
 # front. dashboard.api_secret is the manual dashboard login secret and also
 # supports machine Bearer auth for sideband API clients. Store it safely; it
 # stays valid until you rotate it. Rotate by editing this file and restarting
-# (or hot-reloading) the proxy. Rotation invalidates active dashboard sessions.
+# the proxy. Rotation invalidates active dashboard sessions.
 dashboard:
   enabled: true
   port: 3100

--- a/packages/proxy/src/config-samples-guard.test.ts
+++ b/packages/proxy/src/config-samples-guard.test.ts
@@ -315,8 +315,8 @@ describe('config-samples guard', () => {
 
       const relaxed = await runGuard(root, scaffoldArgs)
       expect(relaxed.code).toBe(0)
-      expect(relaxed.output).toContain('NOT YET ENFORCED')
-      expect(relaxed.output).toContain('#164')
+      expect(relaxed.output).toContain('not enforced without --enforce-completeness')
+      expect(relaxed.output).toContain('missing a top-level `budgets:` stub')
 
       const enforced = await runGuard(root, [...scaffoldArgs, '--enforce-completeness'])
       expect(enforced.code).toBe(1)

--- a/scripts/validate-config-samples.mjs
+++ b/scripts/validate-config-samples.mjs
@@ -12,11 +12,12 @@
  * candidate document, so a silently-dropped section can never pass.
  *
  * Enforced at merge: fence validation (check 1), shipped-config validation
- * (check 2), the examples/basic README mirror rule, and extraction hygiene.
- * Implemented but flag-gated until their fixes land: canonical section order
- * (check 3, --enforce-order, activates with #163) and root-key completeness
- * of the init scaffold + configuration.md (check 4, --enforce-completeness,
- * activates with #164). Both report loudly while unenforced.
+ * (check 2), the examples/basic README mirror rule, extraction hygiene, and
+ * root-key completeness of the init scaffold + configuration.md (check 4,
+ * --enforce-completeness, passed by both package.json entry points).
+ * Implemented but flag-gated until its fix lands: canonical section order
+ * (check 3, --enforce-order, activates with #163). It reports loudly while
+ * unenforced.
  *
  * Usage: node scripts/validate-config-samples.mjs
  *   [--repo-root <dir>] [--cli <path>] [--scaffold-file <path>]
@@ -853,7 +854,7 @@ async function main() {
     if (completenessViolations.length > 0) {
       const header = opts.enforceCompleteness
         ? 'root-key completeness violations (enforced):'
-        : 'NOT YET ENFORCED (activates with #164) — root-key completeness violations:'
+        : 'root-key completeness violations (not enforced without --enforce-completeness):'
       console.log(header)
       for (const violation of completenessViolations) console.log(`  ${violation}`)
       console.log('')


### PR DESCRIPTION
## Summary

Named budgets shipped in v0.10.0 as the headline feature but were absent from the config samples that teach configuration: the `helio init` scaffold and the quickstart configs in both READMEs. This PR adds the same compact budgets block to all three surfaces in canonical position, commented in the scaffold and live in the READMEs. The block keeps two contributors drawing down one pot, which is what separates budgets from a per-rule `spend_limit`.

The scaffold also gains a commented `environment: production` stub, so every top-level section now appears in canonical order. With both stubs in place, this PR activates the config-sample guard's check 4: `--enforce-completeness` is now passed by both `docs:check:ci` and `docs:check:samples`, making root-key completeness of the scaffold and `docs/configuration.md` a hard CI gate. The guard's header comment, its relaxed-run report label, and the CONTRIBUTING bullet are updated to match, and the getting-started section-order note no longer reads as an exact match of the scaffold.

Also fixes the scaffold comment that claimed hot-reload rotates `dashboard.api_secret`. The field is startup-bound, so rotation means editing the file and restarting the proxy.

Closes #164
Closes #179

## Verification (local build of this branch)

Scaffold round-trip, then uncommenting only the budgets stub:

```
$ helio init -o scaffold.yaml
Created scaffold.yaml
$ helio validate -c scaffold.yaml
Config is valid: scaffold.yaml (0 policy rules, 0 budgets)
$ helio validate -c scaffold.yaml   # after stripping the stub's comment prefixes
Config is valid: scaffold.yaml (0 policy rules, 1 budget)
```

Guard with the flag armed (both README quickstart fences pass with their new budget counts, zero completeness violations):

```
Config samples: 78 checked, 77 passed, 0 failed, 1 skipped
```

Activation seen failing in a scratch build with the `# budgets:` line deleted from the template:

```
root-key completeness violations (enforced):
  init scaffold is missing a top-level `budgets:` stub

Config samples: 78 checked, 77 passed, 0 failed, 1 skipped; 1 enforced completeness violation
(exit 1)
```

The hot-reload rotation claim reproduced live before removing it. With the proxy running, `dashboard.api_secret` was changed in the file; the watcher fired and logged:

```
[helio] Budgets reloaded: 0 budgets
[helio] Policy reloaded: 0 rules (default: allow)
[helio] Restart required: non-reloadable fields changed (dashboard). The running process still uses startup values for these fields.
```

After that "rotation", the old secret still authenticated the sideband (HTTP 200) and the new one was rejected (HTTP 401), until restart.

## Tests

Two new tests in `cli.test.ts`, written test-first: the scaffold carries all 10 top-level sections in canonical order with both new stubs at column 0, and uncommenting only the budgets stub yields a config validating with one budget (the capture is pinned to end at the block's last line so it can never silently swallow the next stub). The guard self-test pins were updated for the new relaxed-run label.

Full gate: 2100 proxy tests (including the 28 guard self-tests) + 344 dashboard + 47 python; lint, format, typecheck, docs-drift, and the armed guard all green.
