### PR TITLE
build(deps): patch fast-uri and postcss high advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,12 @@ settings:
 overrides:
   path-to-regexp: 8.4.2
   axios: 1.18.1
-  fast-uri: 3.1.2
+  fast-uri: 3.1.4
   follow-redirects: 1.16.0
   brace-expansion@<1.1.16: 1.1.16
   brace-expansion@>=3.0.0 <5.0.7: 5.0.7
-  postcss@8.5.8: 8.5.10
-  form-data@>=4.0.0 <4.0.6: '>=4.0.6'
+  postcss: 8.5.12
+  form-data@>=4.0.0 <4.0.6: 4.0.6
 
 importers:
 
@@ -142,7 +142,7 @@ importers:
         version: 4.0.2
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -1644,8 +1644,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2198,7 +2198,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: 8.5.10
+      postcss: 8.5.12
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -2211,8 +2211,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -2563,7 +2563,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: 8.5.10
+      postcss: 8.5.12
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -3668,7 +3668,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4179,7 +4179,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -4643,15 +4643,15 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.10
+      postcss: 8.5.12
       tsx: 4.21.0
 
-  postcss@8.5.10:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5028,7 +5028,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -5039,7 +5039,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -5048,7 +5048,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.10
+      postcss: 8.5.12
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -5138,7 +5138,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.12
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,15 +1,19 @@
 packages:
   - 'packages/*'
 
+# Transitive security pins, exact per the version-pinning policy in
+# DEPENDENCIES.md. A pinned version can itself age into a later advisory, so
+# every entry has to move when the audit gate names it (axios in #188,
+# fast-uri and postcss in #194).
 overrides:
   path-to-regexp: 8.4.2
   axios: 1.18.1
-  fast-uri: 3.1.2
+  fast-uri: 3.1.4 # GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx
   follow-redirects: 1.16.0
   'brace-expansion@<1.1.16': 1.1.16
   'brace-expansion@>=3.0.0 <5.0.7': 5.0.7
-  postcss@8.5.8: 8.5.10
-  'form-data@>=4.0.0 <4.0.6': '>=4.0.6'
+  postcss: 8.5.12 # GHSA-6g55-p6wh-862q
+  'form-data@>=4.0.0 <4.0.6': 4.0.6
 
 # pnpm 11 reads settings from this file only; the package.json "pnpm" field
 # is ignored. The GHSAs below are triaged and tracked (esbuild/vite: #64).


### PR DESCRIPTION
## Description

The daily full-tree audit and every push to `main` are failing on three high advisories in the standing tree. `main` is currently red for this reason, and `release.yml` runs the same gate, so it also blocks cutting v0.11.0.

- `fast-uri` [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) (host confusion via failed IDN canonicalization) and [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) (host confusion via a literal backslash authority delimiter), reachable through `@modelcontextprotocol/sdk` → `ajv`.
- `postcss` [GHSA-6g55-p6wh-862q](https://github.com/advisories/GHSA-6g55-p6wh-862q) (arbitrary file read via an attacker-controlled `sourceMappingURL` in a CSS comment), reachable through the `vite` / `tsup` / `vitest` build toolchain.

Both were held below their fixes by this repo's own overrides, which is the same shape as the axios problem in #188: a pinned version can age into a later advisory, and until the pin moves, the tree cannot leave the vulnerable range. `fast-uri` was pinned to `3.1.2` while `ajv` asks for `^3.0.1`, a range that reaches the patched line unaided; the `postcss@8.5.8: 8.5.10` entry rewrote one old request to a version that has since become vulnerable itself. Both now name their patched versions. The `form-data` entry additionally resolved through a range target (`'>=4.0.6'`), the one override that could drift on a lockfile refresh, so it gains an exact target while keeping its advisory-scoped selector.

Exact pinning is unchanged as the policy (`DEPENDENCIES.md`, `AGENTS.md`). Converting these entries to ranged selectors would defuse the recurrence structurally, but that is a change to a documented convention and is deliberately not made here.

Closes #194

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI / build / tooling

## Packages Affected

- [x] Root config / monorepo tooling

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

No tests are added: this changes resolved dependency versions only, and the existing suites plus the audit gate are the verification.

## How to Test

1. `pnpm install --frozen-lockfile && pnpm audit --audit-level=high` — exits 0. Before this change it exits 1 with `4 high`; after, the only remaining high is the pre-triaged ignored GHSA tracked in #64.
2. Confirm the lockfile moved nothing unintended: `git diff main -- pnpm-lock.yaml` touches `fast-uri` 3.1.2 → 3.1.4 and `postcss` 8.5.10 → 8.5.12, plus the peer re-keying that follows postcss through `tsup` and `postcss-load-config`. `form-data` stays at 4.0.6.
3. postcss sits in the dashboard build toolchain, so the build is the real risk surface: `pnpm build` then `pnpm test` (proxy 2141, dashboard 344, python-sdk 47).
4. Full gate: `pnpm lint && pnpm format:check && pnpm -r typecheck && pnpm build && pnpm test && pnpm docs:check:samples`.

## Additional Context

Both versions were vetted read-only before anything was installed, per the dependency posture in CONTRIBUTING:

| Check | `fast-uri@3.1.4` | `postcss@8.5.12` |
| --- | --- | --- |
| Fix vs advisory dates | published 2026-07-19, advisories 2026-07-21 (coordinated) | published 2026-04-26, advisory 2026-07-23 |
| Maintainer continuity | jsumners, delvedor, matteo.collina, eomm (unchanged) | ai / Andrey Sitnik (unchanged) |
| Install hooks | none | none |
| Provenance attestation | none | none |
| Tarball diff | read in full | read in full, added lines pattern-scanned |

With no attestation on either package, both diffs were read rather than trusted. `fast-uri` adds an authority-prefix regex that rejects a literal backslash, swaps `URL.domainToASCII` for `new URL('http://' + host).hostname`, and adds tests for both; the only other change is the version field. `postcss` scopes `loadFile` so a path taken from an untrusted `sourceMappingURL` is ignored unless it ends in `.map`, and JSON-parses the result before use. A pattern scan of every added line outside sourcemaps (network, exec, eval, base64, env) returned nothing in either package. Neither pulls a new dependency.

`fast-uri` 4.x exists but `ajv` asks for `^3.0.1`, so 3.1.4 is the minimal in-range upgrade that clears both advisories.

Follow-up worth deciding separately: whether these overrides should become ranged selectors with exact targets (`'fast-uri@<3.1.4': 3.1.4`), which keeps installed versions exact while preventing a pin from holding the tree below a future fix. That is the third recurrence of this shape (#188, and both packages here), so the recurrence is structural rather than accidental.
