### PR TITLE
ci(docs): order-check the init scaffold in the config-samples guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,10 +175,11 @@ has never been executed, assume it is broken.
   to silence a failing Helio sample; fix the sample instead.
 - Canonical section order (`--enforce-order`) and root-key completeness of the
   `helio init` scaffold and `docs/configuration.md` (`--enforce-completeness`)
-  are both enforced. Every sample's top-level keys must follow the order in
-  `docs/configuration.md`, and every top-level section must appear in the
-  scaffold and the reference (the scaffold may satisfy completeness with a
-  commented stub; `docs/configuration.md` needs the key live in a fence).
+  are both enforced. Every sample's top-level keys, and the scaffold's
+  root-key stubs, must follow the order in `docs/configuration.md`, and every
+  top-level section must appear in the scaffold and the reference (the
+  scaffold may satisfy completeness with a commented stub;
+  `docs/configuration.md` needs the key live in a fence).
 
 ### Performance
 

--- a/packages/proxy/src/config-samples-guard.test.ts
+++ b/packages/proxy/src/config-samples-guard.test.ts
@@ -271,6 +271,47 @@ describe('config-samples guard', () => {
   )
 
   it(
+    'reports a misordered init scaffold loudly by default and fails under --enforce-order',
+    { timeout: 60_000 },
+    async () => {
+      // All 10 stubs present so completeness stays clean and the order
+      // signal is isolated; dashboard: moved up between environment and
+      // policies — the #163 defect class on the one surface the guard
+      // never order-checked.
+      const misorderedScaffold = [
+        'version: "1"',
+        'upstream:',
+        '  url: "http://localhost:8080/mcp"',
+        '# listen:',
+        '# environment:',
+        '# dashboard:',
+        '# policies:',
+        '# budgets:',
+        '# approval:',
+        '# audit:',
+        '# sdk:',
+        '',
+      ].join('\n')
+      const root = makeTree({ 'scaffold.yaml': misorderedScaffold })
+      const scaffoldArgs = ['--scaffold-file', join(root, 'scaffold.yaml')]
+
+      const relaxed = await runGuard(root, scaffoldArgs)
+      expect(relaxed.code).toBe(0)
+      expect(relaxed.output).toContain('not enforced without --enforce-order')
+      expect(relaxed.output).toContain('init scaffold: top-level keys not in canonical order')
+
+      const enforced = await runGuard(root, [...scaffoldArgs, '--enforce-order'])
+      expect(enforced.code).toBe(1)
+      expect(enforced.output).toContain('init scaffold: top-level keys not in canonical order')
+      // The scaffold violation counts beside the candidate totals, never
+      // as a failed candidate — this fixture tree has zero candidates.
+      expect(enforced.output).toContain(
+        '0 checked, 0 passed, 0 failed, 0 skipped; 1 enforced order violation',
+      )
+    },
+  )
+
+  it(
     'reports a scaffold missing budgets: loudly by default and fails under --enforce-completeness',
     { timeout: 60_000 },
     async () => {

--- a/scripts/validate-config-samples.mjs
+++ b/scripts/validate-config-samples.mjs
@@ -12,10 +12,11 @@
  * candidate document, so a silently-dropped section can never pass.
  *
  * Enforced at merge: fence validation (check 1), shipped-config validation
- * (check 2), canonical section order (check 3, --enforce-order), root-key
- * completeness of the init scaffold + configuration.md (check 4,
- * --enforce-completeness), the examples/basic README mirror rule, and
- * extraction hygiene. Both package.json entry points pass both flags.
+ * (check 2), canonical section order of every sample and the init scaffold
+ * (check 3, --enforce-order), root-key completeness of the init scaffold +
+ * configuration.md (check 4, --enforce-completeness), the examples/basic
+ * README mirror rule, and extraction hygiene. Both package.json entry
+ * points pass both flags.
  *
  * Usage: node scripts/validate-config-samples.mjs
  *   [--repo-root <dir>] [--cli <path>] [--scaffold-file <path>]
@@ -591,31 +592,56 @@ async function runValidate(cli, filePath, candidateText, expected) {
 }
 
 /**
+ * Acquire the init scaffold text: from --scaffold-file (the test override)
+ * or by running `<cli> init` in the workDir. Acquisition failures are
+ * reported as completeness violations — check 4 owns the scaffold surface,
+ * and both entry points always pass both enforce flags together.
+ */
+async function acquireScaffoldText(opts, workDir) {
+  if (opts.scaffoldFile) {
+    if (existsSync(opts.scaffoldFile)) {
+      return { text: readFileSync(opts.scaffoldFile, 'utf8'), violations: [] }
+    }
+    return { text: null, violations: [`scaffold file not found: ${opts.scaffoldFile}`] }
+  }
+  const scaffoldPath = join(workDir, 'scaffold.yaml')
+  const { code, output } = await run('node', [opts.cli, 'init', '-o', scaffoldPath], {
+    ...process.env,
+  })
+  if (code === 0 && existsSync(scaffoldPath)) {
+    return { text: readFileSync(scaffoldPath, 'utf8'), violations: [] }
+  }
+  return {
+    text: null,
+    violations: [`could not generate the init scaffold (exit ${code}):\n${output.trimEnd()}`],
+  }
+}
+
+/**
+ * Canonical-order check over the RAW scaffold text: the first match
+ * position of each root-key stub — `^(?:#\s*)?key:`, the completeness
+ * matcher and the cli.test.ts pin's regex — orders the found keys, and
+ * orderViolation() applies the same subsequence rule parsed documents get.
+ * Absent keys are skipped; completeness owns missing-key reporting.
+ */
+function scaffoldOrderViolation(scaffoldText) {
+  const found = []
+  for (const key of CANONICAL_ORDER) {
+    const match = scaffoldText.match(new RegExp(`^(?:#\\s*)?${key}:`, 'm'))
+    if (match) found.push({ key, index: match.index })
+  }
+  found.sort((a, b) => a.index - b.index)
+  return orderViolation(found.map((entry) => entry.key))
+}
+
+/**
  * Check 4: all 10 root keys present in the init scaffold (commented stubs
  * count) and, uncommented at column 0, in at least one configuration.md
  * fence. Returns violation strings.
  */
-async function checkCompleteness(opts, workDir, configurationFences) {
+function checkCompleteness(scaffoldText, configurationFences) {
   const violations = []
 
-  let scaffoldText = null
-  if (opts.scaffoldFile) {
-    if (existsSync(opts.scaffoldFile)) {
-      scaffoldText = readFileSync(opts.scaffoldFile, 'utf8')
-    } else {
-      violations.push(`scaffold file not found: ${opts.scaffoldFile}`)
-    }
-  } else {
-    const scaffoldPath = join(workDir, 'scaffold.yaml')
-    const { code, output } = await run('node', [opts.cli, 'init', '-o', scaffoldPath], {
-      ...process.env,
-    })
-    if (code === 0 && existsSync(scaffoldPath)) {
-      scaffoldText = readFileSync(scaffoldPath, 'utf8')
-    } else {
-      violations.push(`could not generate the init scaffold (exit ${code}):\n${output.trimEnd()}`)
-    }
-  }
   if (scaffoldText !== null) {
     for (const key of CANONICAL_ORDER) {
       if (!new RegExp(`^(?:#\\s*)?${key}:`, 'm').test(scaffoldText)) {
@@ -776,11 +802,18 @@ async function main() {
 
     // Skip-marked fences are non-Helio YAML by definition — they must not
     // satisfy the completeness check.
-    const completenessViolations = await checkCompleteness(
-      opts,
-      workDir,
-      fencesByFile.get('docs/configuration.md')?.filter((fence) => !fence.skip),
-    )
+    const scaffold = await acquireScaffoldText(opts, workDir)
+    const completenessViolations = [
+      ...scaffold.violations,
+      ...checkCompleteness(
+        scaffold.text,
+        fencesByFile.get('docs/configuration.md')?.filter((fence) => !fence.skip),
+      ),
+    ]
+    if (scaffold.text !== null) {
+      const violation = scaffoldOrderViolation(scaffold.text)
+      if (violation) orderViolations.push(`init scaffold: ${violation}`)
+    }
 
     // -----------------------------------------------------------------------
     // Report


### PR DESCRIPTION
## Summary

The config-samples guard order-checks every doc fence and every shipped
config, but never the generated `helio init` scaffold: check 4 tested it
for root-key presence only. The only order coverage was the
position-asserting pin in `cli.test.ts`; if a future edit moved a section
and that pin were loosened alongside it, CI would stay green while
`helio init` taught every new user the stale order.

This closes that gap. The guard now takes the first match position of each
root-key stub regex (`^(?:#\s*)?key:`, the same matcher check 4 and the
`cli.test.ts` pin use) over the raw scaffold text, orders the found keys,
and applies the same subsequence rule parsed documents get. A violation
reports under the canonical-order block as `init scaffold:` and counts as
an enforced violation under `--enforce-order`.

- `scripts/validate-config-samples.mjs`: scaffold acquisition extracted to
  `acquireScaffoldText` so the completeness and order checks share one
  acquisition (`helio init` still runs exactly once); new
  `scaffoldOrderViolation` reuses `orderViolation()`; `checkCompleteness`
  is now synchronous with its key loops unchanged. Acquisition failures
  stay completeness violations. Usage header updated.
- `packages/proxy/src/config-samples-guard.test.ts`: new self-test feeds a
  misordered scaffold (all 10 stubs present, `dashboard:` moved up) via
  `--scaffold-file` and pins both modes. Written first and observed RED
  against the stock guard for the predicted reason.
- `CONTRIBUTING.md`: the order/completeness bullet now names the
  scaffold's root-key stubs.

The scaffold's content is untouched and the `cli.test.ts` pin stays as-is
(cheap redundancy, per the issue). Check 4 stays presence-only.

## Live verification

Guard run by hand against a misordered scaffold, relaxed:

```
canonical-order violations (not enforced without --enforce-order):
  init scaffold: top-level keys not in canonical order (version → upstream → listen → environment → policies → budgets → approval → audit → dashboard → sdk)

Config samples: 79 checked, 78 passed, 0 failed, 1 skipped
```

exit 0. Enforced (`--enforce-order`):

```
canonical-order violations (enforced):
  init scaffold: top-level keys not in canonical order (version → upstream → listen → environment → policies → budgets → approval → audit → dashboard → sdk)

Config samples: 79 checked, 78 passed, 0 failed, 1 skipped; 1 enforced order violation
```

exit 1. On the real tree the guard's output is unchanged: `79 checked,
78 passed, 0 failed, 1 skipped`, exit 0, no order block (the shipped
scaffold is canonical).

Full gate green: lint, format:check, typecheck, build, proxy 2186/2186,
dashboard 344/344, guard self-tests 29/29, docs:check:samples. Both
`package.json` entry points and the CI step still pass
`--enforce-order --enforce-completeness` (no change needed).

Closes #185
