### PR TITLE
fix(transport): compare the Content-Type essence on inbound requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Security
+
+- **The MCP transports now match the `Content-Type` essence rather than
+  searching the header for a substring (GHSA-qm2p-4gh2-q6pm).** `/mcp` and
+  `/sse` required `application/json` by testing whether the raw header
+  contained that string, so a value such as
+  `text/plain;x=application/json` satisfied the check. Media types in that
+  family are CORS-safelisted, meaning a browser sends them cross-site with
+  no preflight and no cooperation from the proxy, so a web page an operator
+  visited could reach the MCP endpoint and invoke any tool their policy
+  permitted. Policy evaluation was never bypassed: deny rules, budgets, and
+  approvals applied to these calls exactly as to any other, and the
+  responses were not readable cross-origin. Both transports now compare the
+  media type essence (the part before `;`, case insensitively, per RFC
+  9110), which also makes an uppercase `APPLICATION/JSON` acceptable as the
+  RFC requires. Clients sending a correct `Content-Type` are unaffected;
+  any client relying on a non-JSON media type now receives the 415 it
+  should always have received. All releases through 0.11.0 are affected;
+  upgrading is recommended.
+
 ## [0.11.0] - 2026-07-27
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,6 +51,12 @@ The split exists because an agent on the main MCP port must not be able to self-
 
 The SDK sideband port (default `127.0.0.1:3200`, when `sdk.enabled: true`) is a third internal API for evidence submission from the Python SDK. See `docs/configuration.md` for details.
 
+### Browser-originated traffic on the agent edge
+
+Because the agent edge is bound to loopback by default, the browser on the same machine is part of its threat model: a page an operator visits can address `localhost` even though it cannot read what comes back. Helio requires `Content-Type: application/json` on `/mcp` and `/sse`, and compares the media type essence rather than searching the header for a substring. That distinction is the control: `text/plain`, `multipart/form-data`, and `application/x-www-form-urlencoded` are CORS-safelisted and cross a browser without a preflight, while `application/json` always triggers one that Helio does not answer. Loosening that check to a substring or prefix match re-opens the endpoint to any web page, so treat it as a security boundary rather than protocol hygiene.
+
+Validating the `Origin` header on these transports is tracked separately in issue #213, along with the residual gap that stream establishment on `/sse` carries no `Origin` from any browser.
+
 ## Scope
 
 The following are in scope for security reports:

--- a/packages/proxy/AGENTS.md
+++ b/packages/proxy/AGENTS.md
@@ -26,6 +26,7 @@ src/
 │   ├── streamable-http.ts   → Streamable HTTP MCP transport (primary)
 │   ├── sse.ts               → SSE MCP transport (legacy compat)
 │   ├── stdio-wrapper.ts     → Stdio transport for local MCP servers
+│   ├── content-type.ts      → Media type essence match for the inbound JSON requirement (substring matching is a cross-site hole)
 │   ├── forward-headers.ts   → Allowlist for headers crossing the proxy to upstream (authorization + `x-*` allowlist)
 │   └── response-normalizer.ts → Normalize an upstream forwarding outcome (success/error) into a JSON-RPC response
 ├── upstream/

--- a/packages/proxy/src/transport/content-type.test.ts
+++ b/packages/proxy/src/transport/content-type.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { isJsonContentType } from './content-type.js'
+
+describe('isJsonContentType', () => {
+  it.each([
+    'application/json',
+    'application/json; charset=utf-8',
+    'application/json;charset=utf-8',
+  ])('accepts %s', (header) => {
+    expect(isJsonContentType(header)).toBe(true)
+  })
+
+  it.each(['APPLICATION/JSON', 'Application/Json', 'application/JSON; charset=UTF-8'])(
+    'accepts %s, since media types compare case insensitively',
+    (header) => {
+      expect(isJsonContentType(header)).toBe(true)
+    },
+  )
+
+  it.each(['  application/json  ', '\tapplication/json', 'application/json '])(
+    'accepts %s, ignoring surrounding whitespace',
+    (header) => {
+      expect(isJsonContentType(header)).toBe(true)
+    },
+  )
+
+  // The vulnerability class this function exists to close: these media types
+  // are CORS-safelisted, so a browser sends them cross-site with no preflight.
+  // Smuggling the JSON token into a parameter must not satisfy the check.
+  it.each([
+    'text/plain;x=application/json',
+    'text/plain; charset=application/json',
+    'multipart/form-data; boundary=application/json',
+    'application/x-www-form-urlencoded;v=application/json',
+    'text/plain;application/json',
+    'text/plain;charset=utf-8',
+    'multipart/form-data; boundary=abc123',
+  ])('rejects CORS-safelisted %s', (header) => {
+    expect(isJsonContentType(header)).toBe(false)
+  })
+
+  it.each([undefined, '', '   ', ';', 'application/json extra', 'xapplication/json'])(
+    'rejects %s',
+    (header) => {
+      expect(isJsonContentType(header)).toBe(false)
+    },
+  )
+
+  it('rejects the +json structured suffix family, which MCP does not use', () => {
+    expect(isJsonContentType('application/ld+json')).toBe(false)
+    expect(isJsonContentType('application/problem+json')).toBe(false)
+  })
+
+  // Fetch comma-joins duplicate headers, so a caller cannot pair a safelisted
+  // media type with a second application/json value to slip past the check.
+  it.each(['application/json, text/plain', 'text/plain, application/json'])(
+    'rejects comma-joined duplicate header %s',
+    (header) => {
+      expect(isJsonContentType(header)).toBe(false)
+    },
+  )
+})

