### PR TITLE
fix(transport): omit id from ingress rejection error bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,17 @@ Maintainer notes:
   become proxy-side refusals with a clear error — against a `2026-07-28`
   upstream a missing header is a guaranteed rejection, no longer a
   harmless fallback.
+- **Transport ingress rejections no longer emit `id: null` (#234).**
+  Pre-parse rejections on `/mcp` and `/sse` — wrong `Content-Type`,
+  malformed JSON, and a missing or unknown SSE session — and
+  envelope-invalid bodies with no usable request id now omit the
+  JSON-RPC `id` member entirely, matching the shape the Origin guard
+  and the header/body agreement door already emit. An invalid envelope
+  that does carry a usable `string` or `number` id still has it echoed.
+  No MCP revision ever permitted a null id; the `2026-07-28` error
+  shape sanctions omission as the no-id form, so validators built on it
+  now accept these 4xx bodies. HTTP statuses, error codes, and messages
+  are unchanged.
 
 ### Security
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -157,7 +157,7 @@ For requests that pass JSON-RPC ingress validation at `/mcp`, Helio always retur
 - Valid upstream JSON-RPC responses pass through unchanged at the body layer.
 - Upstream forwarding failures and non-JSON-RPC upstream payloads are normalized to:
   `{"jsonrpc":"2.0","id":<request-id>,"error":{"code":-32603,"message":"...","data":{"failure_class":"..."}}}`
-- HTTP ingress validation errors (for example malformed JSON or wrong `Content-Type`) still return transport HTTP errors such as `400` or `415`.
+- HTTP ingress validation errors (for example malformed JSON or wrong `Content-Type`) still return transport HTTP errors such as `400` or `415`. Their JSON-RPC error bodies omit the `id` member when no request id was readable, per the MCP 2026-07-28 error shape; when the invalid envelope carried a usable id, it is echoed.
 
 ## Step 5: Open the Dashboard
 

--- a/packages/proxy/src/mcp/types.test.ts
+++ b/packages/proxy/src/mcp/types.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { makeJsonRpcError, PARSE_ERROR, INVALID_REQUEST, INTERNAL_ERROR } from './types.js'
+import {
+  makeJsonRpcError,
+  makeJsonRpcErrorWithoutId,
+  PARSE_ERROR,
+  INVALID_REQUEST,
+  INTERNAL_ERROR,
+} from './types.js'
 
 describe('makeJsonRpcError', () => {
   it('builds a valid JSON-RPC error response', () => {
@@ -24,6 +30,21 @@ describe('makeJsonRpcError', () => {
   it('preserves null ids', () => {
     const result = makeJsonRpcError(null, INTERNAL_ERROR, 'error')
     expect(result.id).toBeNull()
+  })
+})
+
+describe('makeJsonRpcErrorWithoutId', () => {
+  it('builds a valid JSON-RPC error response', () => {
+    const result = makeJsonRpcErrorWithoutId(INVALID_REQUEST, 'origin not allowed')
+    expect(result).toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32600, message: 'origin not allowed' },
+    })
+  })
+
+  it('omits the id member entirely', () => {
+    const result = makeJsonRpcErrorWithoutId(PARSE_ERROR, 'bad json')
+    expect(Object.hasOwn(result, 'id')).toBe(false)
   })
 })
 

--- a/packages/proxy/src/mcp/types.test.ts
+++ b/packages/proxy/src/mcp/types.test.ts
@@ -17,19 +17,9 @@ describe('makeJsonRpcError', () => {
     })
   })
 
-  it('sets id to null when undefined', () => {
-    const result = makeJsonRpcError(undefined, PARSE_ERROR, 'bad json')
-    expect(result.id).toBeNull()
-  })
-
   it('preserves string ids', () => {
     const result = makeJsonRpcError('req-42', INVALID_REQUEST, 'missing method')
     expect(result.id).toBe('req-42')
-  })
-
-  it('preserves null ids', () => {
-    const result = makeJsonRpcError(null, INTERNAL_ERROR, 'error')
-    expect(result.id).toBeNull()
   })
 })
 

