### PR TITLE
fix(config): reject unknown keys in all nested config sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,25 @@ Maintainer notes:
   the budgets count alongside the policy rule count, and config failures on
   every CLI surface (start, validate, export, hot reload) name the offending
   paths on schema errors.
+- **Unknown keys inside `helio.yaml` sections are now hard errors
+  (#182).** #167 made the top level strict; the nine section schemas it
+  left lenient (`upstream`, `listen`, `dashboard`, the approval channel
+  entries, `approval`, `audit`, `sdk`) still dropped unknown keys
+  silently and applied defaults in their place: `upstream.request_timout`
+  silently kept the 30-second default, a typo'd `approval.channel:`
+  silently dropped every approval channel, a webhook channel with a
+  misspelled `secret:` silently shipped unsigned, and
+  `dashboard.api_secrett` with `allow_open_mode: true` silently ran the
+  dashboard open. Now every section rejects unknown keys with an error
+  naming the key and its path (`upstream: Unrecognized key: "request_timout"`)
+  on every CLI surface — validate, start, export, and
+  hot reload (which keeps the running configuration). If your config
+  refuses to load after upgrading, read the error and fix or delete the
+  named key. Keys beginning with `x-` remain available as YAML anchor
+  holders at the top level only; an `x-` key inside a section is now
+  rejected like any other unknown key (inside these nine sections it was
+  silently dropped before). The policies and budgets subtrees were
+  already strict and are unchanged.
 
 ### Removed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -473,11 +473,16 @@ Invalid config: Invalid configuration (1 error)
   upstream.url: Invalid input: expected string, received undefined
 ```
 
-The top level of the file is strict: an unknown or misplaced top-level key — a `rules:` block at the top level instead of nested under `policies:`, or a singular `policy:` or `budget:` typo — is a hard error naming the key, not a silently ignored no-op. `helio start` refuses to boot on such a config, and a hot reload that introduces one is rejected while the proxy keeps its current configuration (see [Hot Reload](#hot-reload)).
+The whole file is strict, at every level: an unknown or misplaced key — a `rules:` block at the top level instead of nested under `policies:`, a singular `policy:` or `budget:` typo, a misspelled field inside a section like `upstream.request_timout` or `dashboard.api_secrett`, or an unknown key inside an approval channel entry — is a hard error naming the key and its path, not a silently ignored no-op. `helio start` refuses to boot on such a config, and a hot reload that introduces one is rejected while the proxy keeps its current configuration (see [Hot Reload](#hot-reload)).
 
 ```
 Invalid config: Invalid configuration (1 error)
   (top level): Unrecognized key: "rules"
+```
+
+```
+Invalid config: Invalid configuration (1 error)
+  upstream: Unrecognized key: "request_timout"
 ```
 
 The one exception is top-level keys beginning with lowercase `x-`. They are reserved as extension keys — holders for reusable YAML anchors, in the docker-compose style — and are ignored by the schema:
@@ -498,7 +503,7 @@ policies:
         tool: 'drop_*'
 ```
 
-`${VAR}` references inside an `x-` block are interpolated like everywhere else, so the variables must be set even though the block itself is ignored.
+`${VAR}` references inside an `x-` block are interpolated like everywhere else, so the variables must be set even though the block itself is ignored. The escape hatch is root-only: an `x-` key inside a section (`approval.x-shared:`, say) is rejected like any other unknown key — park anchor holders at the top level.
 
 ## Hot Reload
 

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -522,6 +522,32 @@ rules:
       }
     })
 
