### PR TITLE
feat(proxy): add upstream label plumbing and partitioned limiter keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ Maintainer notes:
   existing reserved-header message; the migration is deleting the
   line.
 
+### Added
+
+- Internal multi-upstream substrate (#295): the policy match context,
+  the tool-scope limiter keys, budget charges and peek entries, and
+  the upstream lifecycle log lines (era detection, annotation priming,
+  the `/sse` cap refusal) can now carry an operator-chosen upstream
+  label. Nothing sets a label yet; it lights up when the multi-upstream
+  composition ships. Singular-mode behavior, key formats, and log
+  lines are byte-identical.
+- Type-level compatibility note for library embedders (#295): the
+  `BudgetChargeContext` passed to `BudgetEngine.resolveCharges()` has
+  a new required `upstream: string | null` field, so charge-context
+  object literals add `upstream: null` to compile. Runtime behavior
+  is unchanged.
+
 ### Fixed
 
 - The Streamable HTTP forwarder no longer forwards a caller-supplied

--- a/packages/proxy/src/budget/engine.test.ts
+++ b/packages/proxy/src/budget/engine.test.ts
@@ -61,12 +61,18 @@ const COMMIT_META = {
   timestampIso: '2026-07-09T12:00:00.000Z',
 }
 
-function chargeCtx(toolName: string, args: Record<string, unknown>, sessionId?: string) {
+function chargeCtx(
+  toolName: string,
+  args: Record<string, unknown>,
+  sessionId?: string,
+  upstream: string | null = null,
+) {
   return {
     toolName,
     toolArguments: args,
     sessionId: sessionId === undefined ? null : mintGatedSession(sessionId),
     senderId: null,
+    upstream,
   }
 }
 
@@ -157,6 +163,7 @@ describe('BudgetEngine.resolveCharges', () => {
       toolArguments: { amount: 1 },
       sessionId: null,
       senderId: 'U7',
+      upstream: null,
     })
     expect(charges[0]?.bucketKey).toBe('budget:sb:sender:U7')
   })
@@ -206,6 +213,7 @@ describe('BudgetEngine.resolveCharges', () => {
         toolArguments: undefined,
         sessionId: null,
         senderId: null,
+        upstream: null,
       })
       expect(charges).toEqual([])
       expect(failures).toEqual([])
@@ -1587,5 +1595,61 @@ describe('BudgetEngine persistence (PR 2)', () => {
     expect(() => engine.recordAll(gated(charges), COMMIT_META)).not.toThrow()
     expect(countRows()).toBe(2)
     expect(engine.listStates().map((s) => s.buckets[0]?.spent)).toEqual([30, 30])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Upstream label on the charge chain (issue #295)
+// ---------------------------------------------------------------------------
+
+describe('BudgetEngine — upstream label (issue #295)', () => {
+  it('stamps the context upstream onto resolved charges', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const { charges } = engine.resolveCharges({
+      ...chargeCtx('stripe_charge', { amount: 25 }),
+      upstream: 'payments',
+    })
+    expect(charges[0]?.upstream).toBe('payments')
+  })
+
+  it('copies the charge upstream onto peek entries', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const { charges } = engine.resolveCharges({
+      ...chargeCtx('stripe_charge', { amount: 25 }),
+      upstream: 'payments',
+    })
+    const { entries } = engine.peekAll(gated(charges))
+    expect(entries[0]?.upstream).toBe('payments')
+  })
+
+  it('snapshots upstream: null for a null-upstream context (singular mode)', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const { charges } = engine.resolveCharges({
+      ...chargeCtx('stripe_charge', { amount: 25 }),
+      upstream: null,
+    })
+    const { entries } = engine.peekAll(gated(charges))
+    expect(entries[0]?.upstream).toBeNull()
+  })
+
+  it('carries upstream through recordAll snapshots, stale branch included', () => {
+    const { engine } = createEngine([budgetConfig()])
+    const spend = engine.resolveCharges({
+      ...chargeCtx('stripe_charge', { amount: 30 }),
+      upstream: 'payments',
+    })
+    const snapshots = engine.recordAll(gated(spend.charges), COMMIT_META)
+    expect(snapshots[0]?.upstream).toBe('payments')
+
+    // Stale branch: a tuple change between peek and commit bumps the
+    // generation; the stale snapshot must carry the label too.
+    const frozen = engine.resolveCharges({
+      ...chargeCtx('stripe_charge', { amount: 10 }),
+      upstream: 'payments',
+    })
+    engine.reconcile(compileBudgets([budgetConfig({ limit: 500 })]))
+    const staleSnapshots = engine.recordAll(gated(frozen.charges), COMMIT_META)
+    expect(staleSnapshots[0]?.stale).toBe(true)
+    expect(staleSnapshots[0]?.upstream).toBe('payments')
   })
 })

--- a/packages/proxy/src/budget/engine.ts
+++ b/packages/proxy/src/budget/engine.ts
@@ -29,6 +29,13 @@ export interface BudgetChargeContext {
   readonly sessionId: GatedSession | null
   /** Adapter-supplied sender id (sideband only); null on the MCP path. */
   readonly senderId: string | null
+  /**
+   * The governed door's configured upstream name (issue #295); null on the
+   * sideband and in singular mode. Required so every door states its
+   * upstream: a silently-missing value would exempt that door's calls from
+   * upstream-scoped contributors once those exist.
+   */
+  readonly upstream: string | null
 }
 
 /** One budget's share of a call: which bucket, how much. */
@@ -43,6 +50,12 @@ export interface BudgetCharge {
    * NOT repopulate the new pot with old-config spend — recordAll skips it.
    */
   readonly generation: number
+  /**
+   * The charge context's upstream name, stamped only when the door set one
+   * (issue #295). Optional is the honest type: `remintDeferredCharges`
+   * rebuilds charges without it, so deferred commits snapshot null.
+   */
+  readonly upstream?: string
 }
 
 /** A budget whose contributor matched but whose amount was unusable. */
@@ -69,6 +82,11 @@ export interface BudgetPeekEntry {
   readonly remaining: number
   /** Epoch ms when the oldest entry ages out (duration); null for session pots. */
   readonly resetAtMs: number | null
+  /**
+   * The charge's upstream label, or null: sideband calls, singular mode, and
+   * reminted deferred commits all snapshot null (issue #295).
+   */
+  readonly upstream: string | null
   /**
    * Set on recordAll snapshots for charges frozen before a tuple-changing
    * reload: the executed spend was ledgered under its evaluate-time
@@ -399,6 +417,7 @@ export class BudgetEngine {
         bucketKey: this.bucketKey(budget, ctx),
         amount: raw,
         generation: this.generations.get(budget.name) ?? 0,
+        ...(ctx.upstream !== null && { upstream: ctx.upstream }),
       })
     }
 
@@ -908,6 +927,7 @@ export class BudgetEngine {
       spent,
       remaining: Math.max(0, charge.budget.limit - spent),
       resetAtMs,
+      upstream: charge.upstream ?? null,
     }
   }
 }

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -1000,7 +1000,7 @@ audit:
           timeoutMs: 8_000,
         })
         expect(stderr).toContain(
-          'Annotation cache primed: 2 tool definitions baselined for drift detection',
+          '[helio] Annotation cache primed: 2 tool definitions baselined for drift detection',
         )
         expect(upstream.calls.some((call) => call.method === 'tools/list')).toBe(true)
       } finally {

--- a/packages/proxy/src/config/watcher.test.ts
+++ b/packages/proxy/src/config/watcher.test.ts
@@ -210,6 +210,7 @@ ${extraContributor}
       toolArguments: { amount: 60 },
       sessionId: null,
       senderId: null,
+      upstream: null,
     })
     engine.recordAll(mintGatedCharges(charges), {
       kind: 'spend',
@@ -297,6 +298,7 @@ budgets:
       toolArguments: { amount: 60, category: 'ads' },
       sessionId: null,
       senderId: null,
+      upstream: null,
     })
     engine.recordAll(mintGatedCharges(charges), {
       kind: 'spend',
@@ -321,6 +323,7 @@ budgets:
       toolArguments: { amount: 5, category: 'ads' },
       sessionId: null,
       senderId: null,
+      upstream: null,
     })
     expect(stale.charges).toEqual([])
     expect(stale.failures).toEqual([])
@@ -395,6 +398,7 @@ budgets:
       toolArguments: { amount: 60 },
       sessionId: null,
       senderId: null,
+      upstream: null,
     })
     engine.recordAll(mintGatedCharges(charges), {
       kind: 'spend',
@@ -416,6 +420,7 @@ budgets:
       toolArguments: { amount: 50 },
       sessionId: null,
       senderId: null,
+      upstream: null,
     })
     expect(engine.peekAll(mintGatedCharges(post.charges)).allowed).toBe(false)
 

--- a/packages/proxy/src/dashboard/api.test.ts
+++ b/packages/proxy/src/dashboard/api.test.ts
@@ -883,6 +883,7 @@ describe('GET /api/budgets', () => {
       toolArguments: { amount: 30 },
       sessionId: null,
       senderId: null,
+      upstream: null,
     })
     engine.recordAll(mintGatedCharges(charges), {
       kind: 'spend',

--- a/packages/proxy/src/feedback/self-repair.test.ts
+++ b/packages/proxy/src/feedback/self-repair.test.ts
@@ -763,6 +763,7 @@ describe('rule_index emission (issue #144 removed the ruleIndex alias)', () => {
     spent: 100,
     remaining: 0,
     resetAtMs: 60_000,
+    upstream: null,
   }
 
   // Break-glass builders only ever see budgets that raised a ticket.
@@ -915,6 +916,7 @@ describe('rule_index emission (issue #144 removed the ruleIndex alias)', () => {
           spent: 100,
           remaining: 0,
           resetAtMs: null,
+          upstream: null,
         },
       ],
       [
@@ -962,6 +964,7 @@ describe('budget break-glass feedback builders', () => {
     spent: 49,
     remaining: 1,
     resetAtMs: 4_600_000,
+    upstream: null,
   }
 
   it('denied: carries approver identity plus every breached budget', () => {

--- a/packages/proxy/src/policy/annotation-prime-loop.test.ts
+++ b/packages/proxy/src/policy/annotation-prime-loop.test.ts
@@ -209,6 +209,63 @@ describe('startAnnotationPrimeLoop', () => {
     controller.stop()
   })
 
+  it('tags every startup-path line with the upstream name when one is set (issue #295)', async () => {
+    const slowInitial = deferred<AnnotationCachePrimeResult>()
+    const forwarder = fakeForwarder([slowInitial.promise, fail('still down')], ok(2))
+
+    const startPromise = startAnnotationPrimeLoop(forwarder, undefined, 'payments')
+    await vi.advanceTimersByTimeAsync(INITIAL_WAIT_MS)
+    const controller = await startPromise
+
+    expect(messages()).toContain(
+      '[helio][payments] Annotation cache priming did not complete within 1500ms; continuing startup fail-closed and retrying in background',
+    )
+    expect(messages()).toContain(
+      '[helio][payments] Annotation cache prime retry 1 scheduled in 1000ms',
+    )
+
+    slowInitial.resolve(fail('slow upstream'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(messages()).toContain(
+      '[helio][payments] Annotation cache priming failed: slow upstream — undocumented tools will be denied (fail-closed) until priming succeeds',
+    )
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(messages()).toContain(
+      '[helio][payments] Annotation cache prime retry 1 failed: still down — still fail-closed',
+    )
+    expect(messages()).toContain(
+      '[helio][payments] Annotation cache prime retry 2 scheduled in 2000ms',
+    )
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(messages()).toContain(
+      '[helio][payments] Annotation cache primed after retry 2: 2 tool definitions baselined for drift detection (baselines are per-process; a restart re-baselines — review tool_drift audit records before restarting)',
+    )
+    controller.stop()
+  })
+
+  it('tags the success-path primed line with the upstream name (issue #295)', async () => {
+    const forwarder = fakeForwarder([], ok(2))
+    const controller = await startAnnotationPrimeLoop(forwarder, revalidation(300_000), 'payments')
+
+    expect(messages()).toContain(
+      '[helio][payments] Annotation cache primed: 2 tool definitions baselined for drift detection (baselines are per-process; a restart re-baselines — review tool_drift audit records before restarting)',
+    )
+    controller.stop()
+  })
+
+  it('tags the revalidation-failed line with the upstream name (issue #295)', async () => {
+    const forwarder = fakeForwarder([ok(2)], fail('upstream 503'))
+    const controller = await startAnnotationPrimeLoop(forwarder, revalidation(300_000), 'payments')
+
+    await vi.advanceTimersByTimeAsync(300_000)
+    expect(messages()).toContain(
+      '[helio][payments] Tool revalidation failed: upstream 503 — keeping the last baselines; next attempt in 300000ms',
+    )
+    controller.stop()
+  })
+
   it('does not revalidate when disabled, and reconfigure() retimes/starts/stops the timer live', async () => {
     const forwarder = fakeForwarder([], ok(1))
     const controller = await startAnnotationPrimeLoop(forwarder, revalidation(300_000, false))

--- a/packages/proxy/src/policy/annotation-prime-loop.ts
+++ b/packages/proxy/src/policy/annotation-prime-loop.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console -- prime loop reports through the CLI's stderr */
 import type { AnnotationCachePrimeResult, GovernedForwarder } from './governed-forwarder.js'
 import type { CompiledToolRevalidation } from './types.js'
+import { helioLogTag } from '../util/log-label.js'
 
 /** Upper bound to wait for startup cache priming before serving requests. */
 const ANNOTATION_PRIME_INITIAL_WAIT_MS = 1_500
@@ -44,7 +45,9 @@ function computePrimeRetryDelayMs(attempt: number): number {
 export async function startAnnotationPrimeLoop(
   forwarder: Pick<GovernedForwarder, 'primeAnnotationCache'>,
   revalidation: CompiledToolRevalidation | undefined,
+  upstreamName?: string,
 ): Promise<AnnotationPrimeController> {
+  const tag = helioLogTag(upstreamName)
   let stopped = false
   let primed = false
   let retryAttempt = 0
@@ -81,7 +84,7 @@ export async function startAnnotationPrimeLoop(
         if (epoch !== revalidateEpoch) return // reconfigured or stopped mid-flight
         if (!result.success) {
           console.error(
-            `[helio] Tool revalidation failed: ${result.reason ?? 'unknown reason'} — keeping the last baselines; next attempt in ${String(rv.intervalMs)}ms`,
+            `${tag} Tool revalidation failed: ${result.reason ?? 'unknown reason'} — keeping the last baselines; next attempt in ${String(rv.intervalMs)}ms`,
           )
         }
         scheduleRevalidation()
@@ -109,7 +112,7 @@ export async function startAnnotationPrimeLoop(
     retryAttempt += 1
     const delayMs = computePrimeRetryDelayMs(retryAttempt)
     console.error(
-      `[helio] Annotation cache prime retry ${String(retryAttempt)} scheduled in ${String(delayMs)}ms`,
+      `${tag} Annotation cache prime retry ${String(retryAttempt)} scheduled in ${String(delayMs)}ms`,
     )
     retryTimer = setTimeout(() => {
       retryTimer = undefined
@@ -126,8 +129,8 @@ export async function startAnnotationPrimeLoop(
       clearRetryTimer()
       const prefix =
         phase === 'initial'
-          ? '[helio] Annotation cache primed'
-          : `[helio] Annotation cache primed after retry ${String(retryAttempt)}`
+          ? `${tag} Annotation cache primed`
+          : `${tag} Annotation cache primed after retry ${String(retryAttempt)}`
       console.error(
         `${prefix}: ${String(result.toolsCached)} tool definitions baselined for drift detection (baselines are per-process; a restart re-baselines — review tool_drift audit records before restarting)`,
       )
@@ -138,11 +141,11 @@ export async function startAnnotationPrimeLoop(
     const reason = result.reason ?? 'unknown reason'
     if (phase === 'initial') {
       console.error(
-        `[helio] Annotation cache priming failed: ${reason} — undocumented tools will be denied (fail-closed) until priming succeeds`,
+        `${tag} Annotation cache priming failed: ${reason} — undocumented tools will be denied (fail-closed) until priming succeeds`,
       )
     } else {
       console.error(
-        `[helio] Annotation cache prime retry ${String(retryAttempt)} failed: ${reason} — still fail-closed`,
+        `${tag} Annotation cache prime retry ${String(retryAttempt)} failed: ${reason} — still fail-closed`,
       )
     }
     scheduleRetry()
@@ -165,7 +168,7 @@ export async function startAnnotationPrimeLoop(
 
   if (initialOutcome === 'timeout') {
     console.error(
-      `[helio] Annotation cache priming did not complete within ${String(ANNOTATION_PRIME_INITIAL_WAIT_MS)}ms; continuing startup fail-closed and retrying in background`,
+      `${tag} Annotation cache priming did not complete within ${String(ANNOTATION_PRIME_INITIAL_WAIT_MS)}ms; continuing startup fail-closed and retrying in background`,
     )
     scheduleRetry()
   }

--- a/packages/proxy/src/policy/bucket-key.ts
+++ b/packages/proxy/src/policy/bucket-key.ts
@@ -14,8 +14,9 @@
  * whichever rule is checking and stores last-write-wins config. The suffix —
  * not a prefix — keeps the sideband's `sender:`-prefixed cardinality
  * accounting working. Both doors MUST build rate and spend keys through this
- * function: they feed the same limiter instances, so key-format agreement is
- * load-bearing (issue #14 groundwork).
+ * module's functions (`toolLimitKey` for the tool-scope base, this one for
+ * the rule suffix): they feed the same limiter instances, so key-format
+ * agreement is load-bearing (issue #14 groundwork).
  */
 export function ruleBucketKey(baseKey: string, ruleIndex: number): string {
   return `${baseKey}:rule:${String(ruleIndex)}`
@@ -31,4 +32,16 @@ const RULE_SUFFIX_RE = /:rule:(\d+)$/
 export function parseRuleIndex(key: string): number | undefined {
   const match = RULE_SUFFIX_RE.exec(key)
   return match ? Number(match[1]) : undefined
+}
+
+/**
+ * Compose the tool-scope limit base key, partitioned by the configured
+ * upstream name when one is set (issue #295): `upstream:<name>:tool:<tool>`.
+ * With no name the output is byte-identical to today's `tool:<tool>` literal
+ * (singular mode). Session keys deliberately never carry the prefix: session
+ * identity is proxy-owned, and per-upstream session limits are expressed as
+ * scoped rules discriminated by {@link ruleBucketKey}.
+ */
+export function toolLimitKey(toolName: string, upstreamName?: string): string {
+  return upstreamName ? `upstream:${upstreamName}:tool:${toolName}` : `tool:${toolName}`
 }

--- a/packages/proxy/src/policy/decision-pipeline-upstream.test.ts
+++ b/packages/proxy/src/policy/decision-pipeline-upstream.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { decide } from './decision-pipeline.js'
+import type { DecideInput } from './decision-pipeline.js'
+import { compilePolicies } from './parser.js'
+import type { PoliciesConfig } from '../config/schema.js'
+import type { CompiledPolicy } from './types.js'
+import type { ToolDriftEvent } from './annotation-cache.js'
+import { evaluatePolicy } from './engine.js'
+
+// Spy-mode module mock: the real evaluatePolicy runs, its calls are observable.
+// Call history is FILE-WIDE — the beforeEach mockClear below is load-bearing for
+// every call-index assertion (calls[1] = "the second call of THIS test").
+vi.mock('./engine.js', { spy: true })
+
+// ---------------------------------------------------------------------------
+// Upstream label threading through decide() (issue #295)
+// ---------------------------------------------------------------------------
+
+function compile(config: Omit<PoliciesConfig, 'dry_run'> & { dry_run?: boolean }): CompiledPolicy {
+  return compilePolicies({ dry_run: false, ...config }).policy
+}
+
+function input(overrides: Partial<DecideInput> & { policy: CompiledPolicy }): DecideInput {
+  return {
+    toolName: 'send',
+    toolArguments: {},
+    sessionId: undefined,
+    environment: undefined,
+    evidenceStore: undefined,
+    baselineAnnotations: undefined,
+    currentAnnotations: undefined,
+    driftEvent: undefined,
+    ...overrides,
+  }
+}
+
+const drift = (aspects: string[]): ToolDriftEvent => ({
+  toolName: 'send',
+  changes: aspects.map((aspect) => ({ aspect: aspect as never, baseline: 1, current: 2 })),
+})
+
+beforeEach(() => {
+  vi.mocked(evaluatePolicy).mockClear()
+})
+
+describe('decide — upstream threading (issue #295)', () => {
+  it('threads upstream into the base evaluatePolicy match context', () => {
+    const policy = compile({ default: 'allow', rules: [] })
+    decide(input({ policy, upstream: 'payments' }))
+    expect(vi.mocked(evaluatePolicy)).toHaveBeenCalledTimes(1)
+    const ctx = vi.mocked(evaluatePolicy).mock.calls[0]?.[1]
+    expect(ctx?.upstream).toBe('payments')
+  })
+
+  it('threads upstream into the second (current-annotations) context in drift log mode', () => {
+    const policy = compile({ default: 'allow', on_tool_drift: 'log', rules: [] })
+    decide(input({ policy, upstream: 'payments', driftEvent: drift(['description']) }))
+    expect(vi.mocked(evaluatePolicy)).toHaveBeenCalledTimes(2)
+    const ctx = vi.mocked(evaluatePolicy).mock.calls[1]?.[1]
+    expect(ctx?.upstream).toBe('payments')
+  })
+
+  it('without upstream, both match contexts carry the key with value undefined', () => {
+    // The always-pass convention (the metadata pattern): the key is present on
+    // every match context; the sideband's inertness lives in the VALUE being
+    // undefined, never in key absence.
+    const policy = compile({ default: 'allow', on_tool_drift: 'log', rules: [] })
+    decide(input({ policy, driftEvent: drift(['description']) }))
+    expect(vi.mocked(evaluatePolicy)).toHaveBeenCalledTimes(2)
+    for (const call of vi.mocked(evaluatePolicy).mock.calls) {
+      const ctx = call[1]
+      expect(ctx.upstream).toBeUndefined()
+      expect('upstream' in ctx).toBe(true)
+    }
+  })
+})

--- a/packages/proxy/src/policy/decision-pipeline.ts
+++ b/packages/proxy/src/policy/decision-pipeline.ts
@@ -59,6 +59,12 @@ export interface DecideInput {
    * `agent_id` match key — it shadows any literal `metadata.agent_id`.
    */
   readonly agentId?: string | undefined
+  /**
+   * The governed door's configured upstream name (issue #295). A string only
+   * on the MCP path when a name is configured; undefined on the sideband and
+   * in singular mode (upstream-scoped rules inert there).
+   */
+  readonly upstream?: string | undefined
 }
 
 /** The decision plus all the metadata the execution/audit steps consume. */
@@ -109,6 +115,7 @@ export function decide(input: DecideInput): PipelineDecision {
     toolArguments,
     environment,
     metadata,
+    upstream: input.upstream,
   })
 
   // In log mode a drifted tool is evaluated against BOTH the baseline
@@ -122,6 +129,7 @@ export function decide(input: DecideInput): PipelineDecision {
       toolArguments,
       environment,
       metadata,
+      upstream: input.upstream,
     })
     decision = stricterDecision(decision, currentDecision)
   }

--- a/packages/proxy/src/policy/governed-forwarder-upstream.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder-upstream.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GovernedForwarder } from './governed-forwarder.js'
+import { compilePolicies } from './parser.js'
+import { decide } from './decision-pipeline.js'
+import type { McpForwarder, McpRequest, ForwardResult, McpResponse } from '../mcp/types.js'
+import type { PoliciesConfig } from '../config/schema.js'
+
+// Spy-mode module mock: the real decide() runs, its inputs are observable.
+// Call history is FILE-WIDE — the beforeEach mockClear is load-bearing.
+vi.mock('./decision-pipeline.js', { spy: true })
+
+// ---------------------------------------------------------------------------
+// GovernedForwarder → decide() upstream stamping (issue #295)
+// ---------------------------------------------------------------------------
+
+function compile(config: Partial<PoliciesConfig> & Pick<PoliciesConfig, 'rules'>) {
+  return compilePolicies({ default: 'allow', dry_run: false, ...config }).policy
+}
+
+function toolsCall(name: string, args: Record<string, unknown> = {}): McpRequest {
+  return { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } }
+}
+
+function successResult(): ForwardResult {
+  const response: McpResponse = {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    body: { jsonrpc: '2.0', id: 1, result: { content: [{ type: 'text', text: 'ok' }] } },
+  }
+  return { response, durationMs: 5 }
+}
+
+function mockForwarder(): McpForwarder & { forward: ReturnType<typeof vi.fn> } {
+  return { forward: vi.fn().mockResolvedValue(successResult()) }
+}
+
+beforeEach(() => {
+  vi.mocked(decide).mockClear()
+})
+
+describe('GovernedForwarder — upstream stamping (issue #295)', () => {
+  it('stamps the configured upstreamName into the decide() input', async () => {
+    const governed = new GovernedForwarder(mockForwarder(), compile({ rules: [] }), {
+      upstreamName: 'payments',
+    })
+    await governed.forward(toolsCall('get_weather'))
+    expect(vi.mocked(decide)).toHaveBeenCalledTimes(1)
+    const input = vi.mocked(decide).mock.calls[0]?.[0]
+    expect(input?.upstream).toBe('payments')
+  })
+})

--- a/packages/proxy/src/policy/governed-forwarder.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder.test.ts
@@ -3674,6 +3674,138 @@ describe('GovernedForwarder', () => {
     })
   })
 
+  describe('upstream-partitioned limiter keys (issue #295)', () => {
+    it('prefixes tool-scoped rate keys with the configured upstream name', async () => {
+      const inner = mockForwarder()
+      const limiter = new RateLimiter({ cleanupIntervalMs: 0 })
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            match: { tool: 'get_weather' },
+            action: 'rate_limit',
+            limits: { max_calls: 5, window: '1m', key: 'tool' },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        rateLimiter: limiter,
+        upstreamName: 'payments',
+      })
+
+      await governed.forward(toolsCallRequest('get_weather', {}, 1))
+
+      expect(limiter.getKeyState('tool:get_weather:rule:0')).toBeUndefined()
+      expect(limiter.getKeyState('upstream:payments:tool:get_weather:rule:0')?.current).toBe(1)
+    })
+
+    it('prefixes tool-scoped spend keys with the configured upstream name', async () => {
+      const inner = mockForwarder()
+      const spendLimiter = new SpendLimiter({ cleanupIntervalMs: 0 })
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            match: { tool: 'stripe_charge' },
+            action: 'spend_limit',
+            limits: {
+              max_spend: { field: '$.amount', limit: 100, currency: 'USD', window: '1h' },
+            },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        spendLimiter,
+        upstreamName: 'payments',
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 40 }))
+
+      expect(spendLimiter.getKeyState('tool:stripe_charge:rule:0')).toBeUndefined()
+      expect(
+        spendLimiter.getKeyState('upstream:payments:tool:stripe_charge:rule:0')?.current_spend,
+      ).toBe(40)
+    })
+
+    it('prefixes the agent-fallback rate key with the configured upstream name', async () => {
+      const inner = mockForwarder()
+      const limiter = new RateLimiter({ cleanupIntervalMs: 0 })
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            match: { tool: 'get_weather' },
+            action: 'rate_limit',
+            limits: { max_calls: 5, window: '1m', key: 'agent' },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        rateLimiter: limiter,
+        upstreamName: 'payments',
+      })
+
+      await governed.forward(toolsCallRequest('get_weather', {}, 1))
+
+      expect(limiter.getKeyState('tool:get_weather:rule:0')).toBeUndefined()
+      expect(limiter.getKeyState('upstream:payments:tool:get_weather:rule:0')?.current).toBe(1)
+
+      consoleSpy.mockRestore()
+    })
+
+    it('prefixes the sender_id-fallback rate key with the configured upstream name', async () => {
+      const inner = mockForwarder()
+      const limiter = new RateLimiter({ cleanupIntervalMs: 0 })
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            match: { tool: 'get_weather' },
+            action: 'rate_limit',
+            limits: { max_calls: 5, window: '1m', key: 'sender_id' },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        rateLimiter: limiter,
+        upstreamName: 'payments',
+      })
+
+      await governed.forward(toolsCallRequest('get_weather', {}, 1))
+
+      expect(limiter.getKeyState('tool:get_weather:rule:0')).toBeUndefined()
+      expect(limiter.getKeyState('upstream:payments:tool:get_weather:rule:0')?.current).toBe(1)
+
+      consoleSpy.mockRestore()
+    })
+
+    it('never prefixes session keys even when an upstream name is set', async () => {
+      const inner = mockForwarder()
+      const limiter = new RateLimiter({ cleanupIntervalMs: 0 })
+      const policy = compile({
+        default: 'allow',
+        rules: [
+          {
+            match: { tool: 'get_weather' },
+            action: 'rate_limit',
+            limits: { max_calls: 5, window: '1m', key: 'session' },
+          },
+        ],
+      })
+      const governed = new GovernedForwarder(inner, policy, {
+        rateLimiter: limiter,
+        upstreamName: 'payments',
+      })
+
+      await governed.forward(toolsCallWithSession('get_weather', 'abc'))
+
+      expect(limiter.getKeyState('session:abc:rule:0')?.current).toBe(1)
+      expect(limiter.listKeyStates().map((state) => state.key)).toEqual(['session:abc:rule:0'])
+    })
+  })
+
   // -------------------------------------------------------------------------
   // spend_limit action
   // -------------------------------------------------------------------------

