### PR TITLE
fix(deps): bump the MCP SDK so @hono/node-server dedupes onto 2.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,10 +232,9 @@ Our audit posture reflects that:
 
 Current ignores (each with no exploit path in our usage, tracked for removal):
 
-| GHSA                  | Package (path)                                                           | Why ignored                                                                                                                                                  | Tracking |
-| --------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
-| `GHSA-frvp-7c67-39w9` | `@hono/node-server` 1.x (via `@modelcontextprotocol/sdk`, dev/test only) | serve-static path traversal; the proxy's production copy is on the patched 2.x line, and the SDK's `^1.19.9` range cannot reach 2.x until the SDK 1.30+ bump | #259     |
-| `GHSA-g7r4-m6w7-qqqr` | esbuild 0.27.4 (via `tsup`/`bundle-require` and `tsx`, build/exec only)  | dev-server file read; none of those tools run the esbuild dev server, and their `^0.27.0` / `~0.27.0` ranges cannot reach the 0.28.1 fix                     | #64      |
+| GHSA                  | Package (path)                                                          | Why ignored                                                                                                                              | Tracking |
+| --------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `GHSA-g7r4-m6w7-qqqr` | esbuild 0.27.4 (via `tsup`/`bundle-require` and `tsx`, build/exec only) | dev-server file read; none of those tools run the esbuild dev server, and their `^0.27.0` / `~0.27.0` ranges cannot reach the 0.28.1 fix | #64      |
 
 ## Issue Labels
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -46,7 +46,7 @@
     "prepack": "pnpm run check:dashboard-assets"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "1.28.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@types/better-sqlite3": "7.6.13",
     "@types/js-yaml": "4.0.9",
     "@types/node": "24.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@modelcontextprotocol/sdk':
-        specifier: 1.28.0
-        version: 1.28.0(zod@4.3.6)
+        specifier: 1.30.0
+        version: 1.30.0(zod@4.3.6)
       '@types/better-sqlite3':
         specifier: 7.6.13
         version: 7.6.13
@@ -162,10 +162,6 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
-
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -670,12 +666,6 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
   '@hono/node-server@2.0.12':
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
@@ -714,8 +704,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@modelcontextprotocol/sdk@1.28.0':
-    resolution: {integrity: sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -2621,10 +2611,6 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
-
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
@@ -2840,12 +2826,6 @@ snapshots:
       lru-cache: 11.2.7
 
   '@asamuzakjp/nwsapi@2.3.9': {}
-
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -3206,10 +3186,6 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.34)':
-    dependencies:
-      hono: 4.12.34
-
   '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
       hono: 4.12.34
@@ -3244,9 +3220,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.28.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.34)
+      '@hono/node-server': 2.0.12(hono@4.12.34)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3453,7 +3429,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -4235,7 +4211,7 @@ snapshots:
       send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5138,12 +5114,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.2
 
   type-is@2.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,15 +21,9 @@ overrides:
   ip-address: 10.3.1 # GHSA-mwp4-54f8-5fhr
 
 # pnpm 11 reads settings from this file only; the package.json "pnpm" field
-# is ignored. The GHSAs below are triaged and tracked (esbuild dev-server:
-# #64, @hono/node-server: #259).
+# is ignored. The GHSA below is triaged and tracked (esbuild dev-server: #64).
 auditConfig:
   ignoreGhsas:
-    # @hono/node-server 1.x via @modelcontextprotocol/sdk (dev-only): the SDK's
-    # ^1.19.9 range cannot reach the 2.x fix line; retire with the SDK 1.30+
-    # bump (#259). Ignore is advisory-wide, so it also masks any future <2.0.5
-    # copy on other paths — do not let it outlive the SDK bump.
-    - GHSA-frvp-7c67-39w9
     # esbuild dev-server file read (low, dev-only): only the 0.27.4 instance
     # (via tsup/bundle-require and tsx) is in range, none of them run the dev
     # server, and tsup's ^0.27.0 / tsx's ~0.27.0 cannot reach 0.28.1; triage


### PR DESCRIPTION
Closes #259. Bump `@modelcontextprotocol/sdk` from 1.28.0 to 1.30.0, the first release whose `@hono/node-server` range accepts the 2.x line. With that widening the SDK dedupes onto the proxy's direct `@hono/node-server@2.0.12`, its dev-only 1.x copy drops out of the lockfile, and the `GHSA-frvp-7c67-39w9` audit ignore retires; the contributing guide's ignore table follows.

Vetted per the DEPENDENCIES.md doctrine: 1.30.0 is the line tip (published 2026-07-27), attested (the SDK team moved to OIDC trusted publishing), no install hooks, MCP core-team maintainers, and the dependency set is otherwise identical to 1.28.0. Two collateral lockfile dedupes ride along, `type-is` 2.0.1 to 2.1.0 and `@babel/code-frame` 7.29.0 to 7.29.7, both converging onto versions #261 already brought into the tree; the old duplicate copies are gone, so the lockfile ends strictly cleaner.

Full gates were green on the first run (build, lint, typecheck, format, 2,867 tests, audit). End state: `pnpm audit --prod` reports zero findings with zero ignores, and the full tree is down to a single documented low ignore (esbuild, tracked on #64), which now also matches the contributing guide's table exactly.
