### PR TITLE
ci(docs): count CHANGELOG.md as documentation in the drift guard

### DIFF
--- a/scripts/check-docs-drift-ci.sh
+++ b/scripts/check-docs-drift-ci.sh
@@ -28,12 +28,14 @@ SOURCE_DRIFT_PATTERNS=(
   '^docker/Dockerfile$'
 )
 
+# Member-identical with check-docs-drift.sh's DOC_PATTERNS; no shared source.
 DOC_PATTERNS=(
   '^README\.md$'
   '^CONTRIBUTING\.md$'
   '^SECURITY\.md$'
   '^CODE_OF_CONDUCT\.md$'
   '^DEPENDENCIES\.md$'
+  '^CHANGELOG\.md$'
   '^docs/.*\.md$'
   '^packages/proxy/README\.md$'
   '^packages/dashboard/README\.md$'

--- a/scripts/check-docs-drift.sh
+++ b/scripts/check-docs-drift.sh
@@ -51,13 +51,17 @@ SOURCE_DRIFT_PATTERNS=(
 
 # Regex patterns matching files that count as "the committer updated a doc".
 # A match here means the commit is exempt from the drift check — the committer
-# is on record as having touched docs in the same unit of work.
+# is on record as having touched docs in the same unit of work. CHANGELOG.md
+# counts for the same reason: a changelog entry puts the committer on record
+# in the same unit of work (issue #307).
+# Member-identical with check-docs-drift-ci.sh's DOC_PATTERNS; no shared source.
 DOC_PATTERNS=(
   '^README\.md$'
   '^CONTRIBUTING\.md$'
   '^SECURITY\.md$'
   '^CODE_OF_CONDUCT\.md$'
   '^DEPENDENCIES\.md$'
+  '^CHANGELOG\.md$'
   '^docs/.*\.md$'
   '^packages/proxy/README\.md$'
   '^packages/dashboard/README\.md$'
@@ -153,7 +157,7 @@ fi
   echo "  SECURITY.md            packages/dashboard/README.md"
   echo "  CODE_OF_CONDUCT.md     packages/python-sdk/README.md"
   echo "  DEPENDENCIES.md        docker/README.md"
-  echo "                         examples/*/README.md"
+  echo "  CHANGELOG.md           examples/*/README.md"
   echo ""
   echo "If the change in any of the files above affects env vars, CLI"
   echo "flags, config keys, HTTP endpoints, curl / python / yaml snippets,"


### PR DESCRIPTION
## Description

The docs-drift guard recognizes only README and docs pages as documentation. A PR that changes drift-listed source and pairs it with only a changelog entry fails the CI twin, and the post-merge main run (base `HEAD~1`) goes red on its squash commit with no non-admin bypass. This PR adds `CHANGELOG.md` to `DOC_PATTERNS` in both guard scripts: a changelog entry puts the committer on record in the same unit of work, which is exactly the exemption's contract. The two arrays stay member-identical (there is no shared source between the scripts), and the hook's failure message now names `CHANGELOG.md` among the pairing files.

This is the merge-gate precursor for #295, the first source+CHANGELOG-only ticket of v0.13.0. The wider guard friction on comment-only and test-only changes stays open on #270 by design and is not touched here. Also deliberately untouched: `scripts/validate-config-samples.mjs` and `packages/proxy/src/config-samples-guard.test.ts`, whose "drift script's DOC_PATTERNS" comments describe a different contract (yaml-fence scanning over the markdown set); `CHANGELOG.md` has no yaml fences and is not scanned. This PR itself carries no CHANGELOG entry: contributor tooling, not user-visible behavior, per the changelog's own scope note and the samples-guard precedent.

Closes #307

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [x] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [ ] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [ ] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [ ] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

The three unchecked items are not applicable here; see Additional Context.

## How to Test

1. On a throwaway branch off this PR's parent, add a line to a drift-listed source file (any `packages/proxy/src/policy/*.ts`), append a line to `CHANGELOG.md`, stage both, and run `bash scripts/check-docs-drift.sh`. It exits 0 with this change and 1 without it.
2. Stage the source file alone and run the hook again. It still exits 1, and the failure message now lists `CHANGELOG.md` among the pairing files.
3. Put the source file and the `CHANGELOG.md` line in one commit (`git commit --no-verify` on the unfixed base) and run `bash scripts/check-docs-drift-ci.sh`. It exits 0 with this change and 1 without it, on both the explicit base-arg path and the no-arg `HEAD~1` fallback. The fallback case is the exact shape of a squash commit's post-merge main run.

## Additional Context

- Fixture evidence recorded before and after the change, all on scratch branches: hook exits went 1/1/0 to 0/1/0 for the pairing, source-only, and existing-docs-pairing cases; CI twin exits went 1 and 1 to 1 and 0 for the source-only and source+CHANGELOG single-commit cases, the latter verified on both diff paths.
- The `DOC_PATTERNS` members of both scripts were extracted and byte-diffed: identical, 12 members each, `'^CHANGELOG\.md$'` with the escaped dot in the same position in both. The anchored pattern matches only the root `CHANGELOG.md`.
- Two full `pnpm test` runs each hit exactly one known-flake failure (a p99 timing miss and a socket `ECONNRESET`, different files, both green in isolation on a diff that touches no TypeScript). Both are noted on #271, including the candidate new ECONNRESET face.
- Checklist N/A items: no TypeScript changed, so the strict-mode item does not apply; the guard scripts have no unit harness, the fixture evidence above stands in for tests; no user-facing behavior changed, so no docs update is owed.