--- a/packages/proxy/src/policy/governed-forwarder.test.ts
+++ b/packages/proxy/src/policy/governed-forwarder.test.ts
@@ -3806,6 +3806,75 @@ describe('GovernedForwarder', () => {
     })
   })
 
+  describe('upstream label on budget charge contexts (issue #295)', () => {
+    const chargeBudget = {
+      name: 'daily-cap',
+      limit: 100,
+      currency: 'USD',
+      window: '24h',
+      key: 'global' as const,
+      on_exceed: 'deny' as const,
+      contributors: [{ match: { tool: 'stripe_*' }, field: '$.amount' }],
+    }
+
+    it('passes the configured upstream name at the budget gate site', async () => {
+      const inner = mockForwarder()
+      const engine = new BudgetEngine({
+        budgets: compileBudgets([chargeBudget]),
+        cleanupIntervalMs: 0,
+      })
+      const spy = vi.spyOn(engine, 'resolveCharges')
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+        upstreamName: 'payments',
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 30 }))
+
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0]?.[0]?.upstream).toBe('payments')
+    })
+
+    it('passes the configured upstream name at the dry-run peek site', async () => {
+      const inner = mockForwarder()
+      const engine = new BudgetEngine({
+        budgets: compileBudgets([chargeBudget]),
+        cleanupIntervalMs: 0,
+      })
+      const spy = vi.spyOn(engine, 'resolveCharges')
+      const governed = new GovernedForwarder(
+        inner,
+        compile({ default: 'allow', dry_run: true, rules: [] }),
+        {
+          budgetEngine: engine,
+          upstreamName: 'payments',
+        },
+      )
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 30 }))
+
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0]?.[0]?.upstream).toBe('payments')
+    })
+
+    it('passes upstream: null at the gate site when no name is configured', async () => {
+      const inner = mockForwarder()
+      const engine = new BudgetEngine({
+        budgets: compileBudgets([chargeBudget]),
+        cleanupIntervalMs: 0,
+      })
+      const spy = vi.spyOn(engine, 'resolveCharges')
+      const governed = new GovernedForwarder(inner, compile({ default: 'allow', rules: [] }), {
+        budgetEngine: engine,
+      })
+
+      await governed.forward(toolsCallRequest('stripe_charge', { amount: 30 }))
+
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0]?.[0]?.upstream).toBeNull()
+    })
+  })
+
   // -------------------------------------------------------------------------
   // spend_limit action
   // -------------------------------------------------------------------------

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -93,6 +93,13 @@ export interface GovernedForwarderOptions {
    * default chain (deny mode) for direct/library construction.
    */
   session?: CompiledSessionIdentity
+  /**
+   * The operator-chosen upstream entry name (issue #295, multi-upstream
+   * substrate). Unset in singular mode — every governance surface then
+   * behaves exactly as today. Nothing in the proxy passes it yet; the
+   * multi-upstream composition loop (issue #294) is what will.
+   */
+  upstreamName?: string
 }
 
 /**
@@ -217,6 +224,7 @@ export class GovernedForwarder implements McpForwarder {
   private readonly rateLimiter: RateLimiter | undefined
   private readonly spendLimiter: SpendLimiter | undefined
   private readonly budgetEngine: BudgetEngine | undefined
+  private readonly upstreamName: string | undefined
   private readonly annotationCache = new ToolAnnotationCache()
   private agentKeyWarned = false
   private senderKeyWarned = false
@@ -231,6 +239,7 @@ export class GovernedForwarder implements McpForwarder {
     this.rateLimiter = options?.rateLimiter
     this.spendLimiter = options?.spendLimiter
     this.budgetEngine = options?.budgetEngine
+    this.upstreamName = options?.upstreamName
     this.session = options?.session ?? DEFAULT_SESSION_IDENTITY
     if (this.evidenceStore) {
       this.evidenceStore.setAllowedEvidenceKeys(collectAllowedEvidenceKeys(policy))
@@ -538,6 +547,7 @@ export class GovernedForwarder implements McpForwarder {
       baselineAnnotations: this.annotationCache.get(toolName),
       currentAnnotations: this.annotationCache.getCurrent(toolName),
       driftEvent: this.annotationCache.getDrift(toolName),
+      upstream: this.upstreamName,
     })
 
     // Pre-generated so budget ledger rows can reference the audit record

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -943,6 +943,7 @@ export class GovernedForwarder implements McpForwarder {
       toolArguments,
       sessionId: sessionGate.ok ? sessionGate.session : null,
       senderId: null, // adapter context; absent on the MCP path
+      upstream: this.upstreamName ?? null,
     })
 
     if (charges.length === 0 && failures.length === 0) return { kind: 'proceed' }
@@ -1557,6 +1558,7 @@ export class GovernedForwarder implements McpForwarder {
         toolArguments,
         sessionId: sessionGate.ok ? sessionGate.session : null,
         senderId: null,
+        upstream: this.upstreamName ?? null,
       })
       if (failures.length > 0 || charges.length > 0) {
         const gated = gateBudgetCharges({ charges, failures }, sessionGate)

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -42,7 +42,7 @@ import type {
 } from '../approval/types.js'
 import type { RateLimiter, RateLimitResult } from './rate-limiter.js'
 import type { SpendLimiter, SpendLimitResult } from './spend-limiter.js'
-import { ruleBucketKey } from './bucket-key.js'
+import { ruleBucketKey, toolLimitKey } from './bucket-key.js'
 import { resolvePath } from './matchers.js'
 import type { BudgetEngine, BudgetPeekEntry } from '../budget/engine.js'
 import type { CompiledApproval } from './types.js'
@@ -1602,7 +1602,9 @@ export class GovernedForwarder implements McpForwarder {
   }
 
   /**
-   * Construct a non-session limit bucket key. Session keys are deliberately
+   * Construct a non-session limit bucket key. Tool-scope keys route through
+   * the shared `toolLimitKey` leaf, which prefixes them with the configured
+   * upstream name when one is set (issue #295). Session keys are deliberately
    * NOT built here: they come only from the gate module's `sessionLimitKey`,
    * whose `GatedSession` parameter makes skipping the identity gate a
    * compile error (issue #218) — call sites branch on `key === 'session'`.
@@ -1621,7 +1623,7 @@ export class GovernedForwarder implements McpForwarder {
             '[helio] Warning: limits.key "agent" is not yet supported, falling back to "tool"',
           )
         }
-        return `tool:${toolName}`
+        return toolLimitKey(toolName, this.upstreamName)
       case 'sender_id':
         // sender_id is an adapter (host-enforced) context field — absent on the
         // MCP path, so fall back to tool scope. Config validation rejects this
@@ -1633,10 +1635,10 @@ export class GovernedForwarder implements McpForwarder {
             '[helio] Warning: limits.key "sender_id" has no sender on the MCP path, falling back to "tool"',
           )
         }
-        return `tool:${toolName}`
+        return toolLimitKey(toolName, this.upstreamName)
       case 'tool':
       default:
-        return `tool:${toolName}`
+        return toolLimitKey(toolName, this.upstreamName)
     }
   }
 

--- a/packages/proxy/src/policy/session-gate.test.ts
+++ b/packages/proxy/src/policy/session-gate.test.ts
@@ -3,6 +3,8 @@ import { readdir, readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { dirname, join, relative } from 'node:path'
 import type { BudgetCharge, BudgetChargeFailure } from '../budget/engine.js'
+import { BudgetEngine } from '../budget/engine.js'
+import { compileBudgets } from '../budget/parser.js'
 import type { CompiledBudget } from '../budget/types.js'
 import type { GatedCharges } from './session-gate.js'
 import {
@@ -224,6 +226,56 @@ describe('freezeGatedPlans', () => {
 
     const overridden = remintDeferredCharges(frozen, 9)
     expect([...overridden].map((c) => c.amount)).toEqual([9, 9])
+  })
+
+  it('the freeze → remint round-trip drops a charge-level upstream label (issue #295)', () => {
+    // Deliberate: the drop IS the sideband-null mechanism — a deferred commit
+    // snapshots upstream: null because the reminted charge carries no
+    // upstream key. Do not add a door name to frozen plans.
+    const labeled = gatedCharges([
+      { ...charge(sessionBudget, 'k1', 5), upstream: 'payments' } as BudgetCharge,
+    ])
+    const frozen = freezeGatedPlans(labeled, [false])
+    const reminted = [...remintDeferredCharges(frozen)]
+    expect(reminted[0]).toBeDefined()
+    expect('upstream' in (reminted[0] as object)).toBe(false)
+  })
+
+  it('a deferred commit snapshots upstream: null — freeze/remint drop the label (issue #295)', () => {
+    const engine = new BudgetEngine({
+      budgets: compileBudgets([
+        {
+          name: 'cap',
+          limit: 100,
+          currency: 'USD',
+          window: '24h',
+          key: 'global',
+          on_exceed: 'deny',
+          contributors: [{ match: { tool: 'stripe_*' }, field: '$.amount' }],
+        },
+      ]),
+      cleanupIntervalMs: 0,
+    })
+    const { charges } = engine.resolveCharges({
+      toolName: 'stripe_charge',
+      toolArguments: { amount: 5 },
+      sessionId: null,
+      senderId: null,
+      upstream: 'payments',
+    })
+    const gated = gateBudgetCharges({ charges, failures: [] }, gateSession('run-a', 'deny'))
+    if (!gated.ok) throw new Error('expected ok')
+    const frozen = freezeGatedPlans(gated.charges, [false])
+    const reminted = remintDeferredCharges(frozen)
+
+    const snapshots = engine.recordAll(reminted, {
+      kind: 'spend',
+      auditRecordId: 'audit-1',
+      origin: 'sideband',
+      toolName: 'stripe_charge',
+      timestampIso: '2026-08-25T12:00:00.000Z',
+    })
+    expect(snapshots[0]?.upstream).toBeNull()
   })
 
   it('rejects fresh unfrozen plan-shaped objects at the remint (type-level)', () => {

--- a/packages/proxy/src/policy/session-gate.ts
+++ b/packages/proxy/src/policy/session-gate.ts
@@ -140,6 +140,8 @@ export function freezeGatedPlans(
         `(${String(breached.length)} markers for ${String(charges.length)} charges)`,
     )
   }
+  // Named-field copy only: a charge-level `upstream` label (issue #295) is
+  // deliberately dropped here, so deferred commits snapshot upstream: null.
   return charges.map(
     (charge, index) =>
       ({

--- a/packages/proxy/src/policy/types.ts
+++ b/packages/proxy/src/policy/types.ts
@@ -225,4 +225,10 @@ export interface MatchContext {
    * request column) is merged in by the decision pipeline, not stored here twice.
    */
   readonly metadata?: Readonly<Record<string, unknown>>