--- a/packages/proxy/src/transport/content-type.ts
+++ b/packages/proxy/src/transport/content-type.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether a `Content-Type` header names JSON.
+ *
+ * Compares the media type essence — everything before the first `;`, case
+ * insensitively, per RFC 9110 — rather than searching the raw header for a
+ * substring.
+ *
+ * The distinction is load bearing on the agent edge. `text/plain`,
+ * `multipart/form-data`, and `application/x-www-form-urlencoded` are
+ * CORS-safelisted, so a browser sends them cross-site with no preflight and
+ * no cooperation from this server, while `application/json` is not and always
+ * triggers one. A substring match is satisfied by hiding the token in a
+ * parameter (`text/plain;x=application/json`), which passes the JSON
+ * requirement while keeping the request preflight-free — putting the MCP
+ * endpoint within reach of any web page the operator happens to visit.
+ */
+export function isJsonContentType(header: string | undefined): boolean {
+  const [essence = ''] = (header ?? '').split(';')
+  return essence.trim().toLowerCase() === 'application/json'
+}

--- a/packages/proxy/src/transport/sse.test.ts
+++ b/packages/proxy/src/transport/sse.test.ts
@@ -254,6 +254,52 @@ describe('SSE transport', () => {
     expect(res.status).toBe(415)
   })
 
