### PR TITLE
docs: record the policy denial error code as grandfathered

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -235,7 +235,7 @@ The request is blocked immediately. No upstream request is made. The response is
 }
 ```
 
-The `data` object also carries `rule_index` and `policy_reason`; the fields shown above are the ones an agent typically acts on.
+The `data` object also carries `rule_index` and `policy_reason`; the fields shown above are the ones an agent typically acts on. Detect a denial by keying on `data.blocked` and `data.reason`, not on the numeric error code: `-32001` predates the MCP `2026-07-28` error-code allocation policy and is retained as grandfathered, and receivers must not assume meaning for this code.
 
 ### require_approval
 

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -59,7 +59,16 @@ import { buildSessionUnresolvedFeedback } from '../feedback/self-repair.js'
 import { DEFAULT_SESSION_IDENTITY } from '../mcp/session-resolver.js'
 import type { CompiledSessionIdentity } from '../mcp/session-resolver.js'
 
-/** Custom JSON-RPC error code for policy denials. */
+/**
+ * Custom JSON-RPC error code for policy denials.
+ *
+ * Allocated before MCP 2026-07-28 partitioned the implementation-defined
+ * error range. That revision places -32000 to -32019 in a legacy sub-range:
+ * new codes must not be allocated there, and receivers must not assume any
+ * specific meaning for this code. Kept as grandfathered (issue #235
+ * ruling); the durable denial contract for clients is the error's data
+ * payload (blocked, reason, rule), never this number.
+ */
 const POLICY_DENIED = -32001
 
 /** Options for constructing a GovernedForwarder. */


### PR DESCRIPTION
## Description

Records the #235 ruling in the two places a reader will look for it. The
2026-08-14 decision keeps `-32001` as the policy denial code, grandfathered
under the MCP 2026-07-28 error-code allocation policy, which places it in
the legacy sub-range of codes allocated before the policy existed.

- `packages/proxy/src/policy/governed-forwarder.ts`: the one-line doc
  comment above `POLICY_DENIED` becomes a block comment recording the
  allocation history, the legacy sub-range consequences (new codes must not
  be allocated there; receivers must not assume meaning for this code), and
  the durable client contract: the error's `data` payload, never the number.
- `docs/policies.md`: one sentence at the end of the `### deny` contract
  paragraph telling clients to detect denials by keying on `data.blocked`
  and `data.reason` rather than the numeric code.

The `docs:` type is deliberate: the `packages/proxy` delta is comment-only,
paired with `docs/policies.md` for the docs-drift hook. No behavior changes,
so no CHANGELOG entry, and no new tests: the 23 existing `-32001` assertions
already pin the emitted code.

Closes #235

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [ ] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `git log -p main..HEAD`: the whole diff is the block comment above
   `POLICY_DENIED` and one sentence appended to the `### deny` contract
   paragraph.
2. Compare both texts against the Error Codes section quoted on #235: the
   allocator rule is range-wide, the receiver rule is scoped to this code.
3. `pnpm format:check && pnpm lint && pnpm typecheck && pnpm test`.
