### PR TITLE
docs: position stateful governance after the stateless protocol pivot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,7 +314,7 @@ sdk:
 - `better-sqlite3` (and `esbuild`) native builds are approved via `allowBuilds` in `pnpm-workspace.yaml` — no manual rebuild needed. `pnpm-workspace.yaml` also pins a few transitive `overrides` and the audit ignore list (`auditConfig.ignoreGhsas`).
 - CI runs on the Node version in `.nvmrc` and Python 3.12; the E2E Python SDK test does `pip install ./packages/python-sdk`.
 - The proxy depends on the official `@modelcontextprotocol/sdk` pinned to an exact version (`devDependencies` in `packages/proxy`) — monitor it for breaking changes.
-- Session identity is resolved by the proxy (`session.identity`, issue #218): the `x-helio-session-id` header by default, the legacy `Mcp-Session-Id` during the deprecation window. The resolved id keys evidence/dependency state and session-scoped limits/budgets; the wire `Mcp-Session-Id` is relayed to the upstream verbatim and never replaced.
+- Session identity is resolved by the proxy (`session.identity`, issue #218): the `x-helio-session-id` header by default, the legacy `Mcp-Session-Id` during the deprecation window. The resolved id keys evidence/dependency state and session-scoped limits/budgets; the wire `Mcp-Session-Id` is relayed upstream on the legacy leg only; against a modern upstream it is never sent.
 - The name "Helio" comes from Helios, the Greek Titan god of the Sun.
 
 ## Post-v1 Roadmap

--- a/README.md
+++ b/README.md
@@ -311,6 +311,15 @@ Every tool call recorded: timestamp, agent identity, tool name, inputs, policy d
 
 ## How Helio Compares
 
+The `2026-07-28` MCP revision made the protocol itself stateless: no handshake, no
+protocol-level sessions, cross-call state carried as handles the model passes between
+tools. That pattern works for application state and fails for governance state,
+because a budget key the model can see is a budget key the model can change. Helio
+keeps session identity, budgets, and evidence in the proxy, outside the agent's
+context, which is why those controls still mean something after the protocol
+stopped tracking sessions. See
+[stateless protocol, stateful governance](docs/policies.md#stateless-protocol-stateful-governance).
+
 |                                              | Helio                                    | Obot                           | Cerbos                            | Built-in (Anthropic / OpenAI)         | Framework (LangChain / CrewAI)      |
 | -------------------------------------------- | ---------------------------------------- | ------------------------------ | --------------------------------- | ------------------------------------- | ----------------------------------- |
 | **What it governs**                          | Per-call actions with cross-call state   | Which tools/MCPs are reachable | App-level authorization decisions | Agent permissions inside one platform | Agent behavior inside one framework |

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -362,7 +362,7 @@ Rate limits use a **sliding window** algorithm to track calls per key. Configure
 **Key scoping:**
 
 - `tool` (default) — One shared limit per tool name, across all sessions.
-- `session` — Each MCP session has its own independent limit.
+- `session` — Each resolved [session identity](./configuration.md#session) has its own independent limit.
 - `sender_id` — One limit per adapter-supplied `sender_id` (host-enforced path). Requires the SDK sideband (`sdk.enabled: true`) — Helio **rejects** the config otherwise, since a sender-keyed limit is meaningless without a sender. On the MCP path (which has no sender) it falls back to `tool` with a one-time warning.
 - `agent` — Currently unsupported on MCP requests; Helio logs a warning and falls back to `tool`.
 
@@ -665,6 +665,42 @@ A gated call made before its dependencies have succeeded is denied with `reason:
 ```
 
 `action` reports the effective decision: the dependency gate denies the call before the rule's `allow` applies.
+
+## Stateless Protocol, Stateful Governance
+
+The `2026-07-28` MCP revision removed protocol-level sessions: no `initialize`
+handshake, no `Mcp-Session-Id` header, no server-held conversation state. It is
+tempting to read that as "stateful governance is obsolete." The opposite is true, and
+the reason matters when you evaluate what a governance layer can actually enforce.
+
+The spec did not abolish cross-call state. It relocated it: servers that need state
+across calls are told to use explicit, server-minted handles passed as ordinary tool
+arguments. That is a sound pattern for application state. The model can see the handle
+and thread it between tools, which is exactly what makes multi-step workflows
+composable.
+
+It is an unsound pattern for governance state. A budget key the model can see is a
+budget key the model can change. If a cumulative spend limit were keyed by a handle the
+agent carries in its own context, the agent could drop it, swap it, or start over with
+a fresh one, and the limit would reset to zero each time. The same applies to
+[evidence requirements](#evidence-requirements) and
+[dependency chains](#dependency-chains): a prerequisite the model attests to itself is
+no prerequisite at all.
+
+Helio holds governance state in the proxy, outside the protocol and outside the
+agent's context. [Session identity](./configuration.md#session) is resolved by the
+proxy, never from tool arguments the model can rewrite, and it keys the session-scoped
+[rate limits](#rate-limits), [spend limits](#spend-limits),
+[budgets](#cross-tool-spend-budgets), evidence, and dependency state described above.
+None of that depends on the protocol's session machinery, so the `2026-07-28`
+revision changes how Helio talks to upstream servers (see
+[era detection](./configuration.md#upstream-mcp-era-detection)) without changing what
+it can enforce.
+
+The distinction is structural. A governance layer that holds no state of its own
+cannot make a cumulative cross-call constraint mean anything: no running budget, no
+dependency chain, no evidence grounding. The protocol shed its state so servers can
+scale. The governor keeps its own so that limits keep meaning something.
 
 ## Feedback Messages
 

--- a/docs/sideband-api.md
+++ b/docs/sideband-api.md
@@ -670,7 +670,7 @@ Emergency force-approval. Both `approved_by` and `reason` are required. The reso
 
 #### GET /api/evidence/:session_id
 
-Get the full evidence + context + completed-tools state for a single MCP session. Unknown session IDs return an empty state (not a 404) so that dashboard pages can render cleanly on first load.
+Get the full evidence + context + completed-tools state for a single resolved [session identity](./configuration.md#session). Unknown session IDs return an empty state (not a 404) so that dashboard pages can render cleanly on first load.
 
 **Response (200):**
 

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -311,6 +311,15 @@ Every tool call recorded: timestamp, agent identity, tool name, inputs, policy d
 
 ## How Helio Compares
 
+The `2026-07-28` MCP revision made the protocol itself stateless: no handshake, no
+protocol-level sessions, cross-call state carried as handles the model passes between
+tools. That pattern works for application state and fails for governance state,
+because a budget key the model can see is a budget key the model can change. Helio
+keeps session identity, budgets, and evidence in the proxy, outside the agent's
+context, which is why those controls still mean something after the protocol
+stopped tracking sessions. See
+[stateless protocol, stateful governance](https://github.com/gethelio/helio/blob/main/docs/policies.md#stateless-protocol-stateful-governance).
+
 |                                              | Helio                                    | Obot                           | Cerbos                            | Built-in (Anthropic / OpenAI)         | Framework (LangChain / CrewAI)      |
 | -------------------------------------------- | ---------------------------------------- | ------------------------------ | --------------------------------- | ------------------------------------- | ----------------------------------- |
 | **What it governs**                          | Per-call actions with cross-call state   | Which tools/MCPs are reachable | App-level authorization decisions | Agent permissions inside one platform | Agent behavior inside one framework |


### PR DESCRIPTION
Closes #225.

## What this does

Adds a "Stateless Protocol, Stateful Governance" section to `docs/policies.md`, placed after Dependency Chains so it reads as the capstone of the stateful controls it argues for, and a matching intro paragraph to "How Helio Compares" in both READMEs (the npm README links the section with an absolute URL). The position: the 2026-07-28 MCP revision moved cross-call state into model-visible tool arguments, which is sound for application state and unsound for governance state, because a budget key the model can see is a budget key the model can change. Helio keeps session identity, budgets, and evidence in the proxy, outside the agent's context, so those controls still mean something after the protocol stopped tracking sessions.

## Inventory result

The issue's cited surfaces were audited on main before writing anything: all six cites were already fixed by #218, #219, and #226. A fresh repo-wide sweep found two residual phrasings that still keyed limits and evidence to "MCP sessions":

- the rate-limit key scoping bullet in `docs/policies.md`
- the evidence endpoint description in `docs/sideband-api.md`

Both now point at the proxy-resolved session identity. The sweep also surfaced one stale clause in the AGENTS.md Useful Context section, which claimed the wire `Mcp-Session-Id` is always relayed upstream verbatim; it is now aligned with era detection (relayed on the legacy leg only, never sent to a modern upstream).

## Out of scope

The landing-page copy pass the issue mentions is tracked outside this repo.

Docs only: no source changes and no CHANGELOG entry (a positioning section is not user-visible behavior, defaults, security posture, or a breaking change).