+    it('rejects a config with an unknown key inside a section (issue #182)', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+      const configPath = join(dir, 'helio.yaml')
+
+      writeFileSync(
+        configPath,
+        `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+  request_timout: "5s"
+dashboard:
+  enabled: false
+`,
+      )
+
+      try {
+        const { code, stderr } = await runCli(['validate', '-c', configPath])
+        expect(code).toBe(1)
+        expect(stderr).toContain('Invalid config: Invalid configuration (1 error)')
+        expect(stderr).toContain('upstream: Unrecognized key: "request_timout"')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
     it('reports the budgets count alongside the policy rule count', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
       const configPath = join(dir, 'helio.yaml')
@@ -684,6 +710,22 @@ dashboard:
         writeFileSync(configPath, original + 'budget:\n  - name: openai-daily\n')
         await expect(startAndCaptureStderr(['-c', configPath])).rejects.toThrow(
           /Unrecognized key: "budget"/,
+        )
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    it('refuses to boot when a section carries an unknown key (issue #182)', async () => {
+      const { dir, configPath } = writeStartConfig()
+      try {
+        // The sideband-gate scenario: a typo'd sdk enable key. The proxy
+        // must exit before listening, not boot with the sideband silently
+        // disabled.
+        const original = readFileSync(configPath, 'utf-8')
+        writeFileSync(configPath, original + 'sdk:\n  enable: true\n')
+        await expect(startAndCaptureStderr(['-c', configPath])).rejects.toThrow(
+          /sdk: Unrecognized key: "enable"/,
         )
       } finally {
         rmSync(dir, { recursive: true, force: true })

--- a/packages/proxy/src/config-samples-guard.test.ts
+++ b/packages/proxy/src/config-samples-guard.test.ts
@@ -699,7 +699,7 @@ describe('config-samples guard', () => {
   )
 
   it(
-    'fails a rule-level approval: fragment instead of validating it as the root section',
+    'fails a rule-level approval: fragment via the strict root schema',
     { timeout: 60_000 },
     async () => {
       const root = makeTree({
@@ -709,7 +709,10 @@ describe('config-samples guard', () => {
       expect(code).toBe(1)
       expect(output).toContain('docs/test.md:3')
       expect(output).toContain('FAIL')
-      expect(output).toContain('policies.rules')
+      // Pre-#182 a classification-time workaround caught this shape
+      // (the lax approval schema would have false-PASSed it); the strict
+      // schema now rejects it by naming the unknown key.
+      expect(output).toContain('Unrecognized key: "channel"')
     },
   )
 

--- a/packages/proxy/src/config/loader.test.ts
+++ b/packages/proxy/src/config/loader.test.ts
@@ -175,6 +175,28 @@ budget:
     }
   })
 
+  it('rejects an unknown key inside a section with the section path in details', async () => {
+    const yaml = `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+  request_timout: "5s"
+dashboard:
+  enabled: false
+`
+    const filePath = await writeTempYaml('nested-typo.yaml', yaml)
+
+    try {
+      await loadConfig(filePath)
+      expect.fail('Should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError)
+      expect((err as ConfigError).details).toEqual([
+        { path: 'upstream', message: 'Unrecognized key: "request_timout"' },
+      ])
+    }
+  })
+
   it('loads a config that parks a YAML anchor in a top-level x- key', async () => {
     const yaml = `
 x-shared: &tool-glob "delete_*"
@@ -414,8 +436,12 @@ policies:
         expect.fail('Should have thrown')
       } catch (err) {
         expect(err).toBeInstanceOf(ConfigError)
-        const paths = ((err as ConfigError).details ?? []).map((d) => d.path)
-        expect(paths).toContain('dashboard.api_secret')
+        // Strict approval rejects the removed #144 alias by name (the
+        // pre-#182 shape surfaced the cross-validator's missing-secret
+        // detail instead).
+        expect((err as ConfigError).details).toEqual([
+          { path: 'approval', message: 'Unrecognized key: "api_secret"' },
+        ])
       }
     })
 

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -944,8 +944,13 @@ describe('helioConfigSchema', () => {
       )
       expect(result.success).toBe(false)
       if (result.success) return
-      const paths = result.error.issues.map((i) => i.path.join('.'))
-      expect(paths).toContain('dashboard.api_secret')
+      // Strict approval rejects the removed #144 alias BY NAME — a better
+      // error than the pre-#182 shape, where the lax schema dropped the
+      // alias and the cross-validator then demanded the dashboard secret.
+      expect(result.error.issues).toHaveLength(1)
+      expect(result.error.issues[0]?.code).toBe('unrecognized_keys')
+      expect(result.error.issues[0]?.path).toEqual(['approval'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "api_secret"')
     })
 
     it('rejects empty-string dashboard.api_secret when require_approval is used', () => {
@@ -1951,8 +1956,9 @@ describe('helioConfigSchema', () => {
 
     it('does not strip x- keys inside sections (root-only escape hatch)', () => {
       // policies is a strict subtree, so the un-stripped key is rejected
-      // there. Non-strict sections handle unknown keys their own way — the
-      // pin here is only that the strip never descends past the root.
+      // there. Every section is strict since #182, so an un-stripped x-
+      // key is always rejected — the pin here is that the strip never
+      // descends past the root.
       const result = helioConfigSchema.safeParse(minimalConfig({ policies: { 'x-shared': true } }))
       expect(result.success).toBe(false)
     })
@@ -1966,6 +1972,171 @@ describe('helioConfigSchema', () => {
       expect(result.error.issues[0]?.code).toBe('unrecognized_keys')
       expect(result.error.issues[0]?.path).toEqual(['policies'])
       expect(result.error.issues[0]?.message).toBe('Unrecognized key: "default_action"')
+    })
+  })
+
+  describe('unknown keys in nested sections (issue #182)', () => {
+    it('rejects an unknown key in upstream, naming it under the section path', () => {
+      // Repro r1: the typo'd timeout silently kept the 30s default. Also
+      // proves .strict() composes on the object stage of upstream's
+      // .refine().superRefine() chain.
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ upstream: { url: 'http://localhost:8080', request_timout: '5s' } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues).toHaveLength(1)
+      expect(result.error.issues[0]?.code).toBe('unrecognized_keys')
+      expect(result.error.issues[0]?.path).toEqual(['upstream'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "request_timout"')
+    })
+
+    it('rejects an unknown key in listen', () => {
+      const result = helioConfigSchema.safeParse(minimalConfig({ listen: { prt: 3000 } }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['listen'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "prt"')
+    })
+
+    it('rejects dashboard.api_secrett with allow_open_mode (the silent open-dashboard repro)', () => {
+      // Repro r4a: pre-#182 this VALIDATED and ran the dashboard open.
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          dashboard: { api_secrett: 'unit-test-secret', allow_open_mode: true },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues).toHaveLength(1)
+      expect(result.error.issues[0]?.path).toEqual(['dashboard'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "api_secrett"')
+    })
+
+    it('names dashboard.api_secrett instead of demanding the secret the operator believes is set', () => {
+      // Repro r4b: pre-#182 this failed, but with the MISLEADING
+      // cross-validator message ("dashboard.api_secret is required…").
+      // The nested strict failure suppresses the cross-validators, so the
+      // single issue names the actual typo.
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ dashboard: { api_secrett: 'unit-test-secret' } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues).toHaveLength(1)
+      expect(result.error.issues[0]?.path).toEqual(['dashboard'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "api_secrett"')
+    })
+
+    it('rejects approval.channel — the typo that silently dropped every channel', () => {
+      // Repro r2. No require_approval rules, so the #152 routing check
+      // could not have fired pre-#182 either; the config was "valid".
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          approval: {
+            channel: [{ type: 'slack', bot_token: 'xoxb-x', signing_secret: 's', channel: '#a' }],
+          },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['approval'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "channel"')
+    })
+
+    it('rejects an unknown key in a slack channel entry', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          approval: {
+            channels: [
+              {
+                type: 'slack',
+                bot_token: 'xoxb-x',
+                signing_secret: 's',
+                channel: '#a',
+                signing_secrt: 'oops',
+              },
+            ],
+          },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.code).toBe('unrecognized_keys')
+      expect(result.error.issues[0]?.path).toEqual(['approval', 'channels', 0])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "signing_secrt"')
+    })
+
+    it('rejects a webhook channel with a misspelled secret (the unsigned-webhook repro)', () => {
+      // Repro r3, in the coherent shape: dashboard enabled with a secret,
+      // so pre-#182 no cross-validator masked the typo and the config
+      // VALIDATED — shipping an unsigned webhook.
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          approval: {
+            channels: [
+              { type: 'webhook', name: 'hook', url: 'https://example.invalid/hook', secrt: 'h' },
+            ],
+          },
+          dashboard: { api_secret: 'unit-test-secret' },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['approval', 'channels', 0])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "secrt"')
+    })
+
+    it('rejects an unknown key in a dashboard channel entry', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ approval: { channels: [{ type: 'dashboard', channel: '#ops' }] } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['approval', 'channels', 0])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "channel"')
+    })
+
+    it('rejects an unknown key in audit', () => {
+      const result = helioConfigSchema.safeParse(minimalConfig({ audit: { retentoin: '90d' } }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['audit'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "retentoin"')
+    })
+
+    it('rejects an unknown key in sdk', () => {
+      const result = helioConfigSchema.safeParse(minimalConfig({ sdk: { enable: true } }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['sdk'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "enable"')
+    })
+
+    it('rejects an x- key inside a previously lax section', () => {
+      // Behavior change the CHANGELOG states: pre-#182 the nine lax
+      // sections silently DROPPED nested x- keys; the strict subtrees
+      // already rejected them. Now every section rejects them — the
+      // escape hatch is root-only, as documented.
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ audit: { 'x-defaults': { retention: '90d' } } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['audit'])
+      expect(result.error.issues[0]?.message).toBe('Unrecognized key: "x-defaults"')
+    })
+
+    it('reports one issue per section when several sections carry unknown keys', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ audit: { retentoin: '90d' }, sdk: { enable: true } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues).toHaveLength(2)
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('audit')
+      expect(paths).toContain('sdk')
     })
   })
 })

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -50,6 +50,7 @@ const upstreamSchema = z
     forward_headers: z.array(z.string().min(1)).default([]),
     headers: z.record(z.string(), z.string()).default({}),
   })
+  .strict()
   .refine((data) => data.transport !== 'stdio' || data.command !== undefined, {
     message: '"command" is required when transport is "stdio"',
     path: ['command'],
@@ -89,10 +90,12 @@ const upstreamSchema = z
 // Listen
 // ---------------------------------------------------------------------------
 
-const listenSchema = z.object({
-  port: z.number().int().min(1).max(65535).default(3000),
-  host: z.string().default('127.0.0.1'),
-})
+const listenSchema = z
+  .object({
+    port: z.number().int().min(1).max(65535).default(3000),
+    host: z.string().default('127.0.0.1'),
+  })
+  .strict()
 
 function isLoopbackHost(host: string): boolean {
   return host === '127.0.0.1' || host === 'localhost' || host === '::1'
@@ -106,14 +109,16 @@ function hasDashboardApiSecret(secret: string | undefined): boolean {
 // Dashboard
 // ---------------------------------------------------------------------------
 
-const dashboardSchema = z.object({
-  enabled: z.boolean().default(true),
-  port: z.number().int().min(1).max(65535).default(3100),
-  host: z.string().default('127.0.0.1'),
-  api_secret: z.string().optional(),
-  allow_open_mode: z.boolean().default(false),
-  sse_heartbeat_interval: durationSchema.default('30s'),
-})
+const dashboardSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    port: z.number().int().min(1).max(65535).default(3100),
+    host: z.string().default('127.0.0.1'),
+    api_secret: z.string().optional(),
+    allow_open_mode: z.boolean().default(false),
+    sse_heartbeat_interval: durationSchema.default('30s'),
+  })
+  .strict()
 
 // ---------------------------------------------------------------------------
 // Policy rule — match conditions
@@ -419,25 +424,31 @@ const budgetSchema = z
 // Approval channels (discriminated union)
 // ---------------------------------------------------------------------------
 
-const slackChannelSchema = z.object({
-  type: z.literal('slack'),
-  name: z.string().min(1).optional(),
-  bot_token: z.string(),
-  signing_secret: z.string(),
-  channel: z.string(),
-})
+const slackChannelSchema = z
+  .object({
+    type: z.literal('slack'),
+    name: z.string().min(1).optional(),
+    bot_token: z.string(),
+    signing_secret: z.string(),
+    channel: z.string(),
+  })
+  .strict()
 
-const webhookChannelSchema = z.object({
-  type: z.literal('webhook'),
-  name: z.string().min(1).optional(),
-  url: z.string(),
-  secret: z.string().optional(),
-})
+const webhookChannelSchema = z
+  .object({
+    type: z.literal('webhook'),
+    name: z.string().min(1).optional(),
+    url: z.string(),
+    secret: z.string().optional(),
+  })
+  .strict()
 
-const dashboardChannelSchema = z.object({
-  type: z.literal('dashboard'),
-  name: z.string().min(1).optional(),
-})
+const dashboardChannelSchema = z
+  .object({
+    type: z.literal('dashboard'),
+    name: z.string().min(1).optional(),
+  })
+  .strict()
 
 const approvalChannelSchema = z.discriminatedUnion('type', [
   slackChannelSchema,
@@ -449,39 +460,45 @@ const approvalChannelSchema = z.discriminatedUnion('type', [
 // Approval
 // ---------------------------------------------------------------------------
 
-const approvalSchema = z.object({
-  timeout: durationSchema.default('300s'),
-  default_on_timeout: z.enum(['deny', 'allow']).default('deny'),
-  channels: z.array(approvalChannelSchema).default([]),
-})
+const approvalSchema = z
+  .object({
+    timeout: durationSchema.default('300s'),
+    default_on_timeout: z.enum(['deny', 'allow']).default('deny'),
+    channels: z.array(approvalChannelSchema).default([]),
+  })
+  .strict()
 
 // ---------------------------------------------------------------------------
 // Audit
 // ---------------------------------------------------------------------------
 
-const auditSchema = z.object({
-  storage: z.enum(['sqlite']).default('sqlite'),
-  path: z.string().default('./helio-audit.db'),
-  retention: durationSchema.default('90d'),
-  include_responses: z.boolean().default(true),
-})
+const auditSchema = z
+  .object({
+    storage: z.enum(['sqlite']).default('sqlite'),
+    path: z.string().default('./helio-audit.db'),
+    retention: durationSchema.default('90d'),
+    include_responses: z.boolean().default(true),
+  })
+  .strict()
 
 // ---------------------------------------------------------------------------
 // SDK
 // ---------------------------------------------------------------------------
 
-const sdkSchema = z.object({
-  enabled: z.boolean().default(false),
-  port: z.number().int().min(1).max(65535).default(3200),
-  host: z.string().default('127.0.0.1'),
-  /**
-   * How long a sideband `/evaluate` decision waits for its `/audit` before the
-   * proxy finalizes it as `evaluation_expired` (issue #12, D4). Bounds the
-   * pending-evaluation registry; an adapter crash cannot silently drop a
-   * decided-allowed call from the trail.
-   */
-  evaluation_ttl: durationSchema.default('10m'),
-})
+const sdkSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    port: z.number().int().min(1).max(65535).default(3200),
+    host: z.string().default('127.0.0.1'),
+    /**
+     * How long a sideband `/evaluate` decision waits for its `/audit` before the
+     * proxy finalizes it as `evaluation_expired` (issue #12, D4). Bounds the
+     * pending-evaluation registry; an adapter crash cannot silently drop a
+     * decided-allowed call from the trail.
+     */
+    evaluation_ttl: durationSchema.default('10m'),
+  })
+  .strict()
 
 // ---------------------------------------------------------------------------
 // Root config

--- a/packages/proxy/src/config/watcher.test.ts
+++ b/packages/proxy/src/config/watcher.test.ts
@@ -499,6 +499,34 @@ budgets:
     ])
   })
 
+  it('calls onError and keeps old policy when a reload introduces an unknown key inside a section', async () => {
+    await writeFile(configPath, configWithDenyRule())
+
+    const reloads: CompiledPolicy[] = []
+    const errors: Error[] = []
+
+    watcher = new ConfigWatcher({
+      configPath,
+      onReload: (policy) => reloads.push(policy),
+      onError: (err) => errors.push(err),
+      debounceMs: 50,
+    })
+    watcher.start()
+    await wait(100)
+
+    // The reload is rejected as a whole: the typo'd retention key inside
+    // audit: must not be dropped while the rest of the file applies.
+    await writeFile(configPath, configWithDenyRule() + 'audit:\n  retentoin: "90d"\n')
+    await wait(500)
+
+    expect(reloads).toHaveLength(0)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBeInstanceOf(ConfigError)
+    expect((errors[0] as ConfigError).details).toEqual([
+      { path: 'audit', message: 'Unrecognized key: "retentoin"' },
+    ])
+  })
+
   it('calls onError when policy has invalid regex', async () => {
     await writeFile(configPath, validConfig())
 

--- a/scripts/validate-config-samples.mjs
+++ b/scripts/validate-config-samples.mjs
@@ -87,16 +87,6 @@ const BUDGET_KEYS = new Set([
 /** A budget-shaped item must carry at least one of these discriminators. */
 const BUDGET_MARKERS = ['limit', 'currency', 'contributors', 'window']
 
-/**
- * Keys of the ROOT approval section (approvalSchema). `approval` is also rule
- * vocabulary, and until #182 the root schema silently drops unknown keys — so
- * a rule-level approval excerpt shown as a top-level `approval:` block would
- * validate against the wrong schema and false-PASS. Any candidate whose root
- * `approval:` carries keys outside this set is rejected here instead.
- * Redundant (and removable) once #182 makes the nested schemas strict.
- */
-const ROOT_APPROVAL_KEYS = new Set(['timeout', 'default_on_timeout', 'channels'])
-
 const SKIP_MARKER = 'helio-config-guard: skip'
 const DUMMY_ENV_VALUE = 'docs-guard-dummy'
 const ENV_VAR_PATTERN = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g
@@ -478,14 +468,11 @@ function classifyFence(text) {
 
   if (isPlainObject(node)) {
     const keys = Object.keys(node)
-    const approvalViolation = rootApprovalViolation(node)
     if (keys.includes('version') && keys.includes('upstream')) {
-      if (approvalViolation) return { kind: 'full-config', reason: approvalViolation }
       // Full config: validate the fence text as-is, byte for byte.
       return { kind: 'full-config', candidateText: text, doc: node, ownKeys: keys }
     }
     if (keys.length > 0 && keys.every((key) => ROOT_KEYS.has(key) || key.startsWith('x-'))) {
-      if (approvalViolation) return { kind: 'fragment', reason: approvalViolation }
       const merged = { ...HARNESS, ...node }
       return {
         kind: 'fragment',
@@ -544,23 +531,6 @@ function expectedCounts(doc) {
       : 0
   const budgets = isPlainObject(doc) && Array.isArray(doc.budgets) ? doc.budgets.length : 0
   return { rules, budgets }
-}
-
-/**
- * Reject a root `approval:` section carrying rule/budget-level approval keys
- * (see ROOT_APPROVAL_KEYS — the false-pass path this closes).
- */
-function rootApprovalViolation(doc) {
-  if (!isPlainObject(doc) || !isPlainObject(doc.approval)) return null
-  const unknown = Object.keys(doc.approval).filter((key) => !ROOT_APPROVAL_KEYS.has(key))
-  if (unknown.length === 0) return null
-  return (
-    `top-level approval: carries ${unknown.map((key) => `"${key}"`).join(', ')} — ` +
-    'rule/budget-level approval keys. The root approval section takes only timeout, ' +
-    'default_on_timeout, and channels, and silently drops unknown keys until #182 lands ' +
-    '(a false pass). Nest the block under policies.rules[].approval (or budgets[].approval) ' +
-    'instead.'
-  )
 }
 
 /** Canonical-order subsequence check over a document's own top-level keys. */
@@ -771,8 +741,6 @@ async function main() {
       const candidate = { label: file, kind: 'shipped-config', failures: [] }
       try {
         const doc = yaml.load(text)
-        const approvalViolation = rootApprovalViolation(doc)
-        if (approvalViolation) candidate.failures.push(approvalViolation)
         candidate.validatePath = join(opts.repoRoot, file)
         candidate.candidateText = text
         candidate.expected = expectedCounts(doc)


### PR DESCRIPTION
## Summary

Nine nested config schemas silently dropped unknown keys and applied their defaults in place of what the operator wrote, the fail-open class #167 closed at the top level, one level down. A typo'd `upstream.request_timout` kept the 30-second default, `approval.channel:` dropped every approval channel, a webhook channel with a misspelled `secret:` shipped unsigned, and `dashboard.api_secrett` with `allow_open_mode: true` ran the dashboard open.

Two commits:

1. `fix(config)`: `.strict()` on all nine schemas (`upstream` on its object stage, before the refinement chain; the eight plain/member schemas wrapped to the house shape). Sixteen new tests written red-first (12 schema pins, 1 loader details pin, 1 watcher reload-rejection pin, 2 CLI pins against the built bundle), the two #144 legacy-alias pins retargeted to the strict rejection (`approval: Unrecognized key: "api_secret"`, single issue, cross-validators suppressed), docs and CHANGELOG updated. The `x-` anchor escape stays root-only; a section-level `x-` key now errors like any other unknown key.
2. `ci(docs)`: the samples guard's root-approval classification workaround removed (both helpers and all three call sites) now that the schema rejects what it pre-screened; its self-test retargeted at the schema's rejection line.

No loader, CLI, watcher, wire, or `formatZodErrors` changes; the #167 error plumbing renders everything. This is a behavior change for operators: configs carrying unknown keys inside `upstream`, `listen`, `dashboard`, approval channel entries, `approval`, `audit`, or `sdk` now refuse to load. The CHANGELOG entry states the break and the fix path. Ships with v0.11.0.

## Verification

- TDD reds observed exactly as the plan inventoried: 13 in `schema.test.ts`, 3 in loader/watcher, 2 in `cli.test.ts` against the pre-fix build; all green post-implementation.
- Full gate: lint, format:check, typecheck, build, proxy tests 2185/2185 (2169 + 16), dashboard 344/344, config samples 79 checked / 78 passed / 1 skipped.
- Guard self-test went red on exactly the pinned assertion after the workaround removal, then 28/28 after the retarget; the real samples tree verdict is unchanged with the workaround gone.
- Review: internal multi-angle pass and an external third-party round on the working tree, both APPROVE with zero findings.

Live repro transcripts against the branch build (`helio validate`, exit 1 each):

```
upstream: Unrecognized key: "request_timout"
approval: Unrecognized key: "channel"
approval.channels.0: Unrecognized key: "secrt"
dashboard: Unrecognized key: "api_secrett"   (with allow_open_mode: true — previously booted open)
dashboard: Unrecognized key: "api_secrett"   (without — previously demanded the secret the operator believed was set)
```

`helio start` on the open-mode repro: exit 1, zero listening lines, same detail. Hot reload with `audit.retentoin` injected into a running proxy:

```
[helio] Config reload failed (keeping current configuration): Invalid configuration (1 error)
[helio]   audit: Unrecognized key: "retentoin"
```

followed by a clean `Budgets reloaded` / `Policy reloaded` pair once the typo was reverted.

One deviation from the reviewed plan, cosmetic: the plan's three dashboard-secret test fixtures used a 32-hex placeholder that the pre-commit secret scan flags; they now use the file's standing `unit-test-secret` placeholder instead. No assertion reads these values.

Closes #182