+  /**
+   * The governed door's configured upstream name (issue #295). A string only on
+   * the MCP path when a name is configured; undefined on the sideband and in
+   * singular mode, so upstream-scoped rules are inert there by construction.
+   */
+  readonly upstream?: string
 }

--- a/packages/proxy/src/sideband/governance-service-upstream.test.ts
+++ b/packages/proxy/src/sideband/governance-service-upstream.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GovernanceService } from './governance-service.js'
+import type { EvaluateInput } from './governance-service.js'
+import { compilePolicies } from '../policy/parser.js'
+import { decide } from '../policy/decision-pipeline.js'
+import type { AuditWriter } from '../audit/writer.js'
+
+// Spy-mode module mock: the real decide() runs, its inputs are observable.
+// Call history is FILE-WIDE — the beforeEach mockClear is load-bearing.
+vi.mock('../policy/decision-pipeline.js', { spy: true })
+
+// ---------------------------------------------------------------------------
+// Sideband decide() input stays upstream-less (issue #295)
+// ---------------------------------------------------------------------------
+
+function makeService(): GovernanceService {
+  const writer = { push: () => {}, pushImmediate: () => {} } as unknown as AuditWriter
+  return new GovernanceService({
+    policy: compilePolicies({ default: 'allow', dry_run: false, rules: [] }).policy,
+    auditWriter: writer,
+    ttlMs: 600_000,
+    now: () => 1_000_000,
+    sweepIntervalMs: 0,
+  })
+}
+
+function evalInput(): EvaluateInput {
+  return {
+    origin: 'openclaw',
+    agent_id: 'main',
+    session_id: null,
+    tool: { name: 'send' },
+    arguments: {},
+    metadata: null,
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(decide).mockClear()
+})
+
+describe('GovernanceService — upstream-less decide input (issue #295)', () => {
+  it('passes NO upstream key to decide() — sideband calls have no upstream', () => {
+    // Guards the inertness design: upstream-scoped rules are inert on the
+    // sideband because decide() copies an undefined input.upstream onto the
+    // match context. A future accidental stamp here would light them up.
+    const service = makeService()
+    service.evaluate(evalInput())
+    expect(vi.mocked(decide)).toHaveBeenCalledTimes(1)
+    const input = vi.mocked(decide).mock.calls[0]?.[0]
+    expect(input).toBeDefined()
+    expect('upstream' in (input as object)).toBe(false)
+  })
+})

