### PR TITLE
docs(upstream): use US spelling in upstream comments

### DIFF
--- a/packages/proxy/src/upstream/connection-error.test.ts
+++ b/packages/proxy/src/upstream/connection-error.test.ts
@@ -21,7 +21,7 @@ describe('describeUnreachableUpstream', () => {
   })
 
   it.each(['ENOTFOUND', 'EAI_AGAIN', 'ECONNRESET', 'EHOSTUNREACH', 'ETIMEDOUT'])(
-    'recognises %s as unreachable',
+    'recognizes %s as unreachable',
     (code) => {
       expect(describeUnreachableUpstream(fetchFailed(code), URL)).toBeInstanceOf(Error)
     },

--- a/packages/proxy/src/upstream/merge-headers.ts
+++ b/packages/proxy/src/upstream/merge-headers.ts
@@ -1,5 +1,5 @@
 /**
- * Merge the three header sources that feed an upstream request, normalising
+ * Merge the three header sources that feed an upstream request, normalizing
  * every name to lower-case so case-only duplicates collapse to one header.
  *
  * Precedence (later wins): base defaults → caller-forwarded → static config.


### PR DESCRIPTION
Replace the two remaining British spellings in the upstream tree with US English, per the house convention:

- `normalizing` in the header-merge docstring (`packages/proxy/src/upstream/merge-headers.ts`)
- `recognizes` in the connection-error test title (`packages/proxy/src/upstream/connection-error.test.ts`)

Comment and test-title text only; no behavior change. A repo-wide sweep confirms these were the last two.

Closes #265.