### PR TITLE
feat(budgets): add CSV export for the spend ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Added
+
+- **CSV export for the budget spend ledger (#155).** One budget's spend
+  history is now exportable everywhere the audit trail is:
+  `GET /api/budgets/:name/events/export?format=csv|json` downloads the
+  ledger as an attachment (`helio-budget-<name>-events.csv`), the
+  dashboard's Budgets view gains per-pot CSV/JSON export buttons, and
+  `helio export --budgets <name>` produces the same artifact offline from
+  the database file — with the proxy stopped or the dashboard disabled.
+  Exports are capped at 10,000 rows and run newest-first (the listing's
+  own order: with no time filters, a capped export keeps the most recent
+  spend reachable), span config resets like the listing, and carry the
+  listing's wire columns verbatim with the audit exporter's CSV escaping
+  and formula-injection defense. Direct embedders of the dashboard app:
+  the `budgets` dependency gains a required `listEventsForExport` method.
+
 ### Changed
 
 - **BREAKING: budget contributors are now `{ match: { tool, input? }, field }`

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -133,7 +133,7 @@ Two indexes serve the hot paths: `idx_budget_events_replay` on `(budget_name, ep
 
 At startup the engine replays the ledger: duration windows rebuild from the rows inside the window (equivalent to never having restarted), and `window: session` pots rebuild from their lifetime sums if their last activity is within `idle_ttl`. Ledger rows may reference an audit record that is still in the async writer buffer (or was lost to a crash): the ledger is the source of truth for spend, the audit table for calls.
 
-The ledger is also the "where did the money go" surface: the dashboard's Budgets view lists it under each pot (approved overages carry a distinct badge), and [`GET /api/budgets/:name/events`](./sideband-api.md#get-apibudgetsnameevents) serves it newest-first, paginated — history spans config resets, so rows from before a pot-resetting edit stay listed. A CSV export of the ledger is not available yet; use the JSON listing.
+The ledger is also the "where did the money go" surface: the dashboard's Budgets view lists it under each pot (approved overages carry a distinct badge), and [`GET /api/budgets/:name/events`](./sideband-api.md#get-apibudgetsnameevents) serves it newest-first, paginated — history spans config resets, so rows from before a pot-resetting edit stay listed. For a spreadsheet artifact, [`GET /api/budgets/:name/events/export`](./sideband-api.md#get-apibudgetsnameeventsexport) downloads the ledger as CSV or JSON (also one click per pot in the Budgets view), and `helio export --budgets <name>` produces the same export offline from the database file.
 
 ### Local Schema Resets (Pre-1.0)
 
@@ -188,17 +188,18 @@ helio export
 
 **Options:**
 
-| Flag                    | Type   | Default      | Description                                            |
-| ----------------------- | ------ | ------------ | ------------------------------------------------------ |
-| `-c, --config <path>`   | string | `helio.yaml` | Path to the config file (used to locate the database). |
-| `-f, --format <format>` | string | `json`       | Output format: `json` or `csv`.                        |
-| `--tool <name>`         | string | —            | Filter by tool name.                                   |
-| `--decision <decision>` | string | —            | Filter by policy decision.                             |
-| `--reason <reason>`     | string | —            | Filter by block reason.                                |
-| `--session <id>`        | string | —            | Filter by session ID.                                  |
-| `--from <iso>`          | string | —            | Start time (ISO 8601).                                 |
-| `--to <iso>`            | string | —            | End time (ISO 8601).                                   |
-| `--limit <n>`           | number | `1000`       | Maximum number of records to export (up to 10,000).    |
+| Flag                    | Type   | Default      | Description                                                |
+| ----------------------- | ------ | ------------ | ---------------------------------------------------------- |
+| `-c, --config <path>`   | string | `helio.yaml` | Path to the config file (used to locate the database).     |
+| `-f, --format <format>` | string | `json`       | Output format: `json` or `csv`.                            |
+| `--budgets <name>`      | string | —            | Export the named budget ledger instead of the audit trail. |
+| `--tool <name>`         | string | —            | Filter by tool name.                                       |
+| `--decision <decision>` | string | —            | Filter by policy decision.                                 |
+| `--reason <reason>`     | string | —            | Filter by block reason.                                    |
+| `--session <id>`        | string | —            | Filter by session ID.                                      |
+| `--from <iso>`          | string | —            | Start time (ISO 8601).                                     |
+| `--to <iso>`            | string | —            | End time (ISO 8601).                                       |
+| `--limit <n>`           | number | `1000`       | Maximum number of records to export (up to 10,000).        |
 
 **Examples:**
 
@@ -214,9 +215,14 @@ helio export --tool create_payment --from "2026-04-09T11:00:00Z" --to "2026-04-0
 
 # Export to a file
 helio export -f csv > audit-report.csv
+
+# Export one budget's spend ledger as CSV
+helio export --budgets daily-cap -f csv > daily-cap.csv
 ```
 
 Audit data is written to stdout; status messages go to stderr. This means you can pipe or redirect the output without capturing log messages.
+
+`--budgets <name>` switches the export target to the named budget's spend ledger, read from the same database file — it works offline, with the proxy stopped and the dashboard disabled. Ledger rows export newest-first with the same twelve columns as the [ledger export endpoint](./sideband-api.md#get-apibudgetsnameeventsexport); `--format` and `--limit` apply unchanged, an unknown name exports an empty artifact, and combining `--budgets` with the audit filter flags (`--tool`, `--decision`, `--reason`, `--session`, `--from`, `--to`) is an error.
 
 ## Dashboard API Export
 

--- a/docs/sideband-api.md
+++ b/docs/sideband-api.md
@@ -12,7 +12,7 @@ The dashboard sideband is a read/write REST + SSE surface served on a separate p
 - **Bind address:** localhost-only by default. Bind publicly only behind a TLS-terminating reverse proxy you control.
 - **Auth:** By default, `dashboard.enabled: true` requires `dashboard.api_secret`. Browser clients unlock with `POST /api/auth/session` + HttpOnly cookie; non-browser clients can use `Authorization: Bearer <api_secret>`. Running without `api_secret` is only allowed with explicit `dashboard.allow_open_mode: true` on loopback hosts. Open mode disables all sideband authentication and is a local/demo posture only: the CORS allowlist above does not make it safe, since an unauthenticated loopback service is still reachable by a determined local attacker (for example via DNS rebinding). See [Authentication](#authentication) below.
 - **CORS:** Allows same-origin, `localhost` / `127.0.0.1` / `0.0.0.0`, and validated private-network IPv4 literals (`10.x`, `172.16-31.x`, `192.168.x`) for Docker bridge and LAN access. Origins are matched as real IP addresses, not by hostname prefix; every other origin, including hostnames, receives no CORS headers. (CORS is a browser-enforced control, not a server-side auth boundary.)
-- **Content type:** JSON for everything except `/api/audit/export` (JSON or CSV attachment) and `/api/events` (SSE stream).
+- **Content type:** JSON for everything except `/api/audit/export` and `/api/budgets/:name/events/export` (JSON or CSV attachments) and `/api/events` (SSE stream).
 - **Non-200 errors:** Always JSON in the shape `{ "error": "<message>" }`. Unknown `/api/*` paths return `404` with this shape (never HTML).
 
 ## Response shape conventions
@@ -54,14 +54,15 @@ The auth endpoints (`/api/auth/*`) and the approval action POSTs sit outside the
 
 ### Non-JSON responses
 
-Two endpoints fall outside the envelope model entirely:
+Three endpoints fall outside the envelope model entirely:
 
 - `GET /api/audit/export` — binary download with `Content-Disposition: attachment` and a `text/csv` or `application/json` body. The body is a bare `AuditRecord[]` array (no envelope) or a CSV document, intended for `curl -o audit.json` and spreadsheet pipelines.
+- `GET /api/budgets/:name/events/export` — the same attachment contract for one budget's spend ledger: a bare ledger-row array or a CSV document.
 - `GET /api/events` — Server-Sent Events stream. Each frame is an `event: <name>\ndata: <json>\n\n` block. Not a single response body.
 
 ### Error shape
 
-Every 4xx and 5xx response across every endpoint (with the two non-JSON exceptions above) returns:
+Every 4xx and 5xx response across every endpoint (with the three non-JSON exceptions above) returns:
 
 ```json
 { "error": "Human-readable error message" }
@@ -380,7 +381,29 @@ An unknown budget name returns `200` with an empty page (budget names are config
 - `audit_record_id` — the audit record of the call that produced the charge. The ledger is the source of truth for spend; the audit trail for calls — the referenced audit row may lag briefly (async audit writer) or be missing after a crash.
 - `origin` — `mcp`, or the adapter origin for sideband-committed charges.
 
-A CSV export of the ledger is not available yet; use the JSON listing.
+#### GET /api/budgets/:name/events/export
+
+Bulk export of one budget's ledger rows as a downloadable attachment. **Not a JSON envelope** — the body is a bare array of the listing's wire rows (or a CSV document with the same twelve columns, in the same order). Returned with `Content-Disposition: attachment; filename="helio-budget-<name>-events.<ext>"`, where `<name>` is the budget name stripped to the config-name character set (`A-Z a-z 0-9 _ -`), so browsers download a file identifiable per pot.
+
+Rows are exported newest-first — the listing's own order, and the deliberate opposite of the audit export's oldest-first: this endpoint takes no time filters, so a capped export keeps the most recent spend reachable, while older rows age out through the audit `retention` window. Like the listing, history spans config resets, and an unknown budget name returns `200` with an empty artifact.
+
+**Query parameters:**
+
+| Parameter | Default | Description                     |
+| --------- | ------- | ------------------------------- |
+| `format`  | `json`  | `json` or `csv`.                |
+| `limit`   | `10000` | Maximum records. Capped at 10k. |
+
+**Example:**
+
+```bash
+curl -s -H "Authorization: Bearer $HELIO_DASHBOARD_SECRET" \
+  "http://localhost:3100/api/budgets/daily-cap/events/export?format=csv" > daily-cap.csv
+```
+
+CSV cells follow the audit export's serialization rules: RFC 4180 escaping, null `audit_record_id` as an empty cell, and the formula-injection defense described in [Audit Trail → CSV Format](./audit.md#csv-format). The dashboard's Budgets view offers the same download per pot, and `helio export --budgets <name>` produces it offline from the database file.
+
+**Non-JSON endpoint** — attachment download, no envelope.
 
 ---
 

--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -1,6 +1,6 @@
 # @gethelio/dashboard
 
-Real-time governance dashboard for the Helio proxy. React SPA that displays live action feeds, approval workflows, audit logs, rate/spend limits, and analytics. Bundled into the proxy at build time and served as static files.
+Real-time governance dashboard for the Helio proxy. React SPA that displays live action feeds, approval workflows, audit logs, rate/spend limits, budgets, and analytics. Bundled into the proxy at build time and served as static files.
 
 ## Package Layout
 
@@ -14,17 +14,19 @@ src/
 ├── api.ts                    → REST client (apiFetch, qs, authHeaders, ApiError, CSRF token + auth/session helpers)
 ├── constants.ts              → Decision/outcome filters, chart color map, MS_PER_* + time-range presets
 ├── outcome.ts                → DisplayOutcome union + helpers that derive/filter audit & feed outcomes
-├── utils.ts                  → Formatting helpers (timeAgo, formatLabel, etc.)
+├── origin.ts                 → Origin + record_kind display labels (MCP/OpenClaw, install scan, drift, etc.)
+├── utils.ts                  → Formatting helpers (timeAgo, formatLabel, formatCurrency, etc.)
 ├── EventSourceContext.tsx    → SSE context provider (forwards onSessionExpired)
 ├── useEventSource.ts         → SSE hook (typed subscribe/unsubscribe)
 ├── useAuditQuery.ts          → Audit filtering + pagination hook
 ├── components/
 │   ├── Header.tsx            → Top bar with sidebar toggle + StatusIndicator
-│   ├── Sidebar.tsx           → Left nav (Feed/Approvals/Audit/Limits/Analytics)
+│   ├── Sidebar.tsx           → Left nav (Feed/Approvals/Audit/Limits/Budgets/Analytics)
 │   ├── ErrorBoundary.tsx     → Top-level React error boundary
 │   ├── PageError.tsx         → Inline per-page error state
 │   ├── ActionCard.tsx        → Collapsible tool action record card
 │   ├── PolicyBadge.tsx       → Color-coded decision badge
+│   ├── OriginBadge.tsx       → Origin + record_kind chips on feed/audit rows
 │   ├── ApprovalStatusBadge.tsx → Approval status indicator
 │   ├── ApprovalActions.tsx   → Approve/Deny/BreakGlass modal
 │   ├── StatusIndicator.tsx   → Connection status + version + uptime
@@ -41,6 +43,7 @@ src/
     ├── ApprovalsPage.tsx     → Pending + resolved tabs, real-time countdown
     ├── AuditPage.tsx         → Audit log (composes AuditFilterBar + AuditTable + AuditDetailPanel)
     ├── LimitsPage.tsx        → Rate + spend limit gauges (5s polling + SSE)
+    ├── BudgetsPage.tsx       → Cross-tool budget pots + ledger events (5s polling + SSE)
     └── AnalyticsPage.tsx     → Charts + aggregate stats (1h/24h/7d presets)
 ```
 
@@ -55,7 +58,7 @@ The proxy build runs this dashboard build first, then copies `packages/dashboard
 ## Tech Stack
 
 - **React** 19 (hooks-based; the one exception is `ErrorBoundary`, a class component since `getDerivedStateFromError`/`componentDidCatch` require it)
-- **React Router** 7 (client-side routing, 5 routes)
+- **React Router** 7 (client-side routing, 6 routes)
 - **Vite** 6 (dev server + bundler)
 - **Tailwind CSS** 4 (@tailwindcss/vite plugin)
 - **Recharts** 3 (charts: line, pie, bar)
@@ -69,22 +72,25 @@ No state management library. All state is React hooks (useState, useEffect, useC
 
 The dashboard talks to the proxy's sideband API (default port 3100):
 
-| Method                                | Path                                                                   | Purpose |
-| ------------------------------------- | ---------------------------------------------------------------------- | ------- |
-| `GET /api/health`                     | Proxy health, version, uptime (unauthenticated)                        |
-| `GET /api/auth/session`               | Current session state (`auth_required`, `authenticated`, `csrf_token`) |
-| `POST /api/auth/session`              | Log in with the dashboard secret                                       |
-| `POST /api/auth/logout`               | Log out / clear the session                                            |
-| `GET /api/feed`                       | Recent action records (limit/offset)                                   |
-| `GET /api/audit`                      | Paginated audit log (tool/decision/session/date filters)               |
-| `GET /api/audit/:id`                  | Single audit record detail                                             |
-| `GET /api/approvals`                  | Approval tickets (filter by status)                                    |
-| `POST /api/approvals/:id/approve`     | Approve a pending ticket                                               |
-| `POST /api/approvals/:id/deny`        | Deny a pending ticket                                                  |
-| `POST /api/approvals/:id/break-glass` | Break-glass override (reason required)                                 |
-| `GET /api/limits`                     | Rate + spend limit states                                              |
-| `GET /api/analytics`                  | Aggregated stats (from/to range)                                       |
-| `GET /api/evidence/:session_id`       | Session evidence chain                                                 |
+| Method                                 | Path                                                                   | Purpose |
+| -------------------------------------- | ---------------------------------------------------------------------- | ------- |
+| `GET /api/health`                      | Proxy health, version, uptime (unauthenticated)                        |
+| `GET /api/auth/session`                | Current session state (`auth_required`, `authenticated`, `csrf_token`) |
+| `POST /api/auth/session`               | Log in with the dashboard secret                                       |
+| `POST /api/auth/logout`                | Log out / clear the session                                            |
+| `GET /api/feed`                        | Recent action records (limit/offset)                                   |
+| `GET /api/audit`                       | Paginated audit log (tool/decision/session/date filters)               |
+| `GET /api/audit/:id`                   | Single audit record detail                                             |
+| `GET /api/approvals`                   | Approval tickets (filter by status)                                    |
+| `POST /api/approvals/:id/approve`      | Approve a pending ticket                                               |
+| `POST /api/approvals/:id/deny`         | Deny a pending ticket                                                  |
+| `POST /api/approvals/:id/break-glass`  | Break-glass override (reason required)                                 |
+| `GET /api/limits`                      | Rate + spend limit states                                              |
+| `GET /api/budgets`                     | Cross-tool budget pot states                                           |
+| `GET /api/budgets/:name/events`        | Paginated spend ledger for one budget                                  |
+| `GET /api/budgets/:name/events/export` | Ledger CSV/JSON attachment download (per-pot export buttons)           |
+| `GET /api/analytics`                   | Aggregated stats (from/to range)                                       |
+| `GET /api/evidence/:session_id`        | Session evidence chain                                                 |
 
 Mutating approval requests (approve/deny/break-glass) carry the CSRF token from the session response as an `x-helio-csrf` header; `api.ts` stores the token via `setCsrfToken()` and attaches it through `authHeaders()`. A 401 from any call triggers the registered unauthorized handler (`setUnauthorizedHandler`), which sends the UI back to the locked state.
 
@@ -92,7 +98,7 @@ Mutating approval requests (approve/deny/break-glass) carry the CSRF token from 
 
 **Dev-mode auth gotcha:** when the target proxy is started with `dashboard.api_secret` set, the dashboard starts in a locked state and requires manual secret login (`POST /api/auth/session`) before API calls succeed. Keep the secret handy from `helio.yaml` when iterating locally.
 
-**SSE:** EventSource connects to `/api/events`. Five event types: `action`, `approval_requested`, `approval_resolved`, `approval_notification_failed`, `limit_warning`.
+**SSE:** EventSource connects to `/api/events`. Seven event types: `action`, `approval_requested`, `approval_resolved`, `approval_notification_failed`, `limit_warning`, `budget_update`, `budget_breached`.
 
 ## Type System
 
@@ -101,10 +107,11 @@ Types are defined in `src/types.ts` (not imported from the proxy package). This 
 - `AuditRecord` — full audit trail entry (24 fields)
 - `ApprovalTicket` — approval request state (18 fields, including escalation + notification-failure data)
 - `RateLimitKeyState`, `SpendLimitKeyState` — limit gauge data
+- `BudgetState`, `BudgetBucketState`, `BudgetEventRecord` — budget pot + ledger data
 - `AnalyticsResponse` — aggregated stats + time series + top tools
 - `AuthSessionResponse` — session state (`auth_required`, `authenticated`, `csrf_token`)
 - `DisplayOutcome` (in `outcome.ts`) — derived outcome union used for badges and filters
-- `DashboardEventType` / `DashboardEventMap` — typed SSE event union (action, approval_requested, approval_resolved, approval_notification_failed, limit_warning)
+- `DashboardEventType` / `DashboardEventMap` — typed SSE event union (action, approval_requested, approval_resolved, approval_notification_failed, limit_warning, budget_update, budget_breached)
 
 ## Security Standards
 
@@ -147,7 +154,7 @@ The dashboard displays sensitive governance data — tool call details, policy d
 
 **Lazy detail loading:** ActionCard and approval cards fetch the full record only when expanded, avoiding large initial payloads.
 
-**Polling + SSE:** LimitsPage polls every 5s and also listens for SSE `limit_warning` events. Warning events trigger a 10s flash highlight effect.
+**Polling + SSE:** LimitsPage polls every 5s and also listens for SSE `limit_warning` events. BudgetsPage polls every 5s and listens for `budget_update` / `budget_breached`. Warning/breach events trigger a 10s flash highlight effect.
 
 **Record buffer cap:** FeedPage caps the in-memory record list at 500 entries to prevent memory growth during long sessions.
 

--- a/packages/dashboard/src/pages/BudgetsPage.test.tsx
+++ b/packages/dashboard/src/pages/BudgetsPage.test.tsx
@@ -1353,3 +1353,95 @@ describe('BudgetsPage', () => {
     })
   })
 })
+
+// ---------------------------------------------------------------------------
+// Ledger export buttons (issue #155)
+// ---------------------------------------------------------------------------
+
+describe('BudgetsPage export buttons', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function stubDownloadEnv(response: Response | Error) {
+    const fetchMock =
+      response instanceof Error
+        ? vi.spyOn(globalThis, 'fetch').mockRejectedValue(response)
+        : vi.spyOn(globalThis, 'fetch').mockResolvedValue(response)
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:http://localhost/fake'),
+      revokeObjectURL: vi.fn(),
+    })
+    const downloads: string[] = []
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      downloads.push(this.download)
+    })
+    return { fetchMock, downloads, clickSpy }
+  }
+
+  it('renders CSV and JSON export buttons on each budget card', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Export daily-cap events as CSV')).toBeTruthy()
+      expect(screen.getByLabelText('Export daily-cap events as JSON')).toBeTruthy()
+    })
+  })
+
+  it('downloads the CSV export through the endpoint, cookie-auth only', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    const { fetchMock, downloads } = stubDownloadEnv(
+      new Response('id,budget_name', {
+        status: 200,
+        headers: { 'content-type': 'text/csv; charset=utf-8' },
+      }),
+    )
+    renderPage()
+
+    const button = await waitFor(() => screen.getByLabelText('Export daily-cap events as CSV'))
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/budgets/daily-cap/events/export?format=csv')
+      expect(downloads).toEqual(['helio-budget-daily-cap-events.csv'])
+    })
+  })
+
+  it('downloads the JSON export with the .json filename', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    const { fetchMock, downloads } = stubDownloadEnv(
+      new Response('[]', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    renderPage()
+
+    const button = await waitFor(() => screen.getByLabelText('Export daily-cap events as JSON'))
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/budgets/daily-cap/events/export?format=json')
+      expect(downloads).toEqual(['helio-budget-daily-cap-events.json'])
+    })
+  })
+
+  it('shows a per-card error and keeps the buttons usable when an export fails', async () => {
+    mockFetchBudgets.mockResolvedValue({ budgets: [budgetState()] })
+    stubDownloadEnv(new Error('network down'))
+    renderPage()
+
+    const button = await waitFor(() => screen.getByLabelText('Export daily-cap events as CSV'))
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(screen.getByText('network down')).toBeTruthy()
+    })
+    const csvButton = screen.getByLabelText<HTMLButtonElement>('Export daily-cap events as CSV')
+    expect(csvButton.disabled).toBe(false)
+  })
+})

--- a/packages/dashboard/src/pages/BudgetsPage.tsx
+++ b/packages/dashboard/src/pages/BudgetsPage.tsx
@@ -436,6 +436,42 @@ function BudgetCard({
   panel: EventsPanelState | undefined
   onToggleEvents: () => void
 }) {
+  const [exportBusy, setExportBusy] = useState(false)
+  const [exportError, setExportError] = useState<string | null>(null)
+
+  // Same download idiom as the audit page's export control: no explicit auth
+  // headers — the same-origin session cookie authenticates the request.
+  const handleExport = useCallback(
+    async (format: 'csv' | 'json') => {
+      setExportError(null)
+      setExportBusy(true)
+      try {
+        const res = await fetch(
+          `/api/budgets/${encodeURIComponent(budget.name)}/events/export?format=${format}`,
+        )
+        if (!res.ok) {
+          const text = await res.text().catch(() => '')
+          throw new Error(text || `Export failed (${String(res.status)})`)
+        }
+
+        const blob = await res.blob()
+        const objectUrl = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = objectUrl
+        a.download = `helio-budget-${budget.name}-events.${format}`
+        document.body.appendChild(a)
+        a.click()
+        document.body.removeChild(a)
+        URL.revokeObjectURL(objectUrl)
+      } catch (err) {
+        setExportError(err instanceof Error ? err.message : 'Failed to export events')
+      } finally {
+        setExportBusy(false)
+      }
+    },
+    [budget.name],
+  )
+
   return (
     <div
       className={`rounded-md border bg-white p-4 transition-shadow ${
@@ -479,14 +515,42 @@ function BudgetCard({
         </div>
       )}
 
-      {/* Recent events (ledger listing) */}
-      <button
-        type="button"
-        onClick={onToggleEvents}
-        className="mt-3 text-xs font-medium text-blue-600 hover:text-blue-500"
-      >
-        {panel ? 'Hide recent events' : 'Recent events'}
-      </button>
+      {/* Recent events (ledger listing) + ledger export */}
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={onToggleEvents}
+          className="text-xs font-medium text-blue-600 hover:text-blue-500"
+        >
+          {panel ? 'Hide recent events' : 'Recent events'}
+        </button>
+        <div className="flex shrink-0 items-center gap-1.5 text-xs">
+          <span className="text-gray-400">Export</span>
+          <button
+            type="button"
+            disabled={exportBusy}
+            aria-label={`Export ${budget.name} events as CSV`}
+            onClick={() => {
+              void handleExport('csv')
+            }}
+            className="font-medium text-blue-600 hover:text-blue-500 disabled:text-gray-300"
+          >
+            CSV
+          </button>
+          <button
+            type="button"
+            disabled={exportBusy}
+            aria-label={`Export ${budget.name} events as JSON`}
+            onClick={() => {
+              void handleExport('json')
+            }}
+            className="font-medium text-blue-600 hover:text-blue-500 disabled:text-gray-300"
+          >
+            JSON
+          </button>
+        </div>
+      </div>
+      {exportError && <p className="mt-1 text-xs text-red-600">{exportError}</p>}
       {panel && <EventsPanel panel={panel} />}
     </div>
   )

--- a/packages/proxy/AGENTS.md
+++ b/packages/proxy/AGENTS.md
@@ -7,7 +7,9 @@ The core governance proxy package. Intercepts MCP `tools/call` requests, evaluat
 ```
 src/
 ├── cli.ts                   → CLI entry point (helio start/init/validate/export)
+├── cli-forwarder.ts         → Build upstream McpForwarder from config (streamable-http / sse / stdio)
 ├── server.ts                → Hono app factory + HTTP server lifecycle
+├── shutdown.ts              → Ordered resource teardown (drain traffic doors before clearing governance state)
 ├── index.ts                 → Public API surface (re-exports from all modules)
 ├── version.ts               → VERSION constant (read from package.json)
 ├── crash-drain.ts           → Crash-drain registry: flush buffered state (audit writer) before process.exit
@@ -27,8 +29,13 @@ src/
 │   ├── forward-headers.ts   → Allowlist for headers crossing the proxy to upstream (authorization + `x-*` allowlist)
 │   └── response-normalizer.ts → Normalize an upstream forwarding outcome (success/error) into a JSON-RPC response
 ├── upstream/
-│   ├── forwarder.ts         → HTTP upstream forwarder (Streamable HTTP)
+│   ├── streamable-http-forwarder.ts → Spec-compliant Streamable HTTP upstream client (JSON + SSE responses, session relay)
+│   ├── forwarder.ts         → Deprecated alias: UpstreamForwarder extends StreamableHttpForwarder
 │   ├── sse-forwarder.ts     → SSE upstream forwarder
+│   ├── upstream-session-manager.ts → Lazy initialize handshake for Helio-internal sessionless requests
+│   ├── merge-headers.ts     → Merge base / forwarded / static upstream headers (static wins)
+│   ├── connection-error.ts  → Operator-facing messages for unreachable upstreams
+│   ├── sse-parse.ts         → SSE chunk parser + JSON-RPC response reader
 │   ├── response.ts          → Response parsing/capture utilities
 │   ├── response-summary.ts  → Response summarization utilities
 │   └── index.ts             → Re-exports
@@ -41,6 +48,7 @@ src/
 │   ├── parser.ts            → YAML config → compiled policy (pre-builds matchers, regexes, durations)
 │   ├── matchers.ts          → Rule matching: tool glob, annotations, input conditions, environment
 │   ├── engine.ts            → First-match-wins policy evaluator
+│   ├── decision-pipeline.ts → Side-effect-free decide() shared by MCP path and sideband governance API
 │   ├── annotation-cache.ts  → Caches tools/list annotations per upstream
 │   ├── governed-forwarder.ts → McpForwarder wrapper that applies policy before forwarding
 │   ├── rate-limiter.ts      → Sliding window rate limiter with injectable clock
@@ -53,9 +61,12 @@ src/
 │   ├── api.ts               → Sideband HTTP API (Hono app on SDK port, bearer-protected)
 │   ├── types.ts             → EvidenceEntry, SessionState, etc.
 │   └── index.ts             → Re-exports
+├── sideband/
+│   ├── governance-service.ts → Engine for hook-based adapters: evaluate / audit / install-scan / native approval resolve
+│   ├── governance-api.ts    → Hono routes for the governance sideband endpoints (Zod-validated)
+│   └── errors.ts            → GovernanceConfigError (fail-closed miswiring, e.g. approval without router)
 ├── feedback/
-│   ├── self-repair.ts       → Structured block feedback builders (discriminated union)
-│   └── index.ts             → Re-exports
+│   └── self-repair.ts       → Structured block feedback builders (discriminated union)
 ├── approval/
 │   ├── types.ts             → ApprovalTicket, ApprovalOutcome, ApprovalStatus, ApprovalChannel interface
 │   ├── queue.ts             → In-memory approval queue (Map, injectable clock, cleanup)
@@ -72,6 +83,13 @@ src/
 │   ├── writer.ts            → AuditWriter: async buffered writer (batch flush to SQLite)
 │   ├── csv.ts               → CSV serialization for audit export
 │   └── index.ts             → Re-exports
+├── budget/
+│   ├── types.ts             → CompiledBudget + contributor/window types
+│   ├── parser.ts            → YAML budgets → compiled budgets (BudgetParseError)
+│   ├── engine.ts            → BudgetEngine: pots, charges, breach decisions, replay/hydrate
+│   ├── ledger.ts            → BudgetLedger: SQLite persistence in the audit DB (budget_* tables)
+│   ├── csv.ts               → CSV serialization for ledger export
+│   └── index.ts             → Re-exports
 ├── dashboard/
 │   ├── api.ts               → createDashboardApp() factory: REST + SSE API on dashboard port
 │   ├── session.ts           → Dashboard auth sessions: secret login, CSRF token issue/verify, TTL cleanup
@@ -79,7 +97,8 @@ src/
 │   └── index.ts             → Re-exports
 ├── util/
 │   ├── clamp.ts             → Numeric clamp + clamped query-int parsing for pagination
-│   └── format-zod-errors.ts → Flatten ZodError issues into `{ path, message }` for CLI/validation output
+│   ├── format-zod-errors.ts → Flatten ZodError issues into `{ path, message }` for CLI/validation output
+│   └── canonical-json.ts    → Deterministic key-sorted JSON (drift fingerprints, /audit idempotency hashes)
 └── __tests__/
     ├── helpers/
     │   ├── mcp-test-server.ts   → Mock MCP server (Hono app with canned JSON-RPC)
@@ -91,11 +110,13 @@ src/
     ├── integration-stdio.test.ts
     ├── integration-governance.test.ts
     ├── integration-sideband.test.ts
+    ├── integration-streamable-http-session.test.ts
+    ├── sideband-shared-limiter.test.ts
     ├── e2e-full.test.ts
     └── e2e-python-sdk-sideband.test.ts
 ```
 
-(`cli.ts` and most behavior-bearing modules have colocated `*.test.ts` unit tests next to them; type-only/barrel files may not. Cross-cutting integration/e2e suites live in `__tests__/`.)
+(`cli.ts` and most behavior-bearing modules have colocated `*.test.ts` unit tests next to them; type-only/barrel files may not. `config-samples-guard.test.ts` exercises `scripts/validate-config-samples.mjs`. Cross-cutting integration/e2e suites live in `__tests__/`.)
 
 ## Build & Entry Points
 
@@ -116,7 +137,7 @@ interface McpForwarder {
 }
 ```
 
-Implementations: `UpstreamForwarder`, `SseUpstreamForwarder`, `StdioForwarder`, `GovernedForwarder` (decorator).
+Implementations: `StreamableHttpForwarder` (preferred; `UpstreamForwarder` is a deprecated alias), `SseUpstreamForwarder`, `StdioForwarder`, `GovernedForwarder` (decorator).
 
 **`CompiledPolicy`** (`policy/types.ts`) — engine-ready policy with pre-built matchers:
 
@@ -226,12 +247,12 @@ pnpm --filter @gethelio/proxy benchmark   # Run performance benchmark (tsx scrip
 
 ## CLI Commands
 
-| Command                                                                                                     | Description                                                                                        |
-| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `helio start [-c path] [--no-hot-reload]`                                                                   | Load config, compile policies, start proxy server (`--no-hot-reload` disables config-watch reload) |
-| `helio init [-o path] [-f]`                                                                                 | Scaffold helio.yaml with commented defaults                                                        |
-| `helio validate [-c path]`                                                                                  | Validate config + compile policies, report errors/warnings                                         |
-| `helio export [-c path] [-f format] [--tool] [--decision] [--reason] [--session] [--from] [--to] [--limit]` | Export audit records as JSON or CSV                                                                |
+| Command                                                                                                                 | Description                                                                                        |
+| ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `helio start [-c path] [--no-hot-reload]`                                                                               | Load config, compile policies, start proxy server (`--no-hot-reload` disables config-watch reload) |
+| `helio init [-o path] [-f]`                                                                                             | Scaffold helio.yaml with commented defaults                                                        |
+| `helio validate [-c path]`                                                                                              | Validate config + compile policies, report errors/warnings                                         |
+| `helio export [-c path] [-f format] [--budgets] [--tool] [--decision] [--reason] [--session] [--from] [--to] [--limit]` | Export audit records — or one budget's spend ledger via `--budgets <name>` — as JSON or CSV        |
 
 ## Performance Constraints
 

--- a/packages/proxy/src/budget/csv.test.ts
+++ b/packages/proxy/src/budget/csv.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { BUDGET_EVENT_CSV_HEADERS, budgetEventsToCsv } from './csv.js'
+import type { BudgetEventRecord } from './ledger.js'
+
+function eventRecord(overrides: Partial<BudgetEventRecord> = {}): BudgetEventRecord {
+  return {
+    id: 'event-1',
+    budget_name: 'daily-cap',
+    bucket_key: 'budget:daily-cap:global',
+    kind: 'spend',
+    amount: 25,
+    currency: 'USD',
+    tool_name: 'stripe_charge',
+    origin: 'mcp',
+    audit_record_id: 'audit-1',
+    timestamp: '2026-07-10T12:00:00.000Z',
+    timestamp_ms: 1_000_000,
+    created_at: '2026-07-10T12:00:00.012Z',
+    ...overrides,
+  }
+}
+
+describe('budgetEventsToCsv', () => {
+  it('emits the wire row columns as the header line, in wire order', () => {
+    expect(BUDGET_EVENT_CSV_HEADERS).toEqual([
+      'id',
+      'budget_name',
+      'bucket_key',
+      'kind',
+      'amount',
+      'currency',
+      'tool_name',
+      'origin',
+      'audit_record_id',
+      'timestamp',
+      'timestamp_ms',
+      'created_at',
+    ])
+    const csv = budgetEventsToCsv([eventRecord()])
+    expect(csv.split('\n')[0]).toBe(
+      'id,budget_name,bucket_key,kind,amount,currency,tool_name,origin,' +
+        'audit_record_id,timestamp,timestamp_ms,created_at',
+    )
+  })
+
+  it('serializes a full row: numbers unquoted, null audit_record_id as an empty cell', () => {
+    const csv = budgetEventsToCsv([eventRecord({ amount: 12.5, audit_record_id: null })])
+    expect(csv.split('\n')[1]).toBe(
+      'event-1,daily-cap,budget:daily-cap:global,spend,12.5,USD,stripe_charge,mcp,,' +
+        '2026-07-10T12:00:00.000Z,1000000,2026-07-10T12:00:00.012Z',
+    )
+  })
+
+  it('quotes fields containing commas, quotes, or newlines', () => {
+    const csv = budgetEventsToCsv([
+      eventRecord({ bucket_key: 'budget:daily-cap:session:a,b', tool_name: 'say "hi"\nnow' }),
+    ])
+    const row = csv.split('\n')[1] ?? ''
+    expect(row).toContain('"budget:daily-cap:session:a,b"')
+    expect(csv).toContain('"say ""hi""')
+  })
+
+  it('neutralizes formula-prefix values via the shared escape', () => {
+    const csv = budgetEventsToCsv([eventRecord({ tool_name: '=SUM(A1:A9)' })])
+    expect(csv.split('\n')[1]).toContain('"\'=SUM(A1:A9)"')
+  })
+
+  it('emits the header line only for zero events, without a trailing newline', () => {
+    const csv = budgetEventsToCsv([])
+    expect(csv).toBe(
+      'id,budget_name,bucket_key,kind,amount,currency,tool_name,origin,' +
+        'audit_record_id,timestamp,timestamp_ms,created_at',
+    )
+  })
+})

--- a/packages/proxy/src/budget/csv.ts
+++ b/packages/proxy/src/budget/csv.ts
@@ -1,0 +1,45 @@
+import { csvEscape } from '../audit/csv.js'
+import type { BudgetEventRecord } from './ledger.js'
+
+// ---------------------------------------------------------------------------
+// CSV export utilities for the budget spend ledger — shared between the CLI
+// export and the dashboard API export. Reuses the audit exporter's csvEscape
+// so RFC 4180 quoting and the formula-injection guard (CWE-1236) stay
+// single-sourced.
+// ---------------------------------------------------------------------------
+
+/** Column headers for CSV ledger export — the wire row, in wire order. */
+export const BUDGET_EVENT_CSV_HEADERS = [
+  'id',
+  'budget_name',
+  'bucket_key',
+  'kind',
+  'amount',
+  'currency',
+  'tool_name',
+  'origin',
+  'audit_record_id',
+  'timestamp',
+  'timestamp_ms',
+  'created_at',
+] as const
+
+/** Convert a single ledger event to a CSV row string. */
+function eventToRow(event: BudgetEventRecord): string {
+  return BUDGET_EVENT_CSV_HEADERS.map((h) => {
+    const val: unknown = event[h]
+    if (val === null || val === undefined) return ''
+    if (typeof val === 'number') return String(val)
+    if (typeof val === 'string') return csvEscape(val)
+    return ''
+  }).join(',')
+}
+
+/** Convert ledger events to a complete CSV string (header + rows). */
+export function budgetEventsToCsv(events: readonly BudgetEventRecord[]): string {
+  const lines: string[] = [BUDGET_EVENT_CSV_HEADERS.join(',')]
+  for (const e of events) {
+    lines.push(eventToRow(e))
+  }
+  return lines.join('\n')
+}

--- a/packages/proxy/src/budget/index.ts
+++ b/packages/proxy/src/budget/index.ts
@@ -2,6 +2,7 @@ export { compileBudgets, BudgetParseError } from './parser.js'
 export { BudgetEngine } from './engine.js'
 export { BudgetLedger } from './ledger.js'
 export type { BudgetLedgerOptions, BudgetEventRecord, BudgetEventsPage } from './ledger.js'
+export { BUDGET_EVENT_CSV_HEADERS, budgetEventsToCsv } from './csv.js'
 export type {
   BudgetChargeContext,
   BudgetCharge,

--- a/packages/proxy/src/budget/ledger.test.ts
+++ b/packages/proxy/src/budget/ledger.test.ts
@@ -6,7 +6,7 @@ import Database from 'better-sqlite3'
 import type { Database as DatabaseType } from 'better-sqlite3'
 import { BudgetLedger } from './ledger.js'
 import type { BudgetLedgerRow, BudgetMetaRow } from './engine.js'
-import { AuditStore } from '../audit/index.js'
+import { AuditStore, EXPORT_MAX_RECORDS } from '../audit/index.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -507,6 +507,113 @@ describe('BudgetLedger.listEvents', () => {
     const page = ledger.listEvents('no-such-budget', {})
     expect(page.events).toEqual([])
     expect(page.total).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bulk export (issue #155)
+// ---------------------------------------------------------------------------
+
+describe('BudgetLedger.listEventsForExport', () => {
+  it('exports newest first, same-ms ties by insert order', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([
+      ledgerRow({ timestamp_ms: 1_000, tool_name: 'oldest' }),
+      ledgerRow({ timestamp_ms: 3_000, tool_name: 'tie-first' }),
+      ledgerRow({ timestamp_ms: 3_000, tool_name: 'tie-second' }),
+      ledgerRow({ timestamp_ms: 2_000, tool_name: 'middle' }),
+    ])
+
+    const { events, total } = ledger.listEventsForExport('daily-cap')
+    expect(total).toBe(4)
+    expect(events.map((e) => e.tool_name)).toEqual(['tie-second', 'tie-first', 'middle', 'oldest'])
+  })
+
+  it('defaults the cap to EXPORT_MAX_RECORDS, above the 1000-row page clamp', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll(
+      Array.from({ length: 1_005 }, (_, i) => ledgerRow({ timestamp_ms: 10_000 + i })),
+    )
+
+    const { events, total } = ledger.listEventsForExport('daily-cap')
+    expect(total).toBe(1_005)
+    expect(events).toHaveLength(1_005)
+  })
+
+  it('clamps an oversized limit to EXPORT_MAX_RECORDS, keeping the newest rows', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll(
+      Array.from({ length: EXPORT_MAX_RECORDS + 5 }, (_, i) =>
+        ledgerRow({ timestamp_ms: 10_000 + i }),
+      ),
+    )
+
+    const { events, total } = ledger.listEventsForExport('daily-cap', 20_000)
+    expect(total).toBe(EXPORT_MAX_RECORDS + 5)
+    expect(events).toHaveLength(EXPORT_MAX_RECORDS)
+    expect(events[0]?.timestamp_ms).toBe(10_000 + EXPORT_MAX_RECORDS + 4)
+    expect(events[events.length - 1]?.timestamp_ms).toBe(10_005)
+  })
+
+  it('floors nonsense limits at one row instead of throwing', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([ledgerRow({ timestamp_ms: 1_000 }), ledgerRow({ timestamp_ms: 2_000 })])
+
+    const page = ledger.listEventsForExport('daily-cap', -3)
+    expect(page.events).toHaveLength(1)
+    expect(page.events[0]?.timestamp_ms).toBe(2_000)
+    expect(page.total).toBe(2)
+  })
+
+  it('keeps the newest rows when the limit truncates, with the full total', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll(Array.from({ length: 5 }, (_, i) => ledgerRow({ timestamp_ms: 1_000 + i })))
+
+    const { events, total } = ledger.listEventsForExport('daily-cap', 2)
+    expect(total).toBe(5)
+    expect(events.map((e) => e.timestamp_ms)).toEqual([1_004, 1_003])
+  })
+
+  it('exports history across epochs — a config reset does not hide old spend', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([
+      ledgerRow({ generation: 1, timestamp_ms: 1_000 }),
+      ledgerRow({ generation: 2, timestamp_ms: 2_000 }),
+    ])
+
+    const { events, total } = ledger.listEventsForExport('daily-cap')
+    expect(total).toBe(2)
+    expect(events.map((e) => e.timestamp_ms)).toEqual([2_000, 1_000])
+  })
+
+  it('returns an empty page for an unknown budget name', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([ledgerRow()])
+
+    const page = ledger.listEventsForExport('no-such-budget')
+    expect(page.events).toEqual([])
+    expect(page.total).toBe(0)
+  })
+
+  it('exports exactly the wire columns — no epoch, no generation', () => {
+    const { ledger } = createLedger()
+    ledger.commitAll([ledgerRow({ generation: 7 })])
+
+    const { events } = ledger.listEventsForExport('daily-cap')
+    expect(Object.keys(events[0] ?? {}).sort()).toEqual([
+      'amount',
+      'audit_record_id',
+      'bucket_key',
+      'budget_name',
+      'created_at',
+      'currency',
+      'id',
+      'kind',
+      'origin',
+      'timestamp',
+      'timestamp_ms',
+      'tool_name',
+    ])
   })
 })
 

--- a/packages/proxy/src/budget/ledger.ts
+++ b/packages/proxy/src/budget/ledger.ts
@@ -17,7 +17,7 @@
 import Database from 'better-sqlite3'
 import type { Database as DatabaseType, Statement } from 'better-sqlite3'
 import { randomUUID } from 'node:crypto'
-import { LIST_MAX_PAGE_SIZE } from '../audit/store.js'
+import { EXPORT_MAX_RECORDS, LIST_MAX_PAGE_SIZE } from '../audit/store.js'
 import type {
   BudgetLedgerRow,
   BudgetMetaRow,
@@ -411,6 +411,25 @@ export class BudgetLedger implements BudgetPersistence {
     )
     const offset = Math.max(Math.trunc(page.offset ?? 0), 0)
     const events = this.listEventsStmt.all(budgetName, limit, offset) as BudgetEventRecord[]
+    const { total } = this.countEventsStmt.get(budgetName) as { total: number }
+    return { events, total }
+  }
+
+  /**
+   * A budget's spend history for bulk export (issue #155). Unlike
+   * {@link listEvents}, which enforces the dashboard's page clamp, this path
+   * allows up to `EXPORT_MAX_RECORDS` in a single call. Newest first — the
+   * listing's own order, and the opposite of the audit export's oldest-first:
+   * the export takes no time filters, so a capped export must keep the most
+   * recent spend reachable (older rows age out via retention). Same
+   * unknown-name and epoch-spanning posture as the listing.
+   */
+  listEventsForExport(budgetName: string, limit?: number): BudgetEventsPage {
+    const clamped = Math.min(
+      Math.max(Math.trunc(limit ?? EXPORT_MAX_RECORDS), 1),
+      EXPORT_MAX_RECORDS,
+    )
+    const events = this.listEventsStmt.all(budgetName, clamped, 0) as BudgetEventRecord[]
     const { total } = this.countEventsStmt.get(budgetName) as { total: number }
     return { events, total }
   }

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -7,6 +7,8 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { AuditStore } from './audit/store.js'
 import type { AuditRecord } from './audit/types.js'
+import { BudgetLedger } from './budget/ledger.js'
+import type { BudgetLedgerRow } from './budget/engine.js'
 
 const CLI_PATH = join(import.meta.dirname, '../dist/cli.js')
 
@@ -1845,6 +1847,190 @@ budget:
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }
+    })
+
+    // --- helio export --budgets ---
+
+    describe('--budgets', () => {
+      function budgetRow(overrides: Partial<BudgetLedgerRow> = {}): BudgetLedgerRow {
+        return {
+          budget_name: 'daily-cap',
+          bucket_key: 'budget:daily-cap:global',
+          kind: 'spend',
+          amount: 25,
+          currency: 'USD',
+          tool_name: 'stripe_charge',
+          origin: 'mcp',
+          audit_record_id: 'audit-1',
+          timestamp: '2026-07-10T12:00:00.000Z',
+          timestamp_ms: 1_000_000,
+          generation: 1,
+          ...overrides,
+        }
+      }
+
+      /** Create a temp dir with a seeded budget ledger and helio.yaml. */
+      function setupBudgetExport(rows: BudgetLedgerRow[]) {
+        const dir = mkdtempSync(join(tmpdir(), 'helio-export-'))
+        const dbPath = join(dir, 'audit.db')
+        const configPath = join(dir, 'helio.yaml')
+
+        const store = new AuditStore({
+          path: dbPath,
+          retention: '90d',
+          includeResponses: true,
+          cleanupIntervalMs: 0,
+        })
+        const ledger = new BudgetLedger({ database: store.database })
+        ledger.commitAll(rows)
+        store.close()
+
+        writeFileSync(
+          configPath,
+          `
+version: "1"
+upstream:
+  url: "http://localhost:8080/mcp"
+dashboard:
+  enabled: false
+audit:
+  path: "${dbPath}"
+  retention: "90d"
+  include_responses: true
+`,
+        )
+
+        return { dir, configPath }
+      }
+
+      const BUDGET_CSV_HEADER =
+        'id,budget_name,bucket_key,kind,amount,currency,tool_name,origin,' +
+        'audit_record_id,timestamp,timestamp_ms,created_at'
+
+      it('exports a budget ledger as CSV, newest first', async () => {
+        const { dir, configPath } = setupBudgetExport([
+          budgetRow({ timestamp_ms: 1_000, tool_name: 'older' }),
+          budgetRow({ timestamp_ms: 2_000, tool_name: 'newer' }),
+        ])
+
+        try {
+          const { code, stdout, stderr } = await runCli([
+            'export',
+            '-c',
+            configPath,
+            '--budgets',
+            'daily-cap',
+            '-f',
+            'csv',
+          ])
+          expect(code).toBe(0)
+          expect(stderr).toContain('Exported 2 of 2 records')
+
+          const lines = stdout.trim().split('\n')
+          expect(lines[0]).toBe(BUDGET_CSV_HEADER)
+          expect(lines[1]).toContain('newer')
+          expect(lines[2]).toContain('older')
+        } finally {
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
+
+      it('exports a budget ledger as a bare JSON array', async () => {
+        const { dir, configPath } = setupBudgetExport([
+          budgetRow({ timestamp_ms: 1_000, tool_name: 'older' }),
+          budgetRow({ timestamp_ms: 2_000, tool_name: 'newer' }),
+        ])
+
+        try {
+          const { code, stdout, stderr } = await runCli([
+            'export',
+            '-c',
+            configPath,
+            '--budgets',
+            'daily-cap',
+            '-f',
+            'json',
+          ])
+          expect(code).toBe(0)
+          expect(stderr).toContain('Exported 2 of 2 records')
+
+          const events = JSON.parse(stdout) as Array<Record<string, unknown>>
+          expect(events.map((e) => e['tool_name'])).toEqual(['newer', 'older'])
+          expect(events[0]).not.toHaveProperty('epoch')
+        } finally {
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
+
+      it('rejects --budgets combined with audit filter flags', async () => {
+        const { dir, configPath } = setupBudgetExport([budgetRow()])
+
+        try {
+          const { code, stderr } = await runCli([
+            'export',
+            '-c',
+            configPath,
+            '--budgets',
+            'daily-cap',
+            '--decision',
+            'deny',
+          ])
+          expect(code).toBe(1)
+          expect(stderr).toContain('--budgets cannot be combined')
+        } finally {
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
+
+      it('keeps the newest rows when --limit truncates', async () => {
+        const { dir, configPath } = setupBudgetExport([
+          budgetRow({ timestamp_ms: 1_000, tool_name: 'oldest' }),
+          budgetRow({ timestamp_ms: 2_000, tool_name: 'middle' }),
+          budgetRow({ timestamp_ms: 3_000, tool_name: 'newest' }),
+        ])
+
+        try {
+          const { code, stdout, stderr } = await runCli([
+            'export',
+            '-c',
+            configPath,
+            '--budgets',
+            'daily-cap',
+            '-f',
+            'json',
+            '--limit',
+            '2',
+          ])
+          expect(code).toBe(0)
+          expect(stderr).toContain('Exported 2 of 3 records')
+
+          const events = JSON.parse(stdout) as Array<Record<string, unknown>>
+          expect(events.map((e) => e['tool_name'])).toEqual(['newest', 'middle'])
+        } finally {
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
+
+      it('exports an empty artifact for an unknown budget name', async () => {
+        const { dir, configPath } = setupBudgetExport([budgetRow()])
+
+        try {
+          const { code, stdout, stderr } = await runCli([
+            'export',
+            '-c',
+            configPath,
+            '--budgets',
+            'no-such-budget',
+            '-f',
+            'csv',
+          ])
+          expect(code).toBe(0)
+          expect(stderr).toContain('Exported 0 of 0 records')
+          expect(stdout.trim()).toBe(BUDGET_CSV_HEADER)
+        } finally {
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
     })
   })
 })

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -24,7 +24,7 @@ import {
 } from './approval/index.js'
 import { RateLimiter } from './policy/index.js'
 import { SpendLimiter } from './policy/index.js'
-import { BudgetEngine, BudgetLedger, compileBudgets } from './budget/index.js'
+import { BudgetEngine, BudgetLedger, budgetEventsToCsv, compileBudgets } from './budget/index.js'
 import { parseDuration } from './config/schema.js'
 import { createDashboardAppWithLifecycle, DashboardEventBus } from './dashboard/index.js'
 import type { AuditRecord } from './audit/index.js'
@@ -581,6 +581,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
         budgets: {
           listStates: () => budgetEngine.listStates(),
           listEvents: (name, page) => budgetLedger.listEvents(name, page),
+          listEventsForExport: (name, limit) => budgetLedger.listEventsForExport(name, limit),
         },
       },
       {
@@ -819,6 +820,7 @@ async function validateCommand(configPath: string): Promise<void> {
 interface ExportOptions {
   config: string
   format: string
+  budgets?: string
   tool?: string
   decision?: string
   reason?: string
@@ -840,6 +842,28 @@ async function exportCommand(opts: ExportOptions): Promise<void> {
   }
   const limit = Math.min(parsedLimit, EXPORT_MAX_RECORDS)
 
+  // The audit filter flags have no meaning against the budget ledger; a
+  // silently ignored filter would make a truncated-looking export lie.
+  if (opts.budgets !== undefined) {
+    const conflicting = (
+      [
+        ['--tool', opts.tool],
+        ['--decision', opts.decision],
+        ['--reason', opts.reason],
+        ['--session', opts.session],
+        ['--from', opts.from],
+        ['--to', opts.to],
+      ] as const
+    ).filter(([, value]) => value !== undefined)
+    if (conflicting.length > 0) {
+      console.error(
+        'Error: --budgets cannot be combined with audit filters ' +
+          `(${conflicting.map(([flag]) => flag).join(', ')})`,
+      )
+      process.exit(1)
+    }
+  }
+
   let config
   try {
     config = await loadConfig(opts.config)
@@ -860,6 +884,22 @@ async function exportCommand(opts: ExportOptions): Promise<void> {
   })
 
   try {
+    // Budget ledger export (issue #155): same database file, the ledger's
+    // own tables. Newest first — the ledger export's order everywhere.
+    if (opts.budgets !== undefined) {
+      const ledger = new BudgetLedger({ database: store.database })
+      const page = ledger.listEventsForExport(opts.budgets, limit)
+
+      if (opts.format === 'csv') {
+        console.log(budgetEventsToCsv(page.events))
+      } else {
+        console.log(JSON.stringify(page.events, null, 2))
+      }
+
+      console.error(`Exported ${String(page.events.length)} of ${String(page.total)} records`)
+      return
+    }
+
     const result = store.listForExport(
       {
         tool_name: opts.tool,
@@ -998,9 +1038,10 @@ program
 
 program
   .command('export')
-  .description('Export audit records to JSON or CSV')
+  .description('Export audit records or a budget ledger to JSON or CSV')
   .option('-c, --config <path>', 'Path to helio.yaml', DEFAULT_CONFIG_PATH)
   .option('-f, --format <format>', 'Output format: json or csv', 'json')
+  .option('--budgets <name>', 'Export the named budget ledger instead of the audit trail')
   .option('--tool <name>', 'Filter by tool name')
   .option('--decision <decision>', 'Filter by policy decision')
   .option('--reason <reason>', 'Filter by block reason')

--- a/packages/proxy/src/dashboard/api.test.ts
+++ b/packages/proxy/src/dashboard/api.test.ts
@@ -856,6 +856,7 @@ function budgetFixture(configs: Parameters<typeof compileBudgets>[0]) {
     listStates: () => engine.listStates(),
     listEvents: (name: string, page: { limit: number; offset: number }) =>
       ledger.listEvents(name, page),
+    listEventsForExport: (name: string, limit: number) => ledger.listEventsForExport(name, limit),
   }
   cleanup.push(engine, auditStore)
   return { engine, ledger, budgets }
@@ -1050,6 +1051,164 @@ describe('GET /api/budgets/:name/events', () => {
     const { get } = setup({ apiSecret: 'test-secret' })
     const res = await get('/api/budgets/daily-cap/events')
     expect(res.status).toBe(401)
+  })
+})
+
+describe('GET /api/budgets/:name/events/export', () => {
+  function seedExportEvents(ledger: BudgetLedger, count: number) {
+    ledger.commitAll(
+      Array.from({ length: count }, (_, i) => ({
+        budget_name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend' as const,
+        amount: 5,
+        currency: 'USD',
+        tool_name: `tool-${String(i)}`,
+        origin: 'mcp',
+        audit_record_id: `audit-${String(i)}`,
+        timestamp: new Date(1_000_000 + i).toISOString(),
+        timestamp_ms: 1_000_000 + i,
+        generation: 1,
+      })),
+    )
+  }
+
+  it('exports as JSON by default: a bare newest-first array as an attachment', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedExportEvents(ledger, 3)
+
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets/daily-cap/events/export')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(res.headers.get('content-disposition')).toBe(
+      'attachment; filename="helio-budget-daily-cap-events.json"',
+    )
+    const body = (await res.json()) as Array<Record<string, unknown>>
+    expect(Array.isArray(body)).toBe(true)
+    expect(body.map((e) => e['tool_name'])).toEqual(['tool-2', 'tool-1', 'tool-0'])
+    expect(body[0]).not.toHaveProperty('epoch')
+  })
+
+  it('exports as CSV when format=csv, with the wire header row', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedExportEvents(ledger, 2)
+
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets/daily-cap/events/export?format=csv')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/csv')
+    expect(res.headers.get('content-disposition')).toBe(
+      'attachment; filename="helio-budget-daily-cap-events.csv"',
+    )
+    const lines = (await res.text()).split('\n')
+    expect(lines[0]).toBe(
+      'id,budget_name,bucket_key,kind,amount,currency,tool_name,origin,' +
+        'audit_record_id,timestamp,timestamp_ms,created_at',
+    )
+    // Newest first in the CSV rows too, not only in the JSON body.
+    expect(lines[1]).toContain('tool-1')
+    expect(lines[2]).toContain('tool-0')
+    expect(lines).toHaveLength(3)
+  })
+
+  it('exports history across epochs, newest first', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    ledger.commitAll([
+      {
+        budget_name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend' as const,
+        amount: 5,
+        currency: 'USD',
+        tool_name: 'old-epoch',
+        origin: 'mcp',
+        audit_record_id: 'audit-old',
+        timestamp: new Date(1_000).toISOString(),
+        timestamp_ms: 1_000,
+        generation: 1,
+      },
+      {
+        budget_name: 'daily-cap',
+        bucket_key: 'budget:daily-cap:global',
+        kind: 'spend' as const,
+        amount: 5,
+        currency: 'USD',
+        tool_name: 'new-epoch',
+        origin: 'mcp',
+        audit_record_id: 'audit-new',
+        timestamp: new Date(2_000).toISOString(),
+        timestamp_ms: 2_000,
+        generation: 2,
+      },
+    ])
+
+    const { get } = setup({ budgets })
+    const res = await get('/api/budgets/daily-cap/events/export')
+    const body = (await res.json()) as Array<Record<string, unknown>>
+    expect(body.map((e) => e['tool_name'])).toEqual(['new-epoch', 'old-epoch'])
+  })
+
+  it('exports above the listing page cap and keeps the newest rows under limit', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedExportEvents(ledger, 1_200)
+
+    const { get } = setup({ budgets })
+    const full = await get('/api/budgets/daily-cap/events/export')
+    const fullBody = (await full.json()) as Array<Record<string, unknown>>
+    expect(fullBody).toHaveLength(1_200)
+
+    const partial = await get('/api/budgets/daily-cap/events/export?limit=1100')
+    const partialBody = (await partial.json()) as Array<Record<string, unknown>>
+    expect(partialBody).toHaveLength(1_100)
+    expect(partialBody[0]?.['tool_name']).toBe('tool-1199')
+    expect(partialBody[partialBody.length - 1]?.['tool_name']).toBe('tool-100')
+  })
+
+  it('exports an empty artifact for an unknown name, sanitizing the filename', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedExportEvents(ledger, 1)
+
+    const { get } = setup({ budgets })
+    const hostile = await get('/api/budgets/bad%22name%0D%0Aevil/events/export')
+    expect(hostile.status).toBe(200)
+    expect(hostile.headers.get('content-disposition')).toBe(
+      'attachment; filename="helio-budget-badnameevil-events.json"',
+    )
+    expect(await hostile.json()).toEqual([])
+
+    const empty = await get('/api/budgets/%2A%2A/events/export')
+    expect(empty.headers.get('content-disposition')).toBe(
+      'attachment; filename="helio-budget-events.json"',
+    )
+  })
+
+  it('serves an empty export when the budgets dep is absent', async () => {
+    const { get } = setup()
+    const json = await get('/api/budgets/daily-cap/events/export')
+    expect(json.status).toBe(200)
+    expect(await json.json()).toEqual([])
+
+    const csv = await get('/api/budgets/daily-cap/events/export?format=csv')
+    expect(csv.status).toBe(200)
+    expect(await csv.text()).toBe(
+      'id,budget_name,bucket_key,kind,amount,currency,tool_name,origin,' +
+        'audit_record_id,timestamp,timestamp_ms,created_at',
+    )
+  })
+
+  it('requires auth when a secret is set, like the audit export', async () => {
+    const { ledger, budgets } = budgetFixture([stripeBudgetConfig])
+    seedExportEvents(ledger, 1)
+
+    const { get } = setup({ budgets, apiSecret: 'test-secret' })
+    const denied = await get('/api/budgets/daily-cap/events/export')
+    expect(denied.status).toBe(401)
+
+    const allowed = await get('/api/budgets/daily-cap/events/export', {
+      authorization: 'Bearer test-secret',
+    })
+    expect(allowed.status).toBe(200)
   })
 })
 

--- a/packages/proxy/src/dashboard/api.ts
+++ b/packages/proxy/src/dashboard/api.ts
@@ -25,6 +25,7 @@ import { DashboardSessionStore } from './session.js'
 import type { AdapterLivenessEntry } from '../sideband/governance-service.js'
 import type { BudgetState } from '../budget/engine.js'
 import type { BudgetEventsPage } from '../budget/ledger.js'
+import { budgetEventsToCsv } from '../budget/csv.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,15 +47,18 @@ export interface DashboardAppDeps {
    */
   readonly adapterLiveness?: { listAdapters(): AdapterLivenessEntry[] }
   /**
-   * Budget read surface for `GET /api/budgets` and
-   * `GET /api/budgets/:name/events` (issue #14) — narrow views of the
-   * BudgetEngine (live pot states) and BudgetLedger (spend history).
-   * Optional on the adapterLiveness pattern: absent (direct embedders),
-   * both endpoints serve empty lists with 200.
+   * Budget read surface for `GET /api/budgets`,
+   * `GET /api/budgets/:name/events`, and
+   * `GET /api/budgets/:name/events/export` (issues #14, #155) — narrow
+   * views of the BudgetEngine (live pot states) and BudgetLedger (spend
+   * history). Optional on the adapterLiveness pattern: absent (direct
+   * embedders), the listings serve empty lists and the export serves an
+   * empty artifact, all with 200.
    */
   readonly budgets?: {
     listStates(): BudgetState[]
     listEvents(name: string, page: { limit: number; offset: number }): BudgetEventsPage
+    listEventsForExport(name: string, limit: number): BudgetEventsPage
   }
 }
 
@@ -150,6 +154,11 @@ const auditQuerySchema = z.object({
 const budgetEventsQuerySchema = z.object({
   limit: clampedQueryInt(50, 1, LIST_MAX_PAGE_SIZE),
   offset: clampedQueryInt(0, 0, Number.MAX_SAFE_INTEGER),
+})
+
+const budgetEventsExportQuerySchema = z.object({
+  format: z.preprocess((value) => (value === 'csv' ? 'csv' : 'json'), z.enum(['json', 'csv'])),
+  limit: clampedQueryInt(EXPORT_MAX_RECORDS, 1, EXPORT_MAX_RECORDS),
 })
 
 const analyticsQuerySchema = z.object({
@@ -601,6 +610,39 @@ export function createDashboardAppWithLifecycle(
       total: page.total,
       limit: query.limit,
       offset: query.offset,
+    })
+  })
+
+  // Bulk ledger export (issue #155) — the audit export's contract
+  // (attachment download, bare body, EXPORT_MAX_RECORDS cap) with the
+  // listing's own semantics: newest first, history across config resets,
+  // unknown names and an absent dep export empty. Newest-first is the
+  // deliberate opposite of the audit export: with no time filters, a capped
+  // export must keep the most recent spend reachable. The filename embeds
+  // the budget name stripped to the config-name charset so the arbitrary
+  // route param can never reach the header raw.
+  app.get('/api/budgets/:name/events/export', (c) => {
+    const query = budgetEventsExportQuerySchema.parse(c.req.query())
+    const name = c.req.param('name')
+    const page = budgets?.listEventsForExport(name, query.limit) ?? { events: [], total: 0 }
+
+    const safeName = name.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 64)
+    const filename = safeName ? `helio-budget-${safeName}-events` : 'helio-budget-events'
+
+    if (query.format === 'csv') {
+      return new Response(budgetEventsToCsv(page.events), {
+        headers: {
+          'content-type': 'text/csv; charset=utf-8',
+          'content-disposition': `attachment; filename="${filename}.csv"`,
+        },
+      })
+    }
+
+    return new Response(JSON.stringify(page.events, null, 2), {
+      headers: {
+        'content-type': 'application/json',
+        'content-disposition': `attachment; filename="${filename}.json"`,
+      },
     })
   })
 


### PR DESCRIPTION
## Summary

- `GET /api/budgets/:name/events/export?format=csv|json` serves one budget's ledger as an attachment download: capped at `EXPORT_MAX_RECORDS` (10k), newest-first, spanning config resets. Unknown names and an absent budgets dep export an empty artifact with 200. The filename embeds the budget name sanitized to the config-name charset (`helio-budget-<name>-events.csv`).
- The Budgets view gains per-pot CSV/JSON export buttons using the audit page's blob-download idiom (cookie auth, per-card busy and error state).
- `helio export --budgets <name>` produces the same artifact offline from the database file, with the proxy stopped or the dashboard disabled. Combining it with the audit filter flags is a hard error, and stderr reports `Exported N of M records`.
- Docs: both "A CSV export of the ledger is not available yet" sentences are replaced with real documentation (new endpoint section and both non-JSON exception lists in sideband-api.md; the audit.md CLI section documents `--budgets`), plus a CHANGELOG entry under Unreleased.
- AGENTS.md refreshed in both packages: proxy command table and module tree (the `budget/` subtree was missing entirely), dashboard endpoint table, and broader staleness fixes.

## Decisions

- Newest-first deliberately diverges from the audit export's oldest-first: this export has no time filters, so a capped export must keep recent spend reachable. The contrast is documented in the endpoint section.
- The CLI variant and the UI control both ship here for full three-surface parity with the audit export.
- `DashboardAppDeps.budgets` gains a required `listEventsForExport`, a compile-time change for direct embedders riding the already-breaking v0.11.0.
- No time filters on the export: #210 (filed during planning) tracks `from`/`to` for pots that exceed 10k rows within retention.

## Testing

- 29 new tests, all written red-first: 8 ledger, 5 CSV module, 7 endpoint, 4 dashboard UI, 5 CLI (one-shot dist spawns). Proxy suite 2190 to 2215, dashboard 344 to 348, samples 79 unchanged.
- Full gate green: lint, format:check, workspace typecheck, build, test, docs:check:samples.
- Live-verified from a local build: endpoint headers, both formats, 401 on a wrong bearer, hostile-name filename sanitization, and the offline CLI with the proxy stopped.
- One internal multi-angle review (APPROVE) and one external round (two P2 staleness findings fixed, one P3 order assertion added, one P3 idiom nit declined for sibling-method consistency).

Closes #155