--- a/packages/proxy/src/sideband/governance-service.test.ts
+++ b/packages/proxy/src/sideband/governance-service.test.ts
@@ -1815,6 +1815,17 @@ describe('GovernanceService — budget gate (issue #14)', () => {
     expect(records[0]?.record.block_reason).toBe('budget_exceeded')
   })
 
+  it('passes upstream: null on the sideband charge context (issue #295)', () => {
+    const { service, budgetEngine } = makeService({ budgets: [stripeBudget()] })
+    if (!budgetEngine) throw new Error('expected budgetEngine')
+    const spy = vi.spyOn(budgetEngine, 'resolveCharges')
+
+    service.evaluate(stripeEval(30))
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]?.[0]?.upstream).toBeNull()
+  })
+
   it('fails closed terminally when the contributor amount is invalid', () => {
     const { service, budgetEngine } = makeService({ budgets: [stripeBudget()] })
     const res = service.evaluate(stripeEval('not-a-number'))

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -38,7 +38,7 @@ import type {
 } from '../approval/types.js'
 import type { RateLimiter } from '../policy/rate-limiter.js'
 import type { SpendLimiter } from '../policy/spend-limiter.js'
-import { ruleBucketKey } from '../policy/bucket-key.js'
+import { ruleBucketKey, toolLimitKey } from '../policy/bucket-key.js'
 import type { BudgetEngine, BudgetChargeFailure, BudgetPeekEntry } from '../budget/engine.js'
 import {
   gateSession,
@@ -2004,7 +2004,9 @@ function policyCanRequireApproval(policy: CompiledPolicy): boolean {
 }
 
 /**
- * Construct a non-session limit bucket key. Session keys are deliberately
+ * Construct a non-session limit bucket key. Tool-scope keys route through
+ * the shared `toolLimitKey` leaf but deliberately stay upstream-less here:
+ * a sideband call has no upstream (issue #295). Session keys are deliberately
  * NOT built here: they come only from the gate module's `sessionLimitKey`,
  * whose `GatedSession` parameter makes skipping the identity gate a compile
  * error (issue #218) — call sites branch on `key === 'session'`.
@@ -2020,7 +2022,7 @@ function buildLimitKey(
     case 'agent':
     case 'tool':
     default:
-      return `tool:${toolName}`
+      return toolLimitKey(toolName)
   }
 }
 

--- a/packages/proxy/src/sideband/governance-service.ts
+++ b/packages/proxy/src/sideband/governance-service.ts
@@ -584,6 +584,7 @@ export class GovernanceService {
         toolArguments: req.arguments,
         sessionId: budgetSessionGate.ok ? budgetSessionGate.session : null,
         senderId,
+        upstream: null, // a sideband call has no upstream (issue #295)
       })
 
       const gatedCharges =

--- a/packages/proxy/src/transport/sse.test.ts
+++ b/packages/proxy/src/transport/sse.test.ts
@@ -770,6 +770,40 @@ describe('SSE transport — concurrent session cap (issue #232)', () => {
     errorSpy.mockRestore()
   })
 
+  it('interpolates the configured routeLabel into the cap-refusal line (issue #295)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    // Self-contained history: vi.spyOn returns the shared spy instance, and a
+    // prior failing test never reaches its mockRestore.
+    errorSpy.mockClear()
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder, { maxConcurrentSessions: 0, routeLabel: '/sse/payments' })
+
+    const refused = await app.request('/sse')
+    expect(refused.status).toBe(503)
+    expect(capLogLines(errorSpy)).toEqual([
+      '[helio] /sse/payments at session cap (0); refusing new streams (1 refusals so far).',
+    ])
+    errorSpy.mockRestore()
+  })
+
+  it('emits the byte-exact default-label cap line when no routeLabel is set (issue #295)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    errorSpy.mockClear()
+    const forwarder = createMockForwarder(okResponse)
+    const app = mountRoute(forwarder, { maxConcurrentSessions: 3 })
+
+    await openStream(app)
+    await openStream(app)
+    await openStream(app)
+
+    const refused = await app.request('/sse')
+    expect(refused.status).toBe(503)
+    expect(capLogLines(errorSpy)).toEqual([
+      '[helio] /sse at session cap (3); refusing new streams (1 refusals so far).',
+    ])
+    errorSpy.mockRestore()
+  })
+
   it('refuses with plain JSON that is not a JSON-RPC envelope', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const forwarder = createMockForwarder(okResponse)

--- a/packages/proxy/src/transport/sse.ts
+++ b/packages/proxy/src/transport/sse.ts
@@ -76,6 +76,12 @@ export interface SseRouteOptions {
    * is a hardcoded invariant (see MAX_CONCURRENT_SESSIONS).
    */
   readonly maxConcurrentSessions?: number
+  /**
+   * The route path label operator log lines name (issue #295). Defaults to
+   * `/sse`; a multi-upstream mount passes its own path (e.g. `/sse/<name>`)
+   * so the cap-refusal line names the door that refused.
+   */
+  readonly routeLabel?: string
 }
 
 const ssePostQuerySchema = z.object({
@@ -99,6 +105,7 @@ export function createSseRoute(forwarder: McpForwarder, options: SseRouteOptions
   const forwardHeaderAllowlist = options.forwardHeadersAllowlist ?? []
   const sessionIdentity = options.session ?? DEFAULT_SESSION_IDENTITY
   const maxConcurrentSessions = options.maxConcurrentSessions ?? MAX_CONCURRENT_SESSIONS
+  const routeLabel = options.routeLabel ?? '/sse'
 
   // Time-based cap-refusal throttle: the first refusal logs immediately,
   // then at most one summary per window carrying the cumulative count.
@@ -112,7 +119,7 @@ export function createSseRoute(forwarder: McpForwarder, options: SseRouteOptions
     lastRefusalLogAt = now
     // eslint-disable-next-line no-console -- operational error logging
     console.error(
-      `[helio] /sse at session cap (${String(maxConcurrentSessions)}); refusing new streams (${String(refusalCount)} refusals so far).`,
+      `[helio] ${routeLabel} at session cap (${String(maxConcurrentSessions)}); refusing new streams (${String(refusalCount)} refusals so far).`,
     )
   }
 

--- a/packages/proxy/src/upstream/streamable-http-forwarder.test.ts
+++ b/packages/proxy/src/upstream/streamable-http-forwarder.test.ts
@@ -1757,3 +1757,45 @@ describe('StreamableHttpForwarder legacy-leg parity (issue #219)', () => {
     },
   )
 })
+
+// ---------------------------------------------------------------------------
+// Upstream name threading into the session manager (issue #295)
+// ---------------------------------------------------------------------------
+
+describe('StreamableHttpForwarder upstream name threading (issue #295)', () => {
+  it('threads upstreamName into the session manager era lines', async () => {
+    const logged: string[] = []
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logged.push(args.map((arg) => String(arg)).join(' '))
+    })
+    globalThis.fetch = (_u: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const raw = typeof init?.body === 'string' ? init.body : '{}'
+      const body = JSON.parse(raw) as { method: string }
+      if (body.method === 'server/discover') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: 'helio-era-probe',
+              result: { supportedVersions: ['2026-07-28'] },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        )
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { tools: [] } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+    }
+
+    const fwd = new StreamableHttpForwarder({ url: 'http://up/mcp', upstreamName: 'payments' })
+    await fwd.forwardInternal(req())
+
+    expect(logged).toContain(
+      '[helio][payments] Upstream MCP era detected: modern (2026-07-28, via server/discover)',
+    )
+  })
+})

