### PR TITLE
build(deps): clear the three new high audit advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,18 @@ Maintainer notes:
   (GHSA-3jxr-9vmj-r5cp — exponential-time expansion DoS), dev/build-tooling
   transitives; the workspace overrides now map the advisories' full
   vulnerable ranges to the patched versions.
+- **postcss `8.5.12` → `8.5.18`** (GHSA-r28c-9q8g-f849 — path traversal in
+  previous-source-map auto-loading can disclose arbitrary `.map` files),
+  build-tooling transitive under vite; the workspace override pinning
+  postcss moved to the patched version.
+- **brace-expansion `5.0.7` → `5.0.8`** (GHSA-mh99-v99m-4gvg — memory
+  exhaustion via unbounded expansion length). The 1.x line under eslint's
+  `minimatch@3` has no patched release, only ever expands our own lint
+  globs, and cannot take the 5.x API; it is a tracked audit ignore (#205).
+- **react-router advisory GHSA-qwww-vcr4-c8h2 acknowledged** as unreachable:
+  the CSRF bypass lives in the unstable RSC code paths, and the dashboard
+  is a client-side SPA importing no `unstable_*`/RSC API. Tracked audit
+  ignore until the react-router 8 upgrade (#204).
 
 ## [0.10.0] - 2026-07-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,13 +229,15 @@ Our audit posture reflects that:
   ignored** via `auditConfig.ignoreGhsas` in `pnpm-workspace.yaml`, but **only** with a tracking issue to
   remove it. Prefer a real upgrade over an ignore.
 
-Current dev-only ignores (each tracked for removal):
+Current ignores (each with no exploit path in our usage, tracked for removal):
 
-| GHSA                  | Package (path)                      | Why ignored                                                                                                           | Tracking |
-| --------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------- |
-| `GHSA-gv7w-rqvm-qjhr` | esbuild (via vite, dashboard build) | dev-server request vuln; not in the shipped bundle                                                                    | #64      |
-| `GHSA-fx2h-pf6j-xcff` | vite (dashboard build)              | dev-server only; vite is not run in production                                                                        | #64      |
-| `GHSA-vmh5-mc38-953g` | undici (via `jsdom`, test env)      | SOCKS5 ProxyAgent TLS path, not exercised in tests; no patched undici is compatible with `jsdom@29`'s internal layout | #64      |
+| GHSA                  | Package (path)                                   | Why ignored                                                                                                                                                         | Tracking |
+| --------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `GHSA-gv7w-rqvm-qjhr` | esbuild (via vite, dashboard build)              | dev-server request vuln; not in the shipped bundle                                                                                                                  | #64      |
+| `GHSA-fx2h-pf6j-xcff` | vite (dashboard build)                           | dev-server only; vite is not run in production                                                                                                                      | #64      |
+| `GHSA-vmh5-mc38-953g` | undici (via `jsdom`, test env)                   | SOCKS5 ProxyAgent TLS path, not exercised in tests; no patched undici is compatible with `jsdom@29`'s internal layout                                               | #64      |
+| `GHSA-qwww-vcr4-c8h2` | react-router (dashboard)                         | unstable-RSC-only CSRF per upstream; the dashboard is a client-side SPA importing no `unstable_*`/RSC API, and the fix line (8.x) needs a React peer bump           | #204     |
+| `GHSA-mh99-v99m-4gvg` | brace-expansion 1.x (via eslint's `minimatch@3`) | OOM-DoS on expansion; lint globs are our own trusted config, no patched 1.x exists, and 5.0.8's named CJS export breaks `minimatch@3` (5.x paths upgraded for real) | #205     |
 
 ## Issue Labels
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -77,6 +77,6 @@ Action versions are pinned to major version tags (e.g., `@v4`). Dependabot propo
 
 The `pnpm-workspace.yaml` file includes overrides to patch known vulnerabilities in transitive dependencies when upstream packages haven't released fixes yet.
 
-Current security-patch overrides include `axios` pinned at `1.17.0` to address NO_PROXY bypass and proxy gadget advisories inherited via `@slack/web-api`.
+Current security-patch overrides include `axios` pinned at `1.18.1` for its Node-adapter advisories inherited via `@slack/web-api`, `postcss` at `8.5.18` for `GHSA-6g55-p6wh-862q` / `GHSA-r28c-9q8g-f849`, and `brace-expansion >=3.0.0` lifted to `5.0.8` for `GHSA-mh99-v99m-4gvg` (the 1.x line has no patched release and is a tracked audit ignore, #205).
 
-Vitest is pinned at `4.1.8` across JS workspaces to stay above the `GHSA-5xrq-8626-4rwp` floor, and dashboard `react-router` is pinned at `7.16.0` to stay above current `GHSA-49rj-9fvp-4h2h` / `GHSA-8x6r-g9mw-2r78` fixes.
+Vitest is pinned at `4.1.8` across JS workspaces to stay above the `GHSA-5xrq-8626-4rwp` floor, and dashboard `react-router` is pinned at `7.18.0` to stay above the `GHSA-chx6-hx7r-mcp5` fix; its `GHSA-qwww-vcr4-c8h2` (unstable-RSC-only) advisory is a tracked audit ignore until the v8 upgrade (#204).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ overrides:
   fast-uri: 3.1.4
   follow-redirects: 1.16.0
   brace-expansion@<1.1.16: 1.1.16
-  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
-  postcss: 8.5.12
+  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
+  postcss: 8.5.18
   form-data@>=4.0.0 <4.0.6: 4.0.6
 
 importers:
@@ -142,7 +142,7 @@ importers:
         version: 4.0.2
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.18)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -1252,9 +1252,9 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -2082,8 +2082,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2198,7 +2198,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: 8.5.12
+      postcss: 8.5.18
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -2211,8 +2211,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -2563,7 +2563,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: 8.5.12
+      postcss: 8.5.18
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -3748,7 +3748,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4525,7 +4525,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -4550,7 +4550,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -4643,17 +4643,17 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.18)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.12
+      postcss: 8.5.18
       tsx: 4.21.0
 
-  postcss@8.5.12:
+  postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5028,7 +5028,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.18)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -5039,7 +5039,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.18)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -5048,7 +5048,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -5138,7 +5138,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.18
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,17 +11,20 @@ overrides:
   fast-uri: 3.1.4 # GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx
   follow-redirects: 1.16.0
   'brace-expansion@<1.1.16': 1.1.16
-  'brace-expansion@>=3.0.0 <5.0.7': 5.0.7
-  postcss: 8.5.12 # GHSA-6g55-p6wh-862q
+  'brace-expansion@>=3.0.0 <5.0.8': 5.0.8 # GHSA-mh99-v99m-4gvg; 1.x has no patch (#205)
+  postcss: 8.5.18 # GHSA-6g55-p6wh-862q, GHSA-r28c-9q8g-f849
   'form-data@>=4.0.0 <4.0.6': 4.0.6
 
 # pnpm 11 reads settings from this file only; the package.json "pnpm" field
-# is ignored. The GHSAs below are triaged and tracked (esbuild/vite: #64).
+# is ignored. The GHSAs below are triaged and tracked (esbuild/vite: #64,
+# react-router RSC: #204, brace-expansion 1.x: #205).
 auditConfig:
   ignoreGhsas:
     - GHSA-gv7w-rqvm-qjhr
     - GHSA-fx2h-pf6j-xcff
     - GHSA-vmh5-mc38-953g
+    - GHSA-qwww-vcr4-c8h2
+    - GHSA-mh99-v99m-4gvg
 
 # Native build scripts approved to run at install (pnpm 11 renamed
 # onlyBuiltDependencies to allowBuilds).


### PR DESCRIPTION
## Summary

The daily full-tree audit went red on 2026-07-25 and 2026-07-26 (#203) on three high advisories, all published 2026-07-24 within hours of that day's green dispatched run. Two get real upgrades, one is unreachable and gets a time-boxed ignore.

- **postcss `8.5.12` -> `8.5.18`** (GHSA-r28c-9q8g-f849, path traversal in previous-source-map auto-loading). Vetting: trusted-publisher attestations approved by the long-time author, published 12 days before the advisory. The workspace override pinning postcss moves to the patched version.
- **brace-expansion `5.0.7` -> `5.0.8`** (GHSA-mh99-v99m-4gvg, memory exhaustion via unbounded expansion length). Vetting: long-time maintainer, no install hooks, full tarball diff read; the change is the documented `EXPANSION_MAX_LENGTH` accumulator cap and nothing else. The override range widens to `>=3.0.0 <5.0.8` so the `minimatch@10` paths land on the patch. The 1.x remnant under eslint's `minimatch@3` has no patched release and cannot be lifted to 5.x, whose CommonJS build exposes a named `expand` while `minimatch@3` calls the required module directly; it only ever expands our own lint globs, so it is a time-boxed ignore tracked in #205.
- **react-router GHSA-qwww-vcr4-c8h2** (CSRF bypass in the unstable RSC code paths). Unreachable in our usage: the dashboard is a client-side Vite SPA and imports no `unstable_*` or RSC API (verified across `packages/dashboard/src`). There is no patched 7.x, and `8.3.0` raises the React peer floor to `19.2.7` while the dashboard is on `19.2.4`, so the real fix is the v8 upgrade tracked in #204. Time-boxed ignore until then.

Docs kept in sync: the CONTRIBUTING ignore table gains both rows (the heading no longer claims dev-only), DEPENDENCIES.md's pin notes are brought current (the axios and react-router sentences had fallen behind at `1.17.0`/`7.16.0`), and the changelog's Unreleased Security section records all three.

## Verification

- `pnpm audit --audit-level=high` exits 0; every remaining high is a tracked ignore.
- Lockfile diff contains only the two intended version moves.
- Full gate green: lint, format:check, typecheck, build, proxy tests 2169/2169, dashboard tests 344/344, config samples 79 checked / 78 passed / 1 skipped.

Closes #203
