### PR TITLE
build(deps): patch the react-router high advisory

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "react-router": "7.16.0",
+    "react-router": "7.18.0",
     "recharts": "3.8.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
       react-router:
-        specifier: 7.16.0
-        version: 7.16.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 7.18.0
+        version: 7.18.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       recharts:
         specifier: 3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1)
@@ -2292,8 +2292,8 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react-router@7.16.0:
-    resolution: {integrity: sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==}
+  react-router@7.18.0:
+    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -4736,7 +4736,7 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
-  react-router@7.16.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.18.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       cookie: 1.1.1
       react: 19.2.4


### PR DESCRIPTION
Every push to `main` fails the dependency audit on GHSA-chx6-hx7r-mcp5, an unauthenticated denial of service via inefficient route matching in react-router, published 2026-07-24 against all of 7.x below 7.18.0. The dashboard pins 7.16.0 directly.

This bumps the pin to 7.18.0, the advisory's first patched version, vetted before installing per the supply-chain SOP: the fix predates the advisory by five weeks (published 2026-06-16, coordinated disclosure), both maintainers are unchanged, every version in the range carries a SLSA v1 provenance attestation, the package runs no install hooks, and its runtime dependencies are unchanged (`cookie`, `set-cookie-parser`). The CSRF-check change in 7.18.0 applies only to framework-mode server adapters; the dashboard uses library-mode SPA routing (`BrowserRouter`/`Routes`/`NavLink`), which is unaffected. 7.18.1's only change fixes `react-router-dom`'s CommonJS entry, a package not in this tree, so the pin stays at the vetted 7.18.0.

Post-bump: `pnpm audit --audit-level=high` passes (the one remaining high is the documented ignore) and three moderate findings clear from the same report. Full gate green: lint, format, typecheck, build, proxy 2169 / dashboard 344 / python-sdk 47. Because this PR touches the manifest, the PR-level audit step runs here (no skip).

Closes #201
