### PR TITLE
fix(deps): clear the high advisories blocking the audit gate

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -77,6 +77,10 @@ Action versions are pinned to major version tags (e.g., `@v4`). Dependabot propo
 
 The `pnpm-workspace.yaml` file includes overrides to patch known vulnerabilities in transitive dependencies when upstream packages haven't released fixes yet.
 
-Current security-patch overrides include `axios` pinned at `1.18.1` for its Node-adapter advisories inherited via `@slack/web-api`, `postcss` at `8.5.18` for `GHSA-6g55-p6wh-862q` / `GHSA-r28c-9q8g-f849`, and `brace-expansion >=3.0.0` lifted to `5.0.8` for `GHSA-mh99-v99m-4gvg` (the 1.x line has no patched release and is a tracked audit ignore, #205).
+Current security-patch overrides include `axios` pinned at `1.18.1` for its Node-adapter advisories inherited via `@slack/web-api`, `postcss` at `8.5.18` for `GHSA-6g55-p6wh-862q` / `GHSA-r28c-9q8g-f849`, `fast-uri` at `3.1.5` for `GHSA-7p8r-x3mc-p8w7` and its two predecessors, and `ip-address` at `10.3.1` for `GHSA-mwp4-54f8-5fhr` (needed because `express-rate-limit`, inherited via `@modelcontextprotocol/sdk`, depends on an exact `10.1.0`, so no range resolution reaches the fix).
+
+`brace-expansion` is lifted to `1.1.18` and `5.0.9`, which clears both `GHSA-mh99-v99m-4gvg` and `GHSA-rgw5-rvv9-x895`, the latter being a bypass of the former's mitigation. The 1.x line gained a patched release (`1.1.17`, then `1.1.18`) after the original override was written, so `GHSA-mh99-v99m-4gvg` is no longer an audit ignore.
+
+A pin only earns its place while no reachable range resolves to a safe version. `undici` is deliberately **not** pinned: `jsdom` accepts `^7.24.5`, so refreshing the lockfile reaches the patched `7.29.0` on its own, and a pin there would be one more entry to age. Prefer moving the lockfile over adding an override whenever the declared range already permits the fix.
 
 Vitest is pinned at `4.1.8` across JS workspaces to stay above the `GHSA-5xrq-8626-4rwp` floor, and dashboard `react-router` is pinned at `7.18.0` to stay above the `GHSA-chx6-hx7r-mcp5` fix; its `GHSA-qwww-vcr4-c8h2` (unstable-RSC-only) advisory is a tracked audit ignore until the v8 upgrade (#204).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,13 @@ settings:
 overrides:
   path-to-regexp: 8.4.2
   axios: 1.18.1
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   follow-redirects: 1.16.0
-  brace-expansion@<1.1.16: 1.1.16
-  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
+  brace-expansion@<1.1.18: 1.1.18
+  brace-expansion@>=3.0.0 <5.0.9: 5.0.9
   postcss: 8.5.18
   form-data@>=4.0.0 <4.0.6: 4.0.6
+  ip-address: 10.3.1
 
 importers:
 
@@ -1249,11 +1250,11 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
@@ -1644,8 +1645,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1828,8 +1829,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2609,8 +2610,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
@@ -3668,7 +3669,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3743,12 +3744,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4138,7 +4139,7 @@ snapshots:
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.3.1
 
   express@5.2.1:
     dependencies:
@@ -4179,7 +4180,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -4347,7 +4348,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -4396,7 +4397,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4525,11 +4526,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -5094,7 +5095,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,23 +8,28 @@ packages:
 overrides:
   path-to-regexp: 8.4.2
   axios: 1.18.1
-  fast-uri: 3.1.4 # GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx
+  fast-uri: 3.1.5 # GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx, GHSA-7p8r-x3mc-p8w7
   follow-redirects: 1.16.0
-  'brace-expansion@<1.1.16': 1.1.16
-  'brace-expansion@>=3.0.0 <5.0.8': 5.0.8 # GHSA-mh99-v99m-4gvg; 1.x has no patch (#205)
+  # Both brace-expansion advisories at once: GHSA-mh99-v99m-4gvg (patched 1.1.17
+  # / 5.0.8) and GHSA-rgw5-rvv9-x895, which bypasses that mitigation (patched
+  # 1.1.18 / 5.0.9). The 1.x line has a patch now, so it is no longer an ignore.
+  'brace-expansion@<1.1.18': 1.1.18
+  'brace-expansion@>=3.0.0 <5.0.9': 5.0.9
   postcss: 8.5.18 # GHSA-6g55-p6wh-862q, GHSA-r28c-9q8g-f849
   'form-data@>=4.0.0 <4.0.6': 4.0.6
+  # express-rate-limit (via @modelcontextprotocol/sdk) depends on an EXACT
+  # ip-address 10.1.0, so no range resolution can reach the fix.
+  ip-address: 10.3.1 # GHSA-mwp4-54f8-5fhr
 
 # pnpm 11 reads settings from this file only; the package.json "pnpm" field
 # is ignored. The GHSAs below are triaged and tracked (esbuild/vite: #64,
-# react-router RSC: #204, brace-expansion 1.x: #205).
+# react-router RSC: #204).
 auditConfig:
   ignoreGhsas:
     - GHSA-gv7w-rqvm-qjhr
     - GHSA-fx2h-pf6j-xcff
     - GHSA-vmh5-mc38-953g
     - GHSA-qwww-vcr4-c8h2
-    - GHSA-mh99-v99m-4gvg
 
 # Native build scripts approved to run at install (pnpm 11 renamed
 # onlyBuiltDependencies to allowBuilds).


### PR DESCRIPTION
## Description

`pnpm audit --audit-level=high` has been failing on `main`, so every post-merge run is red and
`release.yml` would block a v0.12.0 tag on the same gate.

Three of the five failing advisories were self-inflicted. Overrides added to escape an earlier
advisory pinned `fast-uri` and both `brace-expansion` lines to versions that a *later* advisory
has since named, so our own pins were holding the tree inside the vulnerable range and stopping
the resolver from reaching the fix. This is the same failure mode as #188, where an unconditional
`axios` pin froze the repo into a vulnerable range.

```
before:  24 vulnerabilities   3 low | 13 moderate | 8 high (3 ignored)   exit 1
after:   13 vulnerabilities   3 low |  8 moderate | 2 high (2 ignored)   exit 0
```

The two remaining highs are the pre-existing tracked ignores for #64 and #204. Note the ignore
count went **down**, from three to two: `brace-expansion` is now genuinely fixed rather than
suppressed.

Closes #240
Closes #205

### What changed, and why each one

| Package | From | To | Mechanism |
| --- | --- | --- | --- |
| `fast-uri` | 3.1.4 | 3.1.5 | override raised |
| `brace-expansion` (1.x) | 1.1.16 | 1.1.18 | override selector raised |
| `brace-expansion` (5.x) | 5.0.8 | 5.0.9 | override selector raised |
| `ip-address` | 10.1.0 | 10.3.1 | **new** override |
| `undici` | 7.28.0 | 7.29.0 | lockfile only, deliberately **not** pinned |

`ip-address` needs a pin because `express-rate-limit`, inherited via `@modelcontextprotocol/sdk`,
depends on an exact `10.1.0` rather than a range, so nothing else can reach the fix.

`undici` deliberately gets no pin. `jsdom` accepts `^7.24.5`, so refreshing the lockfile reaches
the patched `7.29.0` on its own. Adding an override there would buy nothing today and create one
more entry to age into the next advisory, which is precisely what caused three of the five
failures this PR is fixing. `DEPENDENCIES.md` now records that rule: an override earns its place
only while no reachable range resolves to a safe version.

### The `brace-expansion` 1.x line stays on 1.x

#205 documented why the 1.x line could not simply be lifted to 5.x: the v5 CommonJS build exposes
a named `exports.expand`, while `minimatch@3` does `require('brace-expansion')` and calls the
result directly, so an override across the major would throw on the first brace pattern in a lint
glob. The selector here keeps 1.x on the 1.x line, and that was verified rather than assumed:

```
brace-expansion@1.1.18  typeof: function   expand("{a,b}c") = [ 'ac', 'bc' ]
eslint "packages/proxy/src/transport/{sse,streamable-http}.ts"  ->  2 files linted, 0 errors
```

### One audit ignore is retired

`GHSA-mh99-v99m-4gvg` was added to `auditConfig.ignoreGhsas` because the 1.x line had no patched
release, which was true when it was written. The advisory now lists `1.1.17` as the 1.x patch, and
`1.1.18` clears the follow-up bypass as well, so the ignore is removed and the advisory is fixed
for real. `DEPENDENCIES.md` carried the same stale "the 1.x line has no patched release" claim and
has been corrected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

No runtime behavior changes. Every affected package reaches the tree through a devDependency
(`vitest`/`jsdom`, `eslint`, `typescript-eslint`, `@modelcontextprotocol/sdk`), so neither the
published npm package nor the Docker image runtime is altered. Confirmed by
`pnpm audit --prod --audit-level=high`, which reported zero unignored high advisories both before
and after.

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode, no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes (no new behavior; existing suites cover the affected toolchain)
- [x] All CI checks pass
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## How to Test

1. `pnpm install --frozen-lockfile`
2. `pnpm audit --audit-level=high` exits 0, where it previously exited 1 with five unignored
   high advisories.
3. `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm format:check` all pass.
4. Confirm the `brace-expansion` API is intact through a brace glob, which is the failure mode
   #205 warned about:
   ```bash
   pnpm exec eslint "packages/proxy/src/transport/{sse,streamable-http}.ts" --format json
   ```
   It should lint 2 files rather than throw a `TypeError`.

## Additional Context

### Vetting

All four target versions were vetted before anything was installed, per the practice
`DEPENDENCIES.md` describes and the lesson from #188 that "pinned" is not "safe":

- **Maintainer continuity**: unchanged from the versions they replace. `fast-uri` by
  `matteo.collina`, both `brace-expansion` lines by `juliangruber`.
- **Provenance**: `undici` and `ip-address` publish SLSA provenance attestations.
- **Tarball diffs** for the three unattested upgrades, since provenance was unavailable. Each
  contains only its security fix: `fast-uri` adds authority-introducer validation plus a security
  test, `brace-expansion` adds an `EXPANSION_MAX_LENGTH` bound. No `child_process`, `eval`,
  network calls, environment reads, or base64 blobs in any diff.
- **Install hooks**: none that run for registry tarballs, and `allowBuilds` already restricts
  build scripts to `better-sqlite3` and `esbuild`.
- **Publish dates**: 4 to 11 days old, consistent with ordinary fix releases rather than anything
  rushed or anomalous.

Installed versions match exactly what was vetted.

### Version pinning policy

This PR does not weaken the exact-pinning policy in `DEPENDENCIES.md`. Every override *value*
remains an exact version, `.npmrc` still sets `save-exact=true`, every direct dependency across
all four manifests is still an exact version, and CI still installs with `--frozen-lockfile`.
`undici` is pinned by the lockfile exactly as the other ~570 transitives are; overrides are the
security-patch mechanism for cases where the declared range cannot reach a fix, which does not
apply to it.

### Follow-up

#241 raises the toolchain and the supported runtime to Node 24 for the same milestone. Filed
separately rather than bundled here, so a security patch and a runtime bump stay independently
reviewable and revertable.
