### PR TITLE
build(deps): patch js-yaml, axios, and brace-expansion high advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ Maintainer notes:
   `/evaluate` keep `matched_rule_index`, approval tickets keep `rule_index`,
   neither ever carried the alias.
 
+### Security
+
+- **js-yaml `4.1.1` → `4.3.0`** (GHSA-52cp-r559-cp3m — YAML merge-key chains
+  can force quadratic CPU consumption). js-yaml parses `helio.yaml`, which is
+  operator-authored, so there is no remote input path; the parser of a
+  governance proxy is upgraded regardless. The patch ships on the maintained
+  v4 line, so no API changes.
+- **axios `1.17.0` → `1.18.1`** (GHSA-gcfj-64vw-6mp9 — the Node HTTP adapter
+  can use an inherited proxy after interceptor config cloning), transitive
+  under `@slack/web-api` (Slack approvals); the workspace override pinning
+  axios moved to the patched version.
+- **brace-expansion `1.1.13`/`5.0.5` → `1.1.16`/`5.0.7`**
+  (GHSA-3jxr-9vmj-r5cp — exponential-time expansion DoS), dev/build-tooling
+  transitives; the workspace overrides now map the advisories' full
+  vulnerable ranges to the patched versions.
+
 ## [0.10.0] - 2026-07-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "9.39.4",
     "eslint-plugin-react-hooks": "7.0.1",
     "husky": "9.1.7",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.3.0",
     "prettier": "3.8.1",
     "typescript": "5.9.3",
     "typescript-eslint": "8.57.1"

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -62,7 +62,7 @@
     "chokidar": "5.0.0",
     "commander": "14.0.3",
     "hono": "4.12.26",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.3.0",
     "picomatch": "4.0.4",
     "safe-regex2": "5.0.0",
     "zod": "4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ settings:
 
 overrides:
   path-to-regexp: 8.4.2
-  axios: 1.17.0
+  axios: 1.18.1
   fast-uri: 3.1.2
   follow-redirects: 1.16.0
-  brace-expansion@1.1.12: 1.1.13
-  brace-expansion@5.0.4: 5.0.5
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
   postcss@8.5.8: 8.5.10
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'
 
@@ -31,8 +31,8 @@ importers:
         specifier: 9.1.7
         version: 9.1.7
       js-yaml:
-        specifier: 4.1.1
-        version: 4.1.1
+        specifier: 4.3.0
+        version: 4.3.0
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -113,8 +113,8 @@ importers:
         specifier: 4.12.26
         version: 4.12.26
       js-yaml:
-        specifier: 4.1.1
-        version: 4.1.1
+        specifier: 4.3.0
+        version: 4.3.0
       picomatch:
         specifier: 4.0.4
         version: 4.0.4
@@ -1214,8 +1214,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.17.0:
-    resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1249,11 +1249,11 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -1874,8 +1874,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@29.0.1:
@@ -3132,7 +3132,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3306,7 +3306,7 @@ snapshots:
       '@slack/types': 2.20.1
       '@types/node': 25.5.0
       '@types/retry': 0.12.0
-      axios: 1.17.0
+      axios: 1.18.1
       eventemitter3: 5.0.4
       form-data: 4.0.6
       is-electron: 2.2.2
@@ -3692,7 +3692,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.17.0:
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
@@ -3743,12 +3743,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4375,7 +4375,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4525,11 +4525,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,11 +3,11 @@ packages:
 
 overrides:
   path-to-regexp: 8.4.2
-  axios: 1.17.0
+  axios: 1.18.1
   fast-uri: 3.1.2
   follow-redirects: 1.16.0
-  brace-expansion@1.1.12: 1.1.13
-  brace-expansion@5.0.4: 5.0.5
+  'brace-expansion@<1.1.16': 1.1.16
+  'brace-expansion@>=3.0.0 <5.0.7': 5.0.7
   postcss@8.5.8: 8.5.10
   'form-data@>=4.0.0 <4.0.6': '>=4.0.6'
 


### PR DESCRIPTION
## Summary

Upgrades the four dependencies flagged high by the scheduled full-tree audit:

- `js-yaml` 4.1.1 → 4.3.0 (GHSA-52cp-r559-cp3m, quadratic CPU via YAML merge-key chains) — exact pin bumped in the root and proxy manifests. `helio.yaml` is operator-authored so there is no remote input path, but the proxy's own config parser gets patched regardless. The fix ships on the maintained v4 line; no API change.
- `axios` 1.17.0 → 1.18.1 (GHSA-gcfj-64vw-6mp9, Node adapter can use an inherited proxy after interceptor config cloning) — transitive under `@slack/web-api`. The existing unconditional workspace override had come to pin the vulnerable version; it now pins the patched one.
- `brace-expansion` 1.1.13/5.0.5 → 1.1.16/5.0.7 (GHSA-3jxr-9vmj-r5cp, exponential-time expansion DoS) — dev/build-tooling transitives; the two overrides are widened to cover the advisories' full vulnerable ranges.

Changelog Security entries added under Unreleased.

## Supply-chain vetting

Per the dependency posture in CONTRIBUTING, each version was vetted before install:

- Publish dates predate the advisories (published 2026-07-20) by 13 to 37 days — coordinated-disclosure fixes, not advisory-chasing publishes.
- Maintainer continuity on all three packages; no new publishers.
- No consumer-executed install hooks anywhere (`prepare` scripts do not run for registry installs, and `allowBuilds` is untouched).
- Both axios releases carry npm provenance attestations.
- js-yaml and brace-expansion publish no provenance, so their tarball diffs were read in full: the substantive changes are the documented fixes (brace-expansion 1.1.16 even ships an advisory writeup), plus benign publish noise (an accidentally shipped re-export shim in js-yaml, leaked test artifacts in brace-expansion). No network, exec, eval, or encoded payloads added.

The open Dependabot group PRs (#178, #142) also clear these advisories but via major jumps (js-yaml 5, `@slack/web-api` 8, eslint 10) that deserve their own deliberate upgrade pass; they stay open.

## Verification

- `pnpm audit --audit-level=high` exits 0. The only remaining high is the documented dev-only ignore; the total advisory count dropped from 22 to 7.
- The lockfile diff was verified to move exactly the four packages, nothing else.
- Full gate green: format, lint, typecheck, 2101 proxy + 344 dashboard + 47 python tests, docs drift check, and the config-samples guard (78 checked, 77 passed, 0 failed, 1 skipped).

Closes #188