--- a/packages/proxy/src/upstream/streamable-http-forwarder.ts
+++ b/packages/proxy/src/upstream/streamable-http-forwarder.ts
@@ -46,6 +46,11 @@ export interface StreamableHttpForwarderOptions {
   requestTimeoutMs?: number
   /** `upstream.protocol_version`: `auto` (default) probes; a dated pin skips it. */
   protocolVersion?: UpstreamProtocolVersionPin
+  /**
+   * The operator-chosen upstream entry name (issue #295), threaded to the
+   * session manager's era lifecycle lines. Unset in singular mode.
+   */
+  upstreamName?: string
 }
 
 /**
@@ -71,6 +76,7 @@ export class StreamableHttpForwarder implements McpForwarder {
       staticHeaders: this.staticHeaders,
       requestTimeoutMs: this.requestTimeoutMs,
       protocolVersion: options.protocolVersion,
+      upstreamName: options.upstreamName,
     })
   }
 

--- a/packages/proxy/src/upstream/upstream-session-manager.test.ts
+++ b/packages/proxy/src/upstream/upstream-session-manager.test.ts
@@ -1326,3 +1326,88 @@ describe('UpstreamSessionManager relay era resolution (issue #219)', () => {
     expect(mgr.getDiscoverCapture()).toEqual({ capabilities: {}, instructions: 'be gentle' })
   })
 })
+
+// ---------------------------------------------------------------------------
+// Era line upstream tagging (issue #295)
+// ---------------------------------------------------------------------------
+
+describe('UpstreamSessionManager era line upstream tagging (issue #295)', () => {
+  it('tags the legacy era-detected line with the upstream name', async () => {
+    stubLegacyUpstream('U-tag')
+    const mgr = new UpstreamSessionManager({
+      url: 'http://up/mcp',
+      staticHeaders: {},
+      upstreamName: 'payments',
+    })
+
+    await mgr.ensureInternalSession()
+
+    expect(loggedLines).toContain(
+      '[helio][payments] Upstream MCP era detected: legacy (initialize handshake)',
+    )
+  })
+
+  it('tags the modern era-detected line with the upstream name', async () => {
+    stubUpstream({
+      'server/discover': () =>
+        jsonRpcResult({ supportedVersions: ['2026-07-28'], capabilities: {} }),
+    })
+    const mgr = new UpstreamSessionManager({
+      url: 'http://up/mcp',
+      staticHeaders: {},
+      upstreamName: 'payments',
+    })
+
+    await mgr.ensureInternalSession()
+
+    expect(loggedLines).toContain(
+      '[helio][payments] Upstream MCP era detected: modern (2026-07-28, via server/discover)',
+    )
+  })
+
+  it('tags the era-cleared line with the upstream name', async () => {
+    stubUpstream({ 'server/discover': () => new Response(null, { status: 202 }) })
+    const mgr = new UpstreamSessionManager({
+      url: 'http://up/mcp',
+      staticHeaders: {},
+      upstreamName: 'payments',
+    })
+
+    await mgr.resolveRelayEra()
+    mgr.clearFalsifiedLegacyEra('relayed initialize was answered with HTTP 404')
+
+    expect(loggedLines).toContain(
+      '[helio][payments] Upstream MCP era cleared: relayed initialize was answered with HTTP 404; relays presume legacy and re-probing is throttled for 30s',
+    )
+  })
+
+  it('emits byte-exact untagged era-detected lines when no name is set', async () => {
+    stubUpstream({
+      'server/discover': () =>
+        jsonRpcResult({ supportedVersions: ['2026-07-28'], capabilities: {} }),
+    })
+    const modern = new UpstreamSessionManager({ url: 'http://up/mcp', staticHeaders: {} })
+    await modern.ensureInternalSession()
+
+    stubLegacyUpstream('U-dark')
+    const legacy = new UpstreamSessionManager({ url: 'http://up/mcp', staticHeaders: {} })
+    await legacy.ensureInternalSession()
+
+    expect(loggedLines.filter((line) => line.includes('era detected'))).toEqual([
+      '[helio] Upstream MCP era detected: modern (2026-07-28, via server/discover)',
+      '[helio] Upstream MCP era detected: legacy (initialize handshake)',
+    ])
+  })
+
+  it('emits the byte-exact untagged era-cleared line when no name is set', async () => {
+    stubUpstream({ 'server/discover': () => new Response(null, { status: 202 }) })
+    const mgr = new UpstreamSessionManager({ url: 'http://up/mcp', staticHeaders: {} })
+
+    await mgr.resolveRelayEra()
+    mgr.clearFalsifiedLegacyEra('relayed initialize was answered with HTTP 404')
+
+    expect(eraClearedLines()).toEqual([
+      '[helio] Upstream MCP era cleared: relayed initialize was answered with HTTP 404; relays presume legacy and re-probing is throttled for 30s',
+    ])
+  })
+})

--- a/packages/proxy/src/upstream/upstream-session-manager.ts
+++ b/packages/proxy/src/upstream/upstream-session-manager.ts
@@ -4,6 +4,7 @@ import {
   HELIO_MCP_MODERN_PROTOCOL_VERSION,
 } from '../mcp/protocol-version.js'
 import { mergeUpstreamHeaders, UPSTREAM_POST_ACCEPT } from './merge-headers.js'
+import { helioLogTag } from '../util/log-label.js'
 import { describeUnreachableUpstream } from './connection-error.js'
 import { parseSseChunk, readSseJsonRpcResponse } from './sse-parse.js'
 /**
@@ -71,6 +72,12 @@ export interface UpstreamSessionManagerOptions {
   staticHeaders: Record<string, string>
   requestTimeoutMs?: number
   protocolVersion?: UpstreamProtocolVersionPin
+  /**
+   * The operator-chosen upstream entry name (issue #295): tags the era
+   * lifecycle lines `[helio][<name>]`. Unset in singular mode — the lines
+   * keep their plain `[helio]` tag.
+   */
+  upstreamName?: string
 }
 
 /** Standard modern `_meta` for Helio-internal requests. */