+  // See the matching case in streamable-http.test.ts: a CORS-safelisted
+  // Content-Type reaches the endpoint from a browser without a preflight, so
+  // the JSON requirement has to compare the essence rather than search for a
+  // substring the caller can hide in a parameter.
+  it.each([
+    'text/plain;x=application/json',
+    'text/plain; charset=application/json',
+    'multipart/form-data; boundary=application/json',
+    'application/x-www-form-urlencoded;v=application/json',
+    'text/plain;charset=utf-8',
+  ])('returns 415 for CORS-safelisted Content-Type %s', async (contentType) => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const sseRes = await app.request('/sse')
+    const events = await readSseEvents(sseRes, 1)
+    const sessionId = extractSessionId(events[0]?.data ?? '')
+
+    const res = await app.request(`/sse?sessionId=${sessionId}`, {
+      method: 'POST',
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      headers: { 'Content-Type': contentType },
+    })
+
+    expect(res.status).toBe(415)
+    expect(forwarder.calls).toHaveLength(0)
+  })
+
+  it('accepts Content-Type with a charset parameter', async () => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const sseRes = await app.request('/sse')
+    const events = await readSseEvents(sseRes, 1)
+    const sessionId = extractSessionId(events[0]?.data ?? '')
+
+    const res = await app.request(`/sse?sessionId=${sessionId}`, {
+      method: 'POST',
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    })
+
+    expect(res.status).toBe(202)
+    expect(forwarder.calls).toHaveLength(1)
+  })
+
   it('returns -32700 for malformed JSON', async () => {
     const forwarder = createMockForwarder(okResponse)
     const app = mountRoute(forwarder)

--- a/packages/proxy/src/transport/sse.ts
+++ b/packages/proxy/src/transport/sse.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { PARSE_ERROR, INVALID_REQUEST, makeJsonRpcError } from '../mcp/types.js'
 import type { McpForwarder, McpRequest } from '../mcp/types.js'
 import { parseJsonRpcRequest } from '../mcp/validation.js'
+import { isJsonContentType } from './content-type.js'
 import { buildForwardHeaders } from './forward-headers.js'
 import { normalizeUpstreamOutcome } from './response-normalizer.js'
 
@@ -120,8 +121,7 @@ export function createSseRoute(forwarder: McpForwarder, options: SseRouteOptions
     }
 
     // Require JSON content type
-    const contentType = c.req.header('content-type') ?? ''
-    if (!contentType.includes('application/json')) {
+    if (!isJsonContentType(c.req.header('content-type'))) {
       return c.json(
         makeJsonRpcError(null, INVALID_REQUEST, 'Content-Type must be application/json'),
         415,

--- a/packages/proxy/src/transport/streamable-http.test.ts
+++ b/packages/proxy/src/transport/streamable-http.test.ts
@@ -223,6 +223,65 @@ describe('streamable-http transport', () => {
     expect(forwarder.calls).toHaveLength(0)
   })
 
+  // A CORS-safelisted Content-Type needs no preflight, so a browser can send
+  // one cross-site without the target's cooperation. Matching the header as a
+  // substring let such a request satisfy the JSON requirement by smuggling the
+  // token into a parameter, putting the MCP endpoint within reach of any web
+  // page. The essence (the part before ';') is what must be compared.
+  it.each([
+    'text/plain;x=application/json',
+    'text/plain; charset=application/json',
+    'multipart/form-data; boundary=application/json',
+    'application/x-www-form-urlencoded;v=application/json',
+    // The ordinary form of a safelisted type, which carries no smuggled token.
+    // Guards against a future rewrite that admits the essence itself.
+    'text/plain;charset=utf-8',
+  ])('returns 415 for CORS-safelisted Content-Type %s', async (contentType) => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const res = await app.request('/mcp', {
+      method: 'POST',
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      headers: { 'Content-Type': contentType },
+    })
+
+    expect(res.status).toBe(415)
+    expect(forwarder.calls).toHaveLength(0)
+  })
+
+  it.each([
+    'application/json',
+    'application/json; charset=utf-8',
+    'APPLICATION/JSON',
+    '  application/json  ',
+  ])('accepts Content-Type %s', async (contentType) => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const res = await app.request('/mcp', {
+      method: 'POST',
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      headers: { 'Content-Type': contentType },
+    })
+
+    expect(res.status).toBe(200)
+    expect(forwarder.calls).toHaveLength(1)
+  })
+
+  it('returns 415 when Content-Type is absent', async () => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const res = await app.request('/mcp', {
+      method: 'POST',
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    })
+
+    expect(res.status).toBe(415)
+    expect(forwarder.calls).toHaveLength(0)
+  })
+
   it('returns -32700 parse error for malformed JSON', async () => {
     const forwarder = createMockForwarder(okResponse)
     const app = mountRoute(forwarder)

--- a/packages/proxy/src/transport/streamable-http.ts
+++ b/packages/proxy/src/transport/streamable-http.ts
@@ -3,6 +3,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { PARSE_ERROR, INVALID_REQUEST, makeJsonRpcError } from '../mcp/types.js'
 import type { McpForwarder, McpRequest } from '../mcp/types.js'
 import { parseJsonRpcRequest } from '../mcp/validation.js'
+import { isJsonContentType } from './content-type.js'
 import { buildForwardHeaders } from './forward-headers.js'
 import { normalizeUpstreamOutcome } from './response-normalizer.js'
 
@@ -32,8 +33,7 @@ export function createStreamableHttpRoute(
 
   app.post('/', async (c) => {
     // Require JSON content type
-    const contentType = c.req.header('content-type') ?? ''
-    if (!contentType.includes('application/json')) {
+    if (!isJsonContentType(c.req.header('content-type'))) {
       return c.json(
         makeJsonRpcError(null, INVALID_REQUEST, 'Content-Type must be application/json'),
         415,


### PR DESCRIPTION
## Summary

The MCP transports required a JSON request body by testing whether the `Content-Type` header
contained the string `application/json`. That test is satisfied by a value like
`text/plain;x=application/json`, whose media type essence is `text/plain`, one of the three
CORS-safelisted types a browser sends cross-origin without a preflight.

`application/json` is not safelisted and always triggers a preflight the proxy does not answer,
so the JSON requirement was in practice the only control keeping browser traffic off `/mcp` and
`/sse`, and a substring test did not hold it.

Both transports now compare the media type essence: the portion before the first `;`, trimmed
and lowercased, per RFC 9110. The comparison moves into a shared `isJsonContentType()` helper
so the two transports cannot drift apart. As a side effect an uppercase `APPLICATION/JSON` is
now accepted, which the RFC requires and the substring test rejected.

Tracked as GHSA-qm2p-4gh2-q6pm. Released in 0.11.1.

## Testing

Written test first; every case was watched failing before the fix existed.

- `content-type.test.ts` covers the predicate directly: safelisted essences, smuggled tokens,
  casing, whitespace, absent and empty headers, comma-joined duplicates, and the `+json`
  structured suffix family.
- Both transport suites assert 415 and, critically, that the forwarder is never called, so a
  regression cannot pass by returning the right status while still forwarding.
- Verified against a running proxy and a real browser: the cross-site probe that previously
  produced audit records for executed tool calls now produces none, while an
  `application/json` client is unaffected.

Full gate green: 2256 proxy tests, 348 dashboard, 47 Python, plus lint, typecheck,
format:check, docs drift, and config samples at the 79/78/1 baseline.

## Notes for review

- Policy evaluation was never bypassed by the old behavior. Deny rules, budgets, and approval
  gates applied to these requests as to any other, so the exposure was an unauthenticated
  caller choosing among policy-allowed tools rather than an escalation past the rules.
- The four remaining `.includes()` content type checks under `upstream/` parse upstream
  responses rather than caller input, and are deliberately out of scope. A hostile upstream
  controls its own headers and gains nothing from smuggling.
- `Origin` header validation on these transports, and the related gap that `GET /sse` carries
  no `Origin` from any browser, remain open and are tracked in #213. `SECURITY.md` says so.
