### PR TITLE
feat(config): print the watching line from the watcher's ready hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ Maintainer notes:
   rejected like any other unknown key (inside these nine sections it was
   silently dropped before). The policies and budgets subtrees were
   already strict and are unchanged.
+- The `Watching <config> for policy changes` startup line now prints
+  once the config watcher is actually armed (chokidar's `ready`), not
+  merely after watching was requested — a script that waits for the
+  line can trust a subsequent config edit to be observed. Same text,
+  same position, still within milliseconds on startup.
 
 ### Removed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -507,7 +507,7 @@ policies:
 
 ## Hot Reload
 
-Helio watches your configuration file for changes and automatically reloads policy rules without restarting the proxy. The file watcher uses a 200ms debounce to batch rapid saves.
+Helio watches your configuration file for changes and automatically reloads policy rules without restarting the proxy. The file watcher uses a 200ms debounce to batch rapid saves. At startup, the `Watching <config> for policy changes` line prints once the watcher is armed (the initial file scan is complete), not merely when watching was requested, so a script that waits for that line before editing the config can trust the edit to be observed.
 
 On successful reload:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,6 +119,8 @@ Config: helio.yaml
 Watching helio.yaml for policy changes
 ```
 
+The final `Watching` line prints once the config watcher is armed — an edit to `helio.yaml` made after it appears will be picked up (see [Hot Reload](./configuration.md#hot-reload)).
+
 > **Note:** Use `-c` to specify a different config file: `npx @gethelio/proxy start -c production.yaml`
 >
 > On startup, Helio also sends a synthetic upstream `tools/list` to warm the tool-annotation cache before first traffic. If the prime attempt cannot complete quickly, Helio continues startup and retries in the background. During that window, annotation matching remains fail-closed using MCP defaults.

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -806,24 +806,22 @@ dashboard:
         )
         expect(updated).not.toBe(original)
 
-        // Chokidar start() is async and exposes no armed signal, so a single
-        // write can land before the watcher listens. Re-touch the file with
-        // the same content (fresh mtime) until the watcher reports it. The
-        // retries also paper over a watcher that drops only the first event
-        // — accepted: arming and first-event loss are indistinguishable here.
-        const sawRestartRequired = () =>
-          stderr.includes('Restart required: non-reloadable fields changed')
-        const retryDeadline = Date.now() + 8_000
+        // The Watching line prints from chokidar's ready hook, so the
+        // marker above means the initial scan is done and the watcher is
+        // armed. One gap remains below that API: on macOS the kernel
+        // FSEvents stream goes live a few milliseconds AFTER ready, and a
+        // write inside that window is dropped by the OS (measured
+        // sub-5ms and load-independent; Linux inotify has no such gap).
+        // The grace covers it with ~20x margin, so exactly ONE write
+        // suffices — a watcher that drops the first change event now
+        // fails this test.
+        const WATCH_ARM_GRACE_MS = 100
+        await new Promise((resolve) => setTimeout(resolve, WATCH_ARM_GRACE_MS))
         writeFileSync(configPath, updated)
-        for (;;) {
-          try {
-            await waitForLog(sawRestartRequired, 1_000)
-            break
-          } catch (err) {
-            if (Date.now() >= retryDeadline) throw err
-            writeFileSync(configPath, updated)
-          }
-        }
+        await waitForLog(
+          () => stderr.includes('Restart required: non-reloadable fields changed'),
+          8_000,
+        )
         expect(stderr).toContain('Restart required: non-reloadable fields changed')
         // The banner's "Helio proxy listening" also contains "listen" — match
         // the changed path inside the warning's parenthesized list instead.

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -666,6 +666,9 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     configWatcher = new ConfigWatcher({
       configPath,
       initialConfig: config,
+      onReady: () => {
+        console.error(`Watching ${configPath} for policy changes`)
+      },
       onReload: (newPolicy, reloadWarnings, restartRequiredPaths, newBudgets) => {
         // The RUNNING approval surface is startup-bound: a reload whose
         // policy or budgets reference channels (or a dashboard) that only
@@ -723,7 +726,6 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
       },
     })
     configWatcher.start()
-    console.error(`Watching ${configPath} for policy changes`)
   } else {
     console.error(
       `[helio] Hot-reload disabled — config changes to ${configPath} will require a restart`,

--- a/packages/proxy/src/config/watcher.test.ts
+++ b/packages/proxy/src/config/watcher.test.ts
@@ -1130,4 +1130,91 @@ policies:
     expect(reloads).toHaveLength(1)
     expect(reloads[0]?.rules).toHaveLength(1)
   })
+
+  // -------------------------------------------------------------------------
+  // Ready hook
+  // -------------------------------------------------------------------------
+
+  it('calls onReady exactly once, across repeated start() calls', async () => {
+    await writeFile(configPath, validConfig())
+    let readyCount = 0
+    watcher = new ConfigWatcher({
+      configPath,
+      onReload: () => {},
+      onError: () => {},
+      onReady: () => {
+        readyCount += 1
+      },
+      debounceMs: 50,
+    })
+    watcher.start()
+    watcher.start() // Second call is a no-op — must not re-arm or re-fire
+    await wait(300)
+    expect(readyCount).toBe(1)
+  })
+
+  it('does not call onReady after close()', async () => {
+    await writeFile(configPath, validConfig())
+    let readyCount = 0
+    watcher = new ConfigWatcher({
+      configPath,
+      onReload: () => {},
+      onError: () => {},
+      onReady: () => {
+        readyCount += 1
+      },
+      debounceMs: 50,
+    })
+    watcher.start()
+    watcher.close()
+    await wait(300)
+    expect(readyCount).toBe(0)
+  })
+
+  it('calls onReady even when the watched file is missing', async () => {
+    // No write: the path does not exist. Ready means "initial scan done",
+    // not "file exists" — a caller waiting on the hook must not hang when
+    // the config vanished between load and watch.
+    let readyCount = 0
+    watcher = new ConfigWatcher({
+      configPath,
+      onReload: () => {},
+      onError: () => {},
+      onReady: () => {
+        readyCount += 1
+      },
+      debounceMs: 50,
+    })
+    watcher.start()
+    await wait(300)
+    expect(readyCount).toBe(1)
+  })
+
+  it('reports a change written after onReady', async () => {
+    await writeFile(configPath, validConfig())
+    const reloads: CompiledPolicy[] = []
+    let ready = false
+    watcher = new ConfigWatcher({
+      configPath,
+      onReload: (policy) => {
+        reloads.push(policy)
+      },
+      onError: () => {},
+      onReady: () => {
+        ready = true
+      },
+      debounceMs: 50,
+    })
+    watcher.start()
+    // 100ms after start: onReady must already have fired (ready lands in
+    // ~1-2ms), and the wait doubles as the platform arming grace — on
+    // macOS the kernel FSEvents stream goes live a few milliseconds
+    // AFTER ready, and a write inside that window is dropped by the OS.
+    await wait(100)
+    expect(ready).toBe(true)
+    await writeFile(configPath, configWithDenyRule())
+    await wait(500)
+    expect(reloads).toHaveLength(1)
+    expect(reloads[0]?.rules[0]?.name).toBe('block-delete')
+  })
 })

--- a/packages/proxy/src/config/watcher.ts
+++ b/packages/proxy/src/config/watcher.ts
@@ -25,6 +25,9 @@ export interface ConfigWatcherOptions {
   ) => void
   /** Called when a reload attempt fails (parse, validation, or compile error). */
   readonly onError: (error: Error) => void
+  /** Called once the underlying watcher has finished its initial scan
+   *  and is armed (chokidar's `ready` event). Optional. */
+  readonly onReady?: () => void
   /** Baseline config loaded at startup, used for restart-required diffing. */
   readonly initialConfig?: HelioConfig
   /** Environment variables for config interpolation. */
@@ -43,6 +46,7 @@ export class ConfigWatcher {
   private readonly configPath: string
   private readonly onReload: ConfigWatcherOptions['onReload']
   private readonly onError: ConfigWatcherOptions['onError']
+  private readonly onReady: ConfigWatcherOptions['onReady']
   private readonly initialConfig: HelioConfig | undefined
   private readonly env: Record<string, string | undefined> | undefined
   private readonly debounceMs: number
@@ -54,6 +58,7 @@ export class ConfigWatcher {
     this.configPath = options.configPath
     this.onReload = options.onReload
     this.onError = options.onError
+    this.onReady = options.onReady
     this.initialConfig = options.initialConfig
     this.env = options.env
     this.debounceMs = options.debounceMs ?? 200
@@ -71,6 +76,12 @@ export class ConfigWatcher {
 
     this.watcher.on('change', () => {
       this.scheduleReload()
+    })
+
+    this.watcher.on('ready', () => {
+      // close() nulls the watcher synchronously; chokidar also suppresses
+      // ready after close — this guard is our own invariant on top.
+      if (this.watcher && this.onReady) this.onReady()
     })
   }
 


### PR DESCRIPTION
## Summary

- `ConfigWatcher` gains an optional `onReady` callback, invoked once when chokidar's `ready` event reports the initial scan complete. Omitted, the watcher behaves identically to today; `start()` stays `void`, so all existing call sites compile unchanged.
- The CLI passes the `Watching <config> for policy changes` print in as that callback instead of printing it synchronously after `start()`. Same text, same position as the last startup line, still within milliseconds; the line now means the watcher is armed.
- The restart-required hot-reload test shrinks back to a single config write behind the ready marker plus a 100ms platform grace, deleting the #190 retry loop and its first-event-loss tradeoff comment. A watcher that drops the first change event fails the test again. The grace covers the one gap below the API: on macOS the kernel FSEvents stream goes live a few milliseconds after `ready` (measured sub-5ms and load-independent; Linux inotify has no such gap).
- The hot-reload reference and the getting-started walkthrough now document the line's meaning: waiting for it before editing the config is a reliable pattern.

## Verification

- TDD red first: on stock code the three new assertion-based tests failed exactly as planned (`readyCount` 0, `ready` false); the close-before-ready test is green-on-stock by construction and pins the suppression once the hook exists.
- Full gate green: lint, format:check, typecheck, build, tests, samples guard. Measured counts: proxy 2190 (was 2186), dashboard 344, watcher.test.ts 25 tests (was 21), cli.test.ts 43, samples 79 checked / 78 passed / 1 skipped, guard self-tests 29.
- Sufficiency soak under 64 busy-loop spinners, test run against a rebuilt `dist/cli.js` at each step: the shrunken test against the stock watcher failed at run 13 of at most 50 (timeout waiting for the restart-required line, the un-armed watcher dropping the single write); against the fix, 20/20 green under the same saturation.
- Live boot of the patched build with a transcript-shaped config: startup block machine-diffed identical to `docs/getting-started.md:109-119`, `Watching` last. The transcript itself needed no edits; the doc additions document the line's new meaning rather than changing any recorded output.
- Reviewed pre-commit: internal multi-angle review plus an external round, both zero findings.

Closes #191