@@ -138,12 +145,14 @@ export class UpstreamSessionManager {
   private inflight: Promise<UpstreamSession> | undefined
   private inflightProbe: Promise<EraProbeOutcome> | undefined
   private probeBackoffUntil = 0
+  private readonly logTag: string
 
   constructor(options: UpstreamSessionManagerOptions) {
     this.url = options.url
     this.staticHeaders = options.staticHeaders
     this.requestTimeoutMs = options.requestTimeoutMs ?? 30_000
     this.pin = options.protocolVersion ?? 'auto'
+    this.logTag = helioLogTag(options.upstreamName)
   }
 
   /** Return the internal session, establishing it once if needed. */
@@ -306,7 +315,7 @@ export class UpstreamSessionManager {
     this.probeBackoffUntil = Date.now() + ERA_PROBE_BACKOFF_MS
     // eslint-disable-next-line no-console -- operator-visible era lifecycle detail
     console.error(
-      `[helio] Upstream MCP era cleared: ${door}; ` +
+      `${this.logTag} Upstream MCP era cleared: ${door}; ` +
         `relays presume legacy and re-probing is throttled for ` +
         `${String(ERA_PROBE_BACKOFF_MS / 1000)}s`,
     )
@@ -375,8 +384,8 @@ export class UpstreamSessionManager {
     // eslint-disable-next-line no-console -- operator-visible startup detail
     console.error(
       era === 'modern'
-        ? `[helio] Upstream MCP era detected: modern (${HELIO_MCP_MODERN_PROTOCOL_VERSION}, via server/discover)`
-        : '[helio] Upstream MCP era detected: legacy (initialize handshake)',
+        ? `${this.logTag} Upstream MCP era detected: modern (${HELIO_MCP_MODERN_PROTOCOL_VERSION}, via server/discover)`
+        : `${this.logTag} Upstream MCP era detected: legacy (initialize handshake)`,
     )
   }
 

--- a/packages/proxy/src/util/log-label.ts
+++ b/packages/proxy/src/util/log-label.ts
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------------------
+// Operator log tag, shared by every module that emits per-upstream `[helio]`
+// lifecycle lines.
+//
+// Leaf module: the single format authority for the upstream qualifier
+// (issue #295), so the tag cannot drift between the era, prime-loop, and
+// future per-upstream lines.
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose the operator log tag: `[helio][<name>]` when an upstream name is
+ * set, the plain `[helio]` otherwise. Every line keeps its universal
+ * `[helio]` anchor (operators filter on it); the name reads as a qualifier
+ * of that tag.
+ */
+export function helioLogTag(upstreamName?: string): string {
+  return upstreamName ? `[helio][${upstreamName}]` : '[helio]'
+}


### PR DESCRIPTION
## Summary

First substrate ticket of the v0.13.0 multi-upstream pass (epic #35), deliberately dark: nothing sets an upstream name yet, and singular-mode behavior is byte-identical (keys, log strings, wire JSON, event payloads).

- Policy: `GovernedForwarderOptions.upstreamName` is stamped into the decision pipeline, and `MatchContext.upstream` / `DecideInput.upstream` thread through both `evaluatePolicy` sites. The sideband decide input stays upstream-less.
- Limiter keys: tool-scope rate and spend keys route through a new shared `toolLimitKey` in the bucket-key leaf (`upstream:<name>:tool:<tool>` when a name is set, today's literal otherwise). Session keys and budget bucket keys never carry the prefix.
- Budgets: `BudgetChargeContext.upstream` (required; null on the sideband and in singular mode) flows from charge to peek entry. Freeze and remint deliberately drop the label, so deferred sideband commits snapshot null. No wire block or event payload reads the new field.
- Logs: a `helioLogTag` helper renders `[helio][<name>]`; the era detected and cleared lines, all six annotation prime-loop lines, and the `/sse` cap-refusal line (via a `routeLabel` option, default `/sse`) can carry the label. No composition site passes any of it.
- CHANGELOG: an `Added` entry for the substrate plus the type-level compatibility note for embedders constructing `BudgetChargeContext` literals.

Depends on #307 (landed as `4c9baef`): the CHANGELOG entry is what satisfies the docs-drift CI twin and the post-merge main run for this dark PR.

## Out of scope (later tickets in the pass)

- Event, audit, CSV, and ticket fields: #292
- Config surface and matchers: #293
- Composition wiring and the LimitsPage tolerance: #294 (the stdio and pin log lines are commented there)

## Notes

- One retarget surfaced during implementation beyond the plan's inventory: four `BudgetPeekEntry` test fixture literals in `feedback/self-repair.test.ts` gained `upstream: null` (typecheck-only; no assertion moved).
- Full-suite flakes during verification were triaged to #271 (eighth occurrence commented there); a clean-main worktree runs green and none of the flaky paths are touched here.

Closes #295
