### PR TITLE
fix(config): align schema field order and shipped examples with the canonical order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,12 +173,12 @@ has never been executed, assume it is broken.
   is not Helio config YAML (say, a docker-compose file), put
   `<!-- helio-config-guard: skip -->` on the line above it. Never use the marker
   to silence a failing Helio sample; fix the sample instead.
-- Root-key completeness of the `helio init` scaffold and `docs/configuration.md`
-  (`--enforce-completeness`) is enforced: every top-level section must appear
-  (the scaffold may satisfy it with a commented stub; `docs/configuration.md`
-  needs the key live in a fence). One further check is implemented but not yet
-  enforced: canonical section order (`--enforce-order`, arms with #163). It
-  reports loudly in the meantime.
+- Canonical section order (`--enforce-order`) and root-key completeness of the
+  `helio init` scaffold and `docs/configuration.md` (`--enforce-completeness`)
+  are both enforced. Every sample's top-level keys must follow the order in
+  `docs/configuration.md`, and every top-level section must appear in the
+  scaffold and the reference (the scaffold may satisfy completeness with a
+  commented stub; `docs/configuration.md` needs the key live in a fence).
 
 ### Performance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,6 +274,8 @@ Budget spend **persists across restarts**: every charge is written to a ledger i
 
 Configuration for human-in-the-loop approval workflows. See [Approval Workflows](./approvals.md) for full documentation.
 
+In the canonical section order, `approval` follows `policies` and `budgets` because it is not a third gate: it is the shared channel and timeout configuration that policy rules (`require_approval`) and budget break-glass approvals both delegate to when they need a human. A strict lifecycle reading could argue for `approval` between `policies` and `budgets`, since on the MCP door a rule's approval resolves before the budget gate runs. That reading is rejected: the top-level `approval:` block is shared configuration, not the gate itself, and ordering the config around one door's implementation detail would separate the two enforcement layers a reader most needs to compare.
+
 | Field                | Type     | Required | Default | Description                                    |
 | -------------------- | -------- | -------- | ------- | ---------------------------------------------- |
 | `timeout`            | duration | No       | `300s`  | Maximum time to wait for an approval decision. |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -113,16 +113,6 @@ listen:
 Where the Helio proxy listens. Point your MCP client here instead of directly at the upstream server.
 
 ```yaml
-dashboard:
-  enabled: true
-  port: 3100
-  # Local demo mode: allow unauthenticated dashboard access on loopback only.
-  allow_open_mode: true
-```
-
-The web dashboard for real-time visibility. Served on a separate port. This example intentionally uses local open mode (`allow_open_mode: true`) so `pnpm start` works without secret setup; keep this loopback-only.
-
-```yaml
 policies:
   default: allow
   flag_destructive: log
@@ -168,6 +158,16 @@ audit:
 ```
 
 Every tool call is recorded to a local SQLite database. `include_responses: true` captures the full upstream response (set to `false` for privacy-sensitive deployments). Records older than 90 days are automatically cleaned up.
+
+```yaml
+dashboard:
+  enabled: true
+  port: 3100
+  # Local demo mode: allow unauthenticated dashboard access on loopback only.
+  allow_open_mode: true
+```
+
+The web dashboard for real-time visibility. Served on a separate port. This example intentionally uses local open mode (`allow_open_mode: true`) so `pnpm start` works without secret setup; keep this loopback-only.
 
 ## Next Steps
 

--- a/examples/basic/helio.yaml
+++ b/examples/basic/helio.yaml
@@ -13,12 +13,6 @@ listen:
   port: 3000
   host: '127.0.0.1'
 
-dashboard:
-  enabled: true
-  port: 3100
-  # Local demo mode: allow unauthenticated dashboard access on loopback only.
-  allow_open_mode: true
-
 policies:
   default: allow
   flag_destructive: log
@@ -49,3 +43,9 @@ audit:
   path: ./helio-audit.db
   retention: 90d
   include_responses: true
+
+dashboard:
+  enabled: true
+  port: 3100
+  # Local demo mode: allow unauthenticated dashboard access on loopback only.
+  allow_open_mode: true

--- a/examples/slack-approvals/helio.yaml
+++ b/examples/slack-approvals/helio.yaml
@@ -14,17 +14,6 @@ listen:
   port: 3000
   host: '127.0.0.1'
 
-dashboard:
-  enabled: true
-  port: 3100
-  # Required whenever any rule uses `require_approval`. Generate a fresh
-  # secret with `openssl rand -hex 32` and put it in `.env` as
-  # HELIO_DASHBOARD_SECRET (see `.env.example`). The proxy refuses to
-  # start while this resolves to an empty string, so a forgotten or
-  # blank value can never be mistaken for a working install. Rotate by
-  # generating a new value and restarting the proxy.
-  api_secret: '${HELIO_DASHBOARD_SECRET}'
-
 policies:
   default: allow
   rules:
@@ -70,3 +59,14 @@ audit:
   path: ./helio-audit.db
   retention: 90d
   include_responses: true
+
+dashboard:
+  enabled: true
+  port: 3100
+  # Required whenever any rule uses `require_approval`. Generate a fresh
+  # secret with `openssl rand -hex 32` and put it in `.env` as
+  # HELIO_DASHBOARD_SECRET (see `.env.example`). The proxy refuses to
+  # start while this resolves to an empty string, so a forgotten or
+  # blank value can never be mistaken for a working install. Rotate by
+  # generating a new value and restarting the proxy.
+  api_secret: '${HELIO_DASHBOARD_SECRET}'

--- a/examples/spend-limits/helio.yaml
+++ b/examples/spend-limits/helio.yaml
@@ -13,12 +13,6 @@ listen:
   port: 3000
   host: '127.0.0.1'
 
-dashboard:
-  enabled: true
-  port: 3100
-  # Local demo mode: allow unauthenticated dashboard access on loopback only.
-  allow_open_mode: true
-
 policies:
   default: allow
   rules:
@@ -80,3 +74,9 @@ audit:
   path: ./helio-audit.db
   retention: 90d
   include_responses: true
+
+dashboard:
+  enabled: true
+  port: 3100
+  # Local demo mode: allow unauthenticated dashboard access on loopback only.
+  allow_open_mode: true

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "format:check": "prettier --check .",
     "secrets:scan": "bash ./scripts/secret-scan-ci.sh",
     "secrets:scan:staged": "bash ./scripts/secret-scan-staged.sh",
-    "docs:check:ci": "bash ./scripts/check-docs-drift-ci.sh && node ./scripts/validate-config-samples.mjs --enforce-completeness",
-    "docs:check:samples": "node ./scripts/validate-config-samples.mjs --enforce-completeness",
+    "docs:check:ci": "bash ./scripts/check-docs-drift-ci.sh && node ./scripts/validate-config-samples.mjs --enforce-order --enforce-completeness",
+    "docs:check:samples": "node ./scripts/validate-config-samples.mjs --enforce-order --enforce-completeness",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/proxy/src/config-samples-guard.test.ts
+++ b/packages/proxy/src/config-samples-guard.test.ts
@@ -256,8 +256,8 @@ describe('config-samples guard', () => {
 
       const relaxed = await runGuard(root)
       expect(relaxed.code).toBe(0)
-      expect(relaxed.output).toContain('NOT YET ENFORCED')
-      expect(relaxed.output).toContain('#163')
+      expect(relaxed.output).toContain('not enforced without --enforce-order')
+      expect(relaxed.output).toContain('top-level keys not in canonical order')
 
       const enforced = await runGuard(root, ['--enforce-order'])
       expect(enforced.code).toBe(1)

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -154,6 +154,44 @@ describe('helioConfigSchema', () => {
   })
 
   // -------------------------------------------------------------------------
+  // Canonical key order
+  // -------------------------------------------------------------------------
+
+  describe('canonical key order', () => {
+    it('emits top-level keys in the canonical section order', () => {
+      // Input keys are deliberately reversed: the assertion holds only while
+      // zod emits output in shape-declaration order, so both a re-misplaced
+      // shape field and a zod that starts preserving input order fail loudly.
+      const result = helioConfigSchema.safeParse({
+        sdk: {},
+        dashboard: { enabled: false },
+        audit: {},
+        approval: {},
+        budgets: [],
+        policies: {},
+        environment: 'production',
+        listen: {},
+        upstream: { url: 'http://localhost:8080' },
+        version: '1',
+      })
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(Object.keys(result.data)).toEqual([
+        'version',
+        'upstream',
+        'listen',
+        'environment',
+        'policies',
+        'budgets',
+        'approval',
+        'audit',
+        'dashboard',
+        'sdk',
+      ])
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // Version
   // -------------------------------------------------------------------------
 

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -463,7 +463,6 @@ const helioConfigBaseSchema = z
     version: z.literal('1'),
     upstream: upstreamSchema,
     listen: listenSchema.prefault({}),
-    dashboard: dashboardSchema.prefault({}),
     environment: z.string().optional(),
     policies: policiesSchema.prefault({}),
     // Budgets sit beside policies deliberately: they are the second half of the
@@ -471,6 +470,9 @@ const helioConfigBaseSchema = z
     budgets: z.array(budgetSchema).default([]),
     approval: approvalSchema.prefault({}),
     audit: auditSchema.prefault({}),
+    // Dashboard follows audit deliberately: an operator surface, not part of
+    // the request path (canonical section order, #89/#163).
+    dashboard: dashboardSchema.prefault({}),
     sdk: sdkSchema.prefault({}),
   })
   .strict()

--- a/scripts/validate-config-samples.mjs
+++ b/scripts/validate-config-samples.mjs
@@ -12,12 +12,10 @@
  * candidate document, so a silently-dropped section can never pass.
  *
  * Enforced at merge: fence validation (check 1), shipped-config validation
- * (check 2), the examples/basic README mirror rule, extraction hygiene, and
- * root-key completeness of the init scaffold + configuration.md (check 4,
- * --enforce-completeness, passed by both package.json entry points).
- * Implemented but flag-gated until its fix lands: canonical section order
- * (check 3, --enforce-order, activates with #163). It reports loudly while
- * unenforced.
+ * (check 2), canonical section order (check 3, --enforce-order), root-key
+ * completeness of the init scaffold + configuration.md (check 4,
+ * --enforce-completeness), the examples/basic README mirror rule, and
+ * extraction hygiene. Both package.json entry points pass both flags.
  *
  * Usage: node scripts/validate-config-samples.mjs
  *   [--repo-root <dir>] [--cli <path>] [--scaffold-file <path>]
@@ -846,7 +844,7 @@ async function main() {
     if (orderViolations.length > 0) {
       const header = opts.enforceOrder
         ? 'canonical-order violations (enforced):'
-        : 'NOT YET ENFORCED (activates with #163) — canonical-order violations:'
+        : 'canonical-order violations (not enforced without --enforce-order):'
       console.log(header)
       for (const violation of orderViolations) console.log(`  ${violation}`)
       console.log('')


### PR DESCRIPTION
Closes #163

Aligns the last two stale surfaces with the canonical section order (version, upstream, listen, environment, policies, budgets, approval, audit, dashboard, sdk) and arms the config-sample guard's final check. With this merge, all four guard checks enforce: fence validation, shipped-config validation, canonical order, and root-key completeness.

## Changes

- `helioConfigBaseSchema` moves `dashboard` from 4th to 9th, between `audit` and `sdk`. A new shape test pins the emitted key order; its input keys are fully reversed, so it fails loudly for a re-misplaced field and cannot pass vacuously if zod ever starts preserving input order.
- `examples/basic`, `examples/slack-approvals`, and `examples/spend-limits` move their `dashboard:` block after `audit:` (pure move, comments intact). All three revalidate through the built CLI with unchanged rule and budget counts.
- The basic README's walkthrough moves its dashboard fence and prose after the audit section, keeping every fence a contiguous verbatim substring of the reordered file (the guard's mirror rule passes).
- `--enforce-order` is added to both `docs:check:ci` and `docs:check:samples`. Activation was watched failing: a scratch edit moving `dashboard:` back up produced `1 enforced order violation` and exit 1.
- The guard header, relaxed-run label, self-test pins, and the CONTRIBUTING bullet stop describing order as pending; the completeness asymmetry note is kept.
- `docs/configuration.md` gains the ratified approval-placement rationale, naming and rejecting the strict-lifecycle reading so the ordering is not relitigated.

AGENTS.md is listed in the issue body but was already canonical on main; it is untouched.

## Verification

- TDD: the shape test watched RED against the old shape (dashboard emitted 4th), GREEN after the move, and re-proved RED against a scratch stale shape after the reversed-input hardening.
- Guard armed and clean: 78 checked, 77 passed, 0 failed, 1 skipped, zero order or completeness violations.
- Full gate: 2101 proxy, 344 dashboard, and 47 python tests, plus format, lint, typecheck, and the docs-drift script, all green.
- External diff review: two low-severity findings; the test-hardening one is fixed here, the guard's scaffold-order blind spot is filed as #185 (the scaffold order stays pinned by cli.test.ts meanwhile).