--- a/packages/proxy/src/mcp/types.ts
+++ b/packages/proxy/src/mcp/types.ts
@@ -175,8 +175,11 @@ export function makeJsonRpcError(
  * Build a JSON-RPC 2.0 error response with the `id` member omitted entirely.
  *
  * The MCP 2026-07-28 error-response type declares `id` as optional and does
- * not permit `null`, so rejections issued before any request is parsed (no
- * id exists yet) must leave the member out rather than emit `id: null`.
+ * not permit `null`, so omission is the conforming shape whenever no usable
+ * `string | number` request id exists: pre-parse door rejections (before a
+ * body is parsed) and post-parse failures with no extractable id (invalid
+ * envelopes, notifications, explicit `id: null`). With a usable id in hand,
+ * use `makeJsonRpcError` and echo it instead.
  */
 export function makeJsonRpcErrorWithoutId(code: number, message: string): JsonRpcResponse {
   return {

--- a/packages/proxy/src/mcp/types.ts
+++ b/packages/proxy/src/mcp/types.ts
@@ -158,15 +158,20 @@ export interface McpForwarderWithInternal extends McpForwarder {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a well-formed JSON-RPC 2.0 error response. */
+/**
+ * Build a well-formed JSON-RPC 2.0 error response echoing a usable request
+ * id. The id parameter is deliberately narrower than `JsonRpcResponse.id`:
+ * this helper cannot emit `id: null`, so a caller with no usable id must
+ * use `makeJsonRpcErrorWithoutId` instead of passing null through.
+ */
 export function makeJsonRpcError(
-  id: string | number | null | undefined,
+  id: string | number,
   code: number,
   message: string,
 ): JsonRpcResponse {
   return {
     jsonrpc: '2.0',
-    id: id ?? null,
+    id,
     error: { code, message },
   }
 }

--- a/packages/proxy/src/transport/sse.test.ts
+++ b/packages/proxy/src/transport/sse.test.ts
@@ -404,6 +404,26 @@ describe('SSE transport', () => {
     expect(json.id).toBe(5)
   })
 
+  // Guards the `=== null` arm of the envelope rejection: a truthiness rewrite
+  // typechecks identically but would route these falsy-but-usable ids into the
+  // id-omitting branch instead of echoing them.
+  it.each([0, ''])('echoes the falsy request id %j on an invalid envelope', async (id) => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const sseRes = await app.request('/sse')
+    const events = await readSseEvents(sseRes, 1)
+    const sessionId = extractSessionId(events[0]?.data ?? '')
+
+    const res = await postSse(app, sessionId, { jsonrpc: '2.0', id })
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as JsonRpcResponse
+    expect(json.error?.code).toBe(-32600)
+    expect(Object.hasOwn(json, 'id')).toBe(true)
+    expect(json.id).toBe(id)
+  })
+
   it('emits normalized JSON-RPC error event when forwarder throws', async () => {
     const forwarder = createThrowingForwarder()
     const app = mountRoute(forwarder)

--- a/packages/proxy/src/transport/sse.test.ts
+++ b/packages/proxy/src/transport/sse.test.ts
@@ -267,6 +267,7 @@ describe('SSE transport', () => {
     expect(res.status).toBe(404)
     const json = (await res.json()) as JsonRpcResponse
     expect(json.error?.message).toContain('unknown session')
+    expect(Object.hasOwn(json, 'id')).toBe(false)
     expect(forwarder.calls).toHaveLength(0)
   })
 
@@ -283,6 +284,7 @@ describe('SSE transport', () => {
     expect(res.status).toBe(400)
     const json = (await res.json()) as JsonRpcResponse
     expect(json.error?.message).toContain('sessionId')
+    expect(Object.hasOwn(json, 'id')).toBe(false)
   })
 
   it('returns 415 when Content-Type is not application/json', async () => {
@@ -300,6 +302,8 @@ describe('SSE transport', () => {
     })
 
     expect(res.status).toBe(415)
+    const json = (await res.json()) as JsonRpcResponse
+    expect(Object.hasOwn(json, 'id')).toBe(false)
   })
 
   // See the matching case in streamable-http.test.ts: a CORS-safelisted
@@ -365,6 +369,7 @@ describe('SSE transport', () => {
     expect(res.status).toBe(400)
     const json = (await res.json()) as JsonRpcResponse
     expect(json.error?.code).toBe(-32700)
+    expect(Object.hasOwn(json, 'id')).toBe(false)
   })
 
   it('returns -32600 for invalid JSON-RPC', async () => {
@@ -380,6 +385,23 @@ describe('SSE transport', () => {
     expect(res.status).toBe(400)
     const json = (await res.json()) as JsonRpcResponse
     expect(json.error?.code).toBe(-32600)
+    expect(Object.hasOwn(json, 'id')).toBe(false)
+  })
+
+  it('echoes the request id on an invalid envelope', async () => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const sseRes = await app.request('/sse')
+    const events = await readSseEvents(sseRes, 1)
+    const sessionId = extractSessionId(events[0]?.data ?? '')
+
+    const res = await postSse(app, sessionId, { jsonrpc: '2.0', id: 5 })
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as JsonRpcResponse
+    expect(json.error?.code).toBe(-32600)
+    expect(json.id).toBe(5)
   })
 
   it('emits normalized JSON-RPC error event when forwarder throws', async () => {
@@ -515,6 +537,7 @@ describe('SSE transport — stale session sweeper', () => {
     expect(stale.status).toBe(404)
     const json = (await stale.json()) as JsonRpcResponse
     expect(json.error?.message).toContain('unknown session')
+    expect(Object.hasOwn(json, 'id')).toBe(false)
   })
 
   it('keeps sessions alive while activity refreshes lastActivity', async () => {

--- a/packages/proxy/src/transport/sse.ts
+++ b/packages/proxy/src/transport/sse.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from 'node:crypto'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { PARSE_ERROR, INVALID_REQUEST, makeJsonRpcError } from '../mcp/types.js'
+import {
+  PARSE_ERROR,
+  INVALID_REQUEST,
+  makeJsonRpcError,
+  makeJsonRpcErrorWithoutId,
+} from '../mcp/types.js'
 import type { McpForwarder, McpRequest } from '../mcp/types.js'
 import { parseJsonRpcRequest } from '../mcp/validation.js'
 import {
@@ -127,7 +132,7 @@ export function createSseRoute(forwarder: McpForwarder, options: SseRouteOptions
     const parsedQuery = ssePostQuerySchema.safeParse(c.req.query())
     if (!parsedQuery.success) {
       return c.json(
-        makeJsonRpcError(null, INVALID_REQUEST, 'missing sessionId query parameter'),
+        makeJsonRpcErrorWithoutId(INVALID_REQUEST, 'missing sessionId query parameter'),
         400,
       )
     }
@@ -135,13 +140,13 @@ export function createSseRoute(forwarder: McpForwarder, options: SseRouteOptions
 
     const session = sessions.get(sessionId)
     if (!session) {
-      return c.json(makeJsonRpcError(null, INVALID_REQUEST, 'unknown session'), 404)
+      return c.json(makeJsonRpcErrorWithoutId(INVALID_REQUEST, 'unknown session'), 404)
     }
 
     // Require JSON content type
     if (!isJsonContentType(c.req.header('content-type'))) {
       return c.json(
-        makeJsonRpcError(null, INVALID_REQUEST, 'Content-Type must be application/json'),
+        makeJsonRpcErrorWithoutId(INVALID_REQUEST, 'Content-Type must be application/json'),
         415,
       )
     }
@@ -151,13 +156,20 @@ export function createSseRoute(forwarder: McpForwarder, options: SseRouteOptions
     try {
       body = await c.req.json()
     } catch {
-      return c.json(makeJsonRpcError(null, PARSE_ERROR, 'invalid JSON'), 400)
+      return c.json(makeJsonRpcErrorWithoutId(PARSE_ERROR, 'invalid JSON'), 400)
     }
 
     // Validate JSON-RPC envelope
     const parsedRequest = parseJsonRpcRequest(body)
     if (!parsedRequest.success) {
-      return c.json(makeJsonRpcError(parsedRequest.id, INVALID_REQUEST, parsedRequest.message), 400)
+      // Echo a usable id; `id: null` means none was extractable, so the body
+      // takes the id-omitting shape. `=== null` deliberately — a truthiness
+      // check would swallow the usable falsy ids 0 and ''.
+      const errorBody =
+        parsedRequest.id === null
+          ? makeJsonRpcErrorWithoutId(INVALID_REQUEST, parsedRequest.message)
+          : makeJsonRpcError(parsedRequest.id, INVALID_REQUEST, parsedRequest.message)
+      return c.json(errorBody, 400)
     }
 
     const id = parsedRequest.request.id

--- a/packages/proxy/src/transport/streamable-http.test.ts
+++ b/packages/proxy/src/transport/streamable-http.test.ts
@@ -316,6 +316,7 @@ describe('streamable-http transport', () => {
     expect(res.status).toBe(415)
     const json = (await res.json()) as JsonRpcResponse
     expect(json.error?.code).toBe(-32600)
+    expect(Object.hasOwn(json, 'id')).toBe(false)
     expect(forwarder.calls).toHaveLength(0)
   })
 
@@ -375,6 +376,8 @@ describe('streamable-http transport', () => {
     })
 
     expect(res.status).toBe(415)
+    const json = (await res.json()) as JsonRpcResponse
+    expect(Object.hasOwn(json, 'id')).toBe(false)
     expect(forwarder.calls).toHaveLength(0)
   })
 
@@ -391,6 +394,7 @@ describe('streamable-http transport', () => {
     expect(res.status).toBe(400)
     const json = (await res.json()) as JsonRpcResponse
     expect(json.error?.code).toBe(-32700)
+    expect(Object.hasOwn(json, 'id')).toBe(false)
     expect(forwarder.calls).toHaveLength(0)
   })
 
@@ -404,18 +408,60 @@ describe('streamable-http transport', () => {
     const json = (await res.json()) as JsonRpcResponse
     expect(json.error?.code).toBe(-32600)
     expect(json.error?.message).toContain('jsonrpc')
+    expect(Object.hasOwn(json, 'id')).toBe(false)
   })
 
-  it('returns -32600 for missing method field', async () => {
+  it('omits id for an invalid envelope carrying an explicit null id', async () => {
     const forwarder = createMockForwarder(okResponse)
     const app = mountRoute(forwarder)
 
-    const res = await postMcp(app, { jsonrpc: '2.0', id: 1 })
+    const res = await postMcp(app, { id: null, method: 'tools/list' })
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as JsonRpcResponse
+    expect(json.error?.code).toBe(-32600)
+    expect(Object.hasOwn(json, 'id')).toBe(false)
+  })
+
+  it('returns -32600 for missing method field and echoes the request id', async () => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const res = await postMcp(app, { jsonrpc: '2.0', id: 5 })
 
     expect(res.status).toBe(400)
     const json = (await res.json()) as JsonRpcResponse
     expect(json.error?.code).toBe(-32600)
     expect(json.error?.message).toContain('method')
+    expect(json.id).toBe(5)
+  })
+
+  // Guards the `=== null` arm of the envelope rejection: a truthiness rewrite
+  // typechecks identically but would route these falsy-but-usable ids into the
+  // id-omitting branch instead of echoing them.
+  it.each([0, ''])('echoes the falsy request id %j on an invalid envelope', async (id) => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const res = await postMcp(app, { jsonrpc: '2.0', id })
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as JsonRpcResponse
+    expect(json.error?.code).toBe(-32600)
+    expect(Object.hasOwn(json, 'id')).toBe(true)
+    expect(json.id).toBe(id)
+  })
+
+  it('omits id when the request id has an invalid type', async () => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const res = await postMcp(app, { jsonrpc: '2.0', id: {}, method: 'tools/list' })
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as JsonRpcResponse
+    expect(json.error?.code).toBe(-32600)
+    expect(Object.hasOwn(json, 'id')).toBe(false)
   })
 
   it('returns -32600 for batch requests (arrays)', async () => {
@@ -431,6 +477,19 @@ describe('streamable-http transport', () => {
     const json = (await res.json()) as JsonRpcResponse
     expect(json.error?.code).toBe(-32600)
     expect(json.error?.message).toContain('batch')
+    expect(Object.hasOwn(json, 'id')).toBe(false)
+  })
+
+  it('omits id for a non-object JSON body', async () => {
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder)
+
+    const res = await postMcp(app, 'hi')
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as JsonRpcResponse
+    expect(json.error?.code).toBe(-32600)
+    expect(Object.hasOwn(json, 'id')).toBe(false)
   })
 
   it('returns -32603 when forwarder throws', async () => {

--- a/packages/proxy/src/transport/streamable-http.ts
+++ b/packages/proxy/src/transport/streamable-http.ts
@@ -69,7 +69,7 @@ export function createStreamableHttpRoute(
     // Require JSON content type
     if (!isJsonContentType(c.req.header('content-type'))) {
       return c.json(
-        makeJsonRpcError(null, INVALID_REQUEST, 'Content-Type must be application/json'),
+        makeJsonRpcErrorWithoutId(INVALID_REQUEST, 'Content-Type must be application/json'),
         415,
       )
     }
@@ -79,13 +79,20 @@ export function createStreamableHttpRoute(
     try {
       body = await c.req.json()
     } catch {
-      return c.json(makeJsonRpcError(null, PARSE_ERROR, 'invalid JSON'), 400)
+      return c.json(makeJsonRpcErrorWithoutId(PARSE_ERROR, 'invalid JSON'), 400)
     }
 
     // Validate JSON-RPC envelope
     const parsedRequest = parseJsonRpcRequest(body)
     if (!parsedRequest.success) {
-      return c.json(makeJsonRpcError(parsedRequest.id, INVALID_REQUEST, parsedRequest.message), 400)
+      // Echo a usable id; `id: null` means none was extractable, so the body
+      // takes the id-omitting shape. `=== null` deliberately — a truthiness
+      // check would swallow the usable falsy ids 0 and ''.
+      const errorBody =
+        parsedRequest.id === null
+          ? makeJsonRpcErrorWithoutId(INVALID_REQUEST, parsedRequest.message)
+          : makeJsonRpcError(parsedRequest.id, INVALID_REQUEST, parsedRequest.message)
+      return c.json(errorBody, 400)
     }
 
     const id = parsedRequest.request.id


### PR DESCRIPTION
## Description

Retires the `id: null` member from transport ingress rejection bodies. No MCP revision ever
permitted a null id, and the `2026-07-28` error shape (`id?: string | number`) sanctions
omission as the no-id form; the Origin guard (#213) and the header/body agreement door (#226)
already emit the id-less shape, so this brings the remaining ingress rejections in line.

Eight paths convert, not the issue's six (recorded on #234): the six unconditional pre-parse
emitters (wrong `Content-Type` and malformed JSON on `/mcp` and `/sse`, missing and unknown
SSE session) now omit the member, and the two envelope-validation rejections omit it only
when the invalid envelope carried no extractable id. An invalid envelope that does carry a
usable `string | number` id still has it echoed, with regression guards covering the falsy
ids `0` and `''` on both transports. HTTP statuses, JSON-RPC codes, messages, and check
order are unchanged everywhere; the `id` member is the entire wire diff.

`makeJsonRpcError` narrows to `(id: string | number, ...)` and drops its `id ?? null`
coercion, so a new `id: null` path through the helper no longer typechecks.
`makeJsonRpcErrorWithoutId` gains direct unit tests and a corrected doc contract.

Out-of-scope capture filed during implementation: #280, the echo/synthesis class (bodies
synthesized to a parsed request that echo the client's own explicit `id: null`). Those four
sites are deliberately untouched here and their existing test pins are intact.

Closes #234

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. Start the proxy against any upstream and send a pre-parse rejection:
   `curl -s localhost:3000/mcp -H 'content-type: text/plain' -d 'not json'` — the 415 body
   has no `id` member (previously `"id": null`).
2. POST an invalid envelope that carries an id:
   `curl -s localhost:3000/mcp -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":5}'`
   — the 400 body echoes `"id": 5`.
3. `pnpm --filter @gethelio/proxy test` — the transport suites assert
   `Object.hasOwn(json, 'id')` on all eight converted paths plus the echo arm, and
   `mcp/types.test.ts` pins both helper shapes.

## Additional Context

The behavior is documented in the getting-started error normalization notes, and the
CHANGELOG carries a Fixed entry. The unified v0.12.0 breaking section is deliberately not
touched: statuses, codes, and messages are unchanged, no doc ever promised the null member,
and the bundled SDK's client transports read rejection bodies as text without schema-parsing
them.
