### PR TITLE
fix(policy): stamp resultType on the synthesized dry-run result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,14 @@ Maintainer notes:
   shape sanctions omission as the no-id form, so validators built on it
   now accept these 4xx bodies. HTTP statuses, error codes, and messages
   are unchanged.
+- **The synthesized dry-run result now carries `resultType` (#227).**
+  MCP `2026-07-28` requires every result to declare a `resultType`,
+  and the dry-run response is the one result Helio manufactures
+  without an upstream round-trip. When the client's validated
+  `MCP-Protocol-Version` claim is `2026-07-28`, that result now
+  carries `resultType: "complete"`. Clients on `2025-06-18`, and
+  clients on transports that predate the header (SSE, stdio), receive
+  the same result without the field, byte-for-byte as before.
 
 ### Security
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -313,10 +313,13 @@ Returns a synthetic response showing what would have happened:
         "type": "text",
         "text": "{\"dry_run\":true,\"would_forward\":true,\"policy_decision\":\"allow\",\"matched_rule\":null,\"evidence_satisfied\":true,\"limits_ok\":true}"
       }
-    ]
+    ],
+    "resultType": "complete"
   }
 }
 ```
+
+Clients on MCP `2025-06-18`, and clients on transports that predate the `MCP-Protocol-Version` header (SSE, stdio), receive the same result without the `resultType` field.
 
 ## Install-Time Policy (`deny_install`)
 

--- a/packages/proxy/src/__tests__/integration-governance.test.ts
+++ b/packages/proxy/src/__tests__/integration-governance.test.ts
@@ -92,6 +92,26 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+interface McpPostResult {
+  status: number
+  body: Record<string, unknown>
+}
+
+/** Raw JSON-RPC POST with caller-controlled headers (for door-passing modern requests). */
+async function postJson(
+  url: string,
+  payload: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Promise<McpPostResult> {
+  const res = await fetch(url, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: { 'content-type': 'application/json', ...headers },
+  })
+  const body = (await res.json()) as Record<string, unknown>
+  return { status: res.status, body }
+}
+
 // ---------------------------------------------------------------------------
 // Suite 1: Full pipeline with 5+ rules
 // ---------------------------------------------------------------------------
@@ -606,6 +626,52 @@ describe('dry-run mode', () => {
       proxy.auditWriter.flush()
       const { records } = proxy.auditStore.list({ dry_run: true })
       expect(records).toHaveLength(1)
+    } finally {
+      await proxy.close()
+    }
+  })
+
+  it('stamps resultType: complete on the dry-run result for a door-passing modern request', async () => {
+    const proxy = createGovernedProxyWithAudit({
+      default: 'allow',
+      dry_run: true,
+      rules: [],
+    })
+
+    const MODERN = '2026-07-28'
+    const MIRROR_KEY = 'io.modelcontextprotocol/protocolVersion'
+
+    try {
+      const { status, body } = await postJson(
+        proxy.url,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'get_weather',
+            arguments: { city: 'London' },
+            _meta: { [MIRROR_KEY]: MODERN },
+          },
+        },
+        {
+          'mcp-protocol-version': MODERN,
+          'mcp-method': 'tools/call',
+          'mcp-name': 'get_weather',
+        },
+      )
+
+      expect(status).toBe(200)
+      expect(body['error']).toBeUndefined()
+      const result = body['result'] as Record<string, unknown>
+      expect(result['resultType']).toBe('complete')
+
+      // The stamp must not disturb the dry-run payload itself.
+      const content = result['content'] as Array<{ type: string; text: string }>
+      const payload = JSON.parse((content[0] ?? { text: '{}' }).text) as Record<string, unknown>
+      expect(payload['dry_run']).toBe(true)
+      expect(payload['would_forward']).toBe(true)
+      expect(payload['policy_decision']).toBe('allow')
     } finally {
       await proxy.close()
     }

--- a/packages/proxy/src/mcp/protocol-version.ts
+++ b/packages/proxy/src/mcp/protocol-version.ts
@@ -1,0 +1,30 @@
+/**
+ * The two MCP revisions Helio speaks, plus the pinned tokenizer for a
+ * client's raw `MCP-Protocol-Version` claim. A leaf module by design:
+ * transport, upstream, and policy all need this vocabulary, and none of
+ * them should have to import another layer's machinery to get it.
+ */
+
+/** The legacy leg's protocol offer — one of the two revisions Helio speaks. */
+export const HELIO_MCP_LEGACY_PROTOCOL_VERSION = '2025-06-18'
+/** MCP revision Helio speaks to a modern upstream (no initialize handshake). */
+export const HELIO_MCP_MODERN_PROTOCOL_VERSION = '2026-07-28'
+
+/**
+ * True iff the raw `MCP-Protocol-Version` value is the modern claim, under
+ * the pinned tier tokenizer: split on `,`, trim each token with
+ * `String.prototype.trim` — deliberately NOT an RFC-OWS `[ \t]` trim, so
+ * exotic Unicode padding (NBSP and friends) cannot dodge the presence
+ * profile — drop empty tokens, and require at least one remaining token
+ * with every one exactly `2026-07-28`. Duplicated headers arrive
+ * comma-joined, so an all-modern duplicate is still the modern claim while
+ * a mixed duplicate is not.
+ */
+export function isModernProtocolClaim(rawValue: string | undefined): boolean {
+  if (rawValue === undefined) return false
+  const tokens = rawValue
+    .split(',')
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+  return tokens.length > 0 && tokens.every((token) => token === HELIO_MCP_MODERN_PROTOCOL_VERSION)
+}

--- a/packages/proxy/src/policy/governed-forwarder.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder.test.ts
@@ -6440,6 +6440,104 @@ describe('GovernedForwarder', () => {
         expect(payload['dry_run']).toBe(true)
       })
     })
+
+    describe('resultType (MCP 2026-07-28)', () => {
+      /** Extract the JSON-RPC result object from a synthetic ForwardResult. */
+      function mcpResultFromResult(result: ForwardResult): Record<string, unknown> {
+        const body = result.response.body as Record<string, unknown>
+        return body['result'] as Record<string, unknown>
+      }
+
+      it('stamps resultType: complete under global dry_run for a modern claim', async () => {
+        const inner = mockForwarder()
+        const policy = compile({ dry_run: true, default: 'allow', rules: [] })
+        const governed = new GovernedForwarder(inner, policy)
+
+        const result = await governed.forward({
+          ...toolsCallRequest('get_weather'),
+          protocolVersion: '2026-07-28',
+        })
+
+        expect(mcpResultFromResult(result)['resultType']).toBe('complete')
+
+        // The stamp must not disturb the dry-run payload itself.
+        const payload = dryRunPayloadFromResult(result)
+        expect(payload['dry_run']).toBe(true)
+        expect(payload['would_forward']).toBe(true)
+        expect(payload['policy_decision']).toBe('allow')
+      })
+
+      it('stamps resultType: complete under per-rule dry_run for a modern claim', async () => {
+        const inner = mockForwarder()
+        const policy = compile({
+          default: 'allow',
+          rules: [{ name: 'shadow-all', match: { tool: '*' }, action: 'dry_run' }],
+        })
+        const governed = new GovernedForwarder(inner, policy)
+
+        const result = await governed.forward({
+          ...toolsCallRequest('send_email'),
+          protocolVersion: '2026-07-28',
+        })
+
+        expect(mcpResultFromResult(result)['resultType']).toBe('complete')
+
+        const payload = dryRunPayloadFromResult(result)
+        expect(payload['dry_run']).toBe(true)
+        expect(payload['would_forward']).toBe(false)
+        expect(payload['policy_decision']).toBe('dry_run')
+        expect(payload['matched_rule']).toBe('shadow-all')
+      })
+
+      it('omits resultType when the request carries no protocol claim', async () => {
+        const inner = mockForwarder()
+        const policy = compile({ dry_run: true, default: 'allow', rules: [] })
+        const governed = new GovernedForwarder(inner, policy)
+
+        const result = await governed.forward(toolsCallRequest('get_weather'))
+
+        expect('resultType' in mcpResultFromResult(result)).toBe(false)
+      })
+
+      it('omits resultType for a legacy 2025-06-18 claim', async () => {
+        const inner = mockForwarder()
+        const policy = compile({ dry_run: true, default: 'allow', rules: [] })
+        const governed = new GovernedForwarder(inner, policy)
+
+        const result = await governed.forward({
+          ...toolsCallRequest('get_weather'),
+          protocolVersion: '2025-06-18',
+        })
+
+        expect('resultType' in mcpResultFromResult(result)).toBe(false)
+      })
+
+      it('stamps resultType for a comma-joined all-modern duplicate claim', async () => {
+        const inner = mockForwarder()
+        const policy = compile({ dry_run: true, default: 'allow', rules: [] })
+        const governed = new GovernedForwarder(inner, policy)
+
+        const result = await governed.forward({
+          ...toolsCallRequest('get_weather'),
+          protocolVersion: '2026-07-28, 2026-07-28',
+        })
+
+        expect(mcpResultFromResult(result)['resultType']).toBe('complete')
+      })
+
+      it('omits resultType for a malformed claim', async () => {
+        const inner = mockForwarder()
+        const policy = compile({ dry_run: true, default: 'allow', rules: [] })
+        const governed = new GovernedForwarder(inner, policy)
+
+        const result = await governed.forward({
+          ...toolsCallRequest('get_weather'),
+          protocolVersion: 'latest',
+        })
+
+        expect('resultType' in mcpResultFromResult(result)).toBe(false)
+      })
+    })
   })
 })
 

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -7,6 +7,7 @@ import type {
   McpResponse,
 } from '../mcp/types.js'
 import { INTERNAL_ERROR, INVALID_PARAMS } from '../mcp/types.js'
+import { isModernProtocolClaim } from '../mcp/protocol-version.js'
 import type { CompiledPolicy } from './types.js'
 import type { PolicyDecision } from './engine.js'
 import { decide } from './decision-pipeline.js'
@@ -1916,6 +1917,11 @@ export class GovernedForwarder implements McpForwarder {
       id: request.id ?? null,
       result: {
         content: [{ type: 'text', text: JSON.stringify(payload) }],
+        // `resultType` is REQUIRED on every 2026-07-28 result; earlier
+        // revisions never defined it, so the field rides on the client's
+        // validated wire claim — the same tokenizer the #226 door uses for
+        // its tier decision, keeping the two verdicts in agreement.
+        ...(isModernProtocolClaim(request.protocolVersion) ? { resultType: 'complete' } : {}),
       },
     }
     const response: McpResponse = {

--- a/packages/proxy/src/transport/header-body-agreement.test.ts
+++ b/packages/proxy/src/transport/header-body-agreement.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import { isModernProtocolClaim } from '../mcp/protocol-version.js'
 import {
-  isModernProtocolClaim,
   validateHeaderBodyAgreement,
   type HeaderBodyAgreementInput,
 } from './header-body-agreement.js'

--- a/packages/proxy/src/transport/header-body-agreement.ts
+++ b/packages/proxy/src/transport/header-body-agreement.ts
@@ -32,11 +32,12 @@
  * HTTP surface (400 + JSON-RPC -32020) and the audit recorder.
  */
 
-import { decodeSentinelValue, nameBearingField } from '../upstream/standard-headers.js'
 import {
   HELIO_MCP_MODERN_PROTOCOL_VERSION,
-  MCP_META_PROTOCOL_VERSION_KEY,
-} from '../upstream/upstream-session-manager.js'
+  isModernProtocolClaim,
+} from '../mcp/protocol-version.js'
+import { decodeSentinelValue, nameBearingField } from '../upstream/standard-headers.js'
+import { MCP_META_PROTOCOL_VERSION_KEY } from '../upstream/upstream-session-manager.js'
 
 /** Everything the agreement check reads, already extracted from the wire. */
 export interface HeaderBodyAgreementInput {
@@ -71,25 +72,6 @@ export interface HeaderMismatchEvidence {
 export type HeaderBodyAgreementResult =
   | { readonly ok: true }
   | { readonly ok: false; readonly reason: string; readonly evidence: HeaderMismatchEvidence }
-
-/**
- * True iff the raw `MCP-Protocol-Version` value is the modern claim, under
- * the pinned tier tokenizer: split on `,`, trim each token with
- * `String.prototype.trim` — deliberately NOT an RFC-OWS `[ \t]` trim, so
- * exotic Unicode padding (NBSP and friends) cannot dodge the presence
- * profile — drop empty tokens, and require at least one remaining token
- * with every one exactly `2026-07-28`. Duplicated headers arrive
- * comma-joined, so an all-modern duplicate is still the modern claim while
- * a mixed duplicate is not.
- */
-export function isModernProtocolClaim(rawValue: string | undefined): boolean {
-  if (rawValue === undefined) return false
-  const tokens = rawValue
-    .split(',')
-    .map((token) => token.trim())
-    .filter((token) => token.length > 0)
-  return tokens.length > 0 && tokens.every((token) => token === HELIO_MCP_MODERN_PROTOCOL_VERSION)
-}
 
 /** Longest echoed value in a rejection reason; the audit record carries the full truth. */
 const DISPLAY_CAP_CHARS = 256

--- a/packages/proxy/src/upstream/streamable-http-forwarder.ts
+++ b/packages/proxy/src/upstream/streamable-http-forwarder.ts
@@ -1,4 +1,8 @@
 import type { McpForwarder, McpRequest, ForwardResult, McpResponse } from '../mcp/types.js'
+import {
+  HELIO_MCP_LEGACY_PROTOCOL_VERSION,
+  HELIO_MCP_MODERN_PROTOCOL_VERSION,
+} from '../mcp/protocol-version.js'
 import { parseUpstreamResponse } from './response.js'
 import { readSseJsonRpcResponse } from './sse-parse.js'
 import { mergeUpstreamHeaders } from './merge-headers.js'
@@ -11,8 +15,6 @@ import {
 import { describeUnreachableUpstream } from './connection-error.js'
 import {
   UpstreamSessionManager,
-  HELIO_MCP_LEGACY_PROTOCOL_VERSION,
-  HELIO_MCP_MODERN_PROTOCOL_VERSION,
   MCP_META_PROTOCOL_VERSION_KEY,
   MCP_MODERN_ONLY_ERROR_CODES,
   buildInternalMeta,

--- a/packages/proxy/src/upstream/upstream-session-manager.ts
+++ b/packages/proxy/src/upstream/upstream-session-manager.ts
@@ -1,12 +1,11 @@
 import { HEADER_MISMATCH } from '../mcp/types.js'
+import {
+  HELIO_MCP_LEGACY_PROTOCOL_VERSION,
+  HELIO_MCP_MODERN_PROTOCOL_VERSION,
+} from '../mcp/protocol-version.js'
 import { mergeUpstreamHeaders } from './merge-headers.js'
 import { describeUnreachableUpstream } from './connection-error.js'
 import { parseSseChunk, readSseJsonRpcResponse } from './sse-parse.js'
-
-/** The legacy leg's protocol offer — one of the two revisions Helio speaks. */
-export const HELIO_MCP_LEGACY_PROTOCOL_VERSION = '2025-06-18'
-/** MCP revision Helio speaks to a modern upstream (no initialize handshake). */
-export const HELIO_MCP_MODERN_PROTOCOL_VERSION = '2026-07-28'
 /**
  * Throttle on era re-probing, armed by a probe failure and by both
  * falsified-era clears (relay falsification and the internal initialize


### PR DESCRIPTION
## Description

MCP `2026-07-28` requires every result to carry a `resultType` field, and the dry-run
response is the one result Helio manufactures without an upstream round-trip. The
synthesized result now carries `resultType: "complete"` when the client's validated
`MCP-Protocol-Version` claim is `2026-07-28`, decided by the same tokenizer the
header/body agreement door (#226) uses for its tier selection, so the response shape and
the door's tier decision agree by construction. Requests with no claim, a legacy claim, or
a malformed claim keep today's bytes, and error responses (deny, drift block,
misconfiguration, unsupported, budget breach) are untouched: the revision defines no
`resultType` on errors.

The version vocabulary moves to a new leaf module `mcp/protocol-version.ts` (both
protocol-version constants plus `isModernProtocolClaim`, verbatim), so the policy layer
shares the door's tokenizer without importing the transport door and the upstream
machinery behind it. No behavior change on the moved code; the existing transport and
upstream suites pin it.

The `initialize`-bridge result stays `resultType`-free by design (#219's pinned
legacy-revision payload), and the pre-existing `id: request.id ?? null` envelope fallback
is deliberately untouched; that gap is #282, filed during planning as its own design
question.

Closes #227

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. Set `policies.dry_run: true` and start the proxy against any upstream.
2. Send a door-passing modern `tools/call`:

   ```bash
   curl -s localhost:3000/mcp \
     -H 'content-type: application/json' \
     -H 'mcp-protocol-version: 2026-07-28' \
     -H 'mcp-method: tools/call' \
     -H 'mcp-name: get_weather' \
     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}'
   ```

   The `result` carries `"resultType": "complete"` alongside the dry-run `content` payload.

3. Send the same body with no `mcp-*` headers: the result is byte-identical to today's,
   with no `resultType` member.
4. `pnpm --filter @gethelio/proxy test` — `governed-forwarder.test.ts` pins the six-claim
   matrix (modern global, modern per-rule, absent, legacy, comma-joined duplicate,
   malformed) and `integration-governance.test.ts` locks the route-capture-to-gate chain
   end to end.

## Additional Context

The dry-run response example in `docs/policies.md` now shows the modern envelope with a
sentence covering the omit cases (`2025-06-18` clients and the header-less SSE/stdio
transports), and the CHANGELOG carries a Fixed entry under Unreleased. Not breaking:
clients MUST already treat a result from an earlier-protocol server that omits the field
as `"complete"`, so the legacy-path bytes are unchanged and the modern-path addition is
the spec-required shape.
