### PR TITLE
feat(proxy): add named multi-upstream configuration, validated and dark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,11 @@ Maintainer notes:
   dimensions; inert on the sideband). Validation rejects the dead
   combinations up front: `match.upstreams` in singular mode, unknown
   names, combination with `match.metadata`, and combination with
-  sender-keyed limits. Singular configs parse exactly as before.
+  sender-keyed limits. Budget contributors gain the same optional
+  `upstreams` scope: a scoped contributor only feeds its pot from the
+  named doors (never from the sideband), an unscoped contributor keeps
+  charging everywhere, and a `sender_id` budget must keep at least one
+  unscoped contributor. Singular configs parse exactly as before.
 - Upstream attribution substrate (#292): audit records gain a nullable
   `upstream` column (indexed, filterable, appended last in CSV
   exports), dashboard action, approval, limit-warning, and budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,10 @@ Maintainer notes:
   with the `legacy_header` identity source are rejected with a message
   naming the remedy (upstream-minted session ids could collide across
   doors), and `helio validate` warns above 16 upstream entries.
-  Singular configs parse exactly as before.
+  `helio init` scaffolds a commented `# upstreams:` pointer beside the
+  singular section, and the docs samples guard understands both forms
+  (`upstreams` shares the canonical slot of `upstream`). Singular
+  configs parse exactly as before.
 - Upstream attribution substrate (#292): audit records gain a nullable
   `upstream` column (indexed, filterable, appended last in CSV
   exports), dashboard action, approval, limit-warning, and budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ Maintainer notes:
   unscoped contributor. Named configs combining evidence-gated rules
   with the `legacy_header` identity source are rejected with a message
   naming the remedy (upstream-minted session ids could collide across
-  doors), and `helio validate` warns above 16 upstream entries.
+  doors), and `helio validate` warns, without refusing, above 16
+  upstream entries.
   `helio init` scaffolds a commented `# upstreams:` pointer beside the
   singular section, and the docs samples guard understands both forms
   (`upstreams` shares the canonical slot of `upstream`). Singular

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ Maintainer notes:
 
 ### Added
 
+- Named multi-upstream configuration (#293): `helio.yaml` accepts a
+  top-level `upstreams:` list of named upstream entries as an
+  alternative to the singular `upstream:` section; exactly one of the
+  two must be set. Each entry takes every `upstream.*` field plus a
+  required `name` (letters, digits, `_`, `-`; unique within the list).
+  `helio validate` fully validates named configs. `helio start` does
+  not serve them yet: it refuses named mode with an error pointing at
+  the composition work (#294). Singular configs parse exactly as
+  before.
 - Upstream attribution substrate (#292): audit records gain a nullable
   `upstream` column (indexed, filterable, appended last in CSV
   exports), dashboard action, approval, limit-warning, and budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,11 @@ Maintainer notes:
   `upstreams` scope: a scoped contributor only feeds its pot from the
   named doors (never from the sideband), an unscoped contributor keeps
   charging everywhere, and a `sender_id` budget must keep at least one
-  unscoped contributor. Singular configs parse exactly as before.
+  unscoped contributor. Named configs combining evidence-gated rules
+  with the `legacy_header` identity source are rejected with a message
+  naming the remedy (upstream-minted session ids could collide across
+  doors), and `helio validate` warns above 16 upstream entries.
+  Singular configs parse exactly as before.
 - Upstream attribution substrate (#292): audit records gain a nullable
   `upstream` column (indexed, filterable, appended last in CSV
   exports), dashboard action, approval, limit-warning, and budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,12 @@ Maintainer notes:
   required `name` (letters, digits, `_`, `-`; unique within the list).
   `helio validate` fully validates named configs. `helio start` does
   not serve them yet: it refuses named mode with an error pointing at
-  the composition work (#294). Singular configs parse exactly as
-  before.
+  the composition work (#294). For library embedders, `HelioConfig` is
+  now a union of the two modes with `isSingularConfig` /
+  `isNamedConfig` guards exported, and `createApp` throws on a named
+  config, pointing at the upcoming `createMultiApp`. A mode switch is
+  restart-required at the reload boundary. Singular configs parse
+  exactly as before.
 - Upstream attribution substrate (#292): audit records gain a nullable
   `upstream` column (indexed, filterable, appended last in CSV
   exports), dashboard action, approval, limit-warning, and budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,13 @@ Maintainer notes:
   now a union of the two modes with `isSingularConfig` /
   `isNamedConfig` guards exported, and `createApp` throws on a named
   config, pointing at the upcoming `createMultiApp`. A mode switch is
-  restart-required at the reload boundary. Singular configs parse
-  exactly as before.
+  restart-required at the reload boundary. Policy rules gain
+  `match.upstreams`, a non-empty list of configured upstream names
+  (exact match, OR within the list, AND with the other match
+  dimensions; inert on the sideband). Validation rejects the dead
+  combinations up front: `match.upstreams` in singular mode, unknown
+  names, combination with `match.metadata`, and combination with
+  sender-keyed limits. Singular configs parse exactly as before.
 - Upstream attribution substrate (#292): audit records gain a nullable
   `upstream` column (indexed, filterable, appended last in CSV
   exports), dashboard action, approval, limit-warning, and budget

--- a/packages/proxy/src/__tests__/helpers/test-utils.ts
+++ b/packages/proxy/src/__tests__/helpers/test-utils.ts
@@ -2,7 +2,7 @@ import type { AddressInfo } from 'node:net'
 import type { Hono } from 'hono'
 import { serve } from '@hono/node-server'
 import type { ServerType } from '@hono/node-server'
-import type { HelioConfig } from '../../config/index.js'
+import type { HelioConfig, SingularHelioConfig } from '../../config/index.js'
 
 /** A running server with its port and a close method. */
 export interface ManagedServer {
@@ -50,7 +50,7 @@ export function closeServer(server: ServerType): Promise<void> {
  */
 export function makeConfig(
   overrides: {
-    upstream?: Partial<HelioConfig['upstream']>
+    upstream?: Partial<SingularHelioConfig['upstream']>
     listen?: Partial<HelioConfig['listen']>
     dashboard?: Partial<HelioConfig['dashboard']>
     policies?: Partial<HelioConfig['policies']>
@@ -60,7 +60,7 @@ export function makeConfig(
     session?: Partial<HelioConfig['session']>
     sdk?: Partial<HelioConfig['sdk']>
   } = {},
-): HelioConfig {
+): SingularHelioConfig {
   return {
     version: '1',
     upstream: {
@@ -93,7 +93,7 @@ export function makeConfig(
       ...overrides.audit,
     },
     sdk: { enabled: false, port: 3200, host: '127.0.0.1', ...overrides.sdk },
-  } as HelioConfig
+  } as SingularHelioConfig
 }
 
 /**

--- a/packages/proxy/src/budget/engine.test.ts
+++ b/packages/proxy/src/budget/engine.test.ts
@@ -112,6 +112,66 @@ describe('BudgetEngine.resolveCharges', () => {
     expect(charges.map((c) => c.budget.name)).toEqual(['cap-a', 'cap-b'])
   })
 
+  describe('upstream-scoped contributors (issue #293)', () => {
+    const scopedBudget = () =>
+      budgetConfig({
+        contributors: [{ match: { tool: 'stripe_*', upstreams: ['a'] }, field: '$.amount' }],
+      })
+
+    it('charges a scoped contributor on its named door', () => {
+      const { engine } = createEngine([scopedBudget()])
+      const { charges, failures } = engine.resolveCharges(
+        chargeCtx('stripe_charge', { amount: 25 }, undefined, 'a'),
+      )
+      expect(failures).toEqual([])
+      expect(charges).toHaveLength(1)
+      expect(charges[0]?.amount).toBe(25)
+    })
+
+    it('does not charge on a door outside the scope', () => {
+      const { engine } = createEngine([scopedBudget()])
+      const { charges, failures } = engine.resolveCharges(
+        chargeCtx('stripe_charge', { amount: 25 }, undefined, 'b'),
+      )
+      expect(charges).toEqual([])
+      expect(failures).toEqual([])
+    })
+
+    it('does not charge when ctx.upstream is null (singular mode and sideband)', () => {
+      const { engine } = createEngine([scopedBudget()])
+      const { charges, failures } = engine.resolveCharges(
+        chargeCtx('stripe_charge', { amount: 25 }),
+      )
+      expect(charges).toEqual([])
+      expect(failures).toEqual([])
+    })
+
+    it('unscoped contributors keep charging on every door', () => {
+      const { engine } = createEngine([budgetConfig()])
+      for (const upstream of ['a', 'b', null]) {
+        const { charges } = engine.resolveCharges(
+          chargeCtx('stripe_charge', { amount: 25 }, undefined, upstream),
+        )
+        expect(charges).toHaveLength(1)
+      }
+    })
+
+    it('skips a non-matching scoped contributor and lets a later unscoped one supply the amount', () => {
+      const { engine } = createEngine([
+        budgetConfig({
+          contributors: [
+            { match: { tool: 'stripe_*', upstreams: ['a'] }, field: '$.amount' },
+            { match: { tool: 'stripe_*' }, field: '$.total' },
+          ],
+        }),
+      ])
+      const { charges } = engine.resolveCharges(
+        chargeCtx('stripe_charge', { amount: 5, total: 999 }, undefined, 'b'),
+      )
+      expect(charges[0]?.amount).toBe(999)
+    })
+  })
+
   it('uses the first matching contributor when globs overlap', () => {
     const { engine } = createEngine([
       budgetConfig({

--- a/packages/proxy/src/budget/engine.ts
+++ b/packages/proxy/src/budget/engine.ts
@@ -361,14 +361,18 @@ export class BudgetEngine {
   /**
    * Resolve which budgets a call feeds and how much it charges each.
    *
-   * A contributor participates when its tool glob matches the tool name AND
-   * every `match.input` condition holds (absent conditions means the glob
-   * alone decides); the FIRST participating contributor (config order, over
-   * that combined predicate) supplies the amount field. A call that matches
-   * the glob but not the conditions simply does not feed the budget — no
-   * charge, no failure. Once a contributor is selected, a missing,
-   * non-numeric, negative, or non-finite amount fails closed as a `failures`
-   * entry — the caller must deny the call.
+   * A contributor participates when its upstream scope admits the call's
+   * door (absent scope admits every door; a scoped contributor never
+   * participates when `ctx.upstream` is null — sideband, singular mode) AND
+   * its tool glob matches the tool name AND every `match.input` condition
+   * holds (absent conditions means the glob alone decides); the FIRST
+   * participating contributor (config order, over that combined predicate)
+   * supplies the amount field. A call that matches the glob but not the
+   * conditions or the scope simply does not feed the budget — no charge, no
+   * failure — and a later contributor may still participate. Once a
+   * contributor is selected, a missing, non-numeric, negative, or non-finite
+   * amount fails closed as a `failures` entry — the caller must deny the
+   * call.
    */
   resolveCharges(ctx: BudgetChargeContext): {
     charges: BudgetCharge[]
@@ -389,6 +393,8 @@ export class BudgetEngine {
     for (const budget of this.budgets.values()) {
       const contributor = budget.contributors.find(
         (c) =>
+          (c.upstreams === undefined ||
+            (ctx.upstream !== null && c.upstreams.includes(ctx.upstream))) &&
           c.match.tool.test(ctx.toolName) &&
           (c.match.input === undefined || matchInput(c.match.input, matchCtx)),
       )

--- a/packages/proxy/src/budget/parser.test.ts
+++ b/packages/proxy/src/budget/parser.test.ts
@@ -42,6 +42,22 @@ describe('compileBudgets', () => {
     expect(budget?.window).toEqual({ kind: 'session', idleTtlMs: 43_200_000 })
   })
 
+  it('passes contributor match.upstreams through to the compiled contributor (issue #293)', () => {
+    const [budget] = compileBudgets([
+      budgetConfig({
+        contributors: [
+          { match: { tool: 'stripe_*', upstreams: ['files', 'search'] }, field: '$.amount' },
+        ],
+      }),
+    ])
+    expect(budget?.contributors[0]?.upstreams).toEqual(['files', 'search'])
+  })
+
+  it('contributor without upstreams compiles without an upstreams field (issue #293)', () => {
+    const [budget] = compileBudgets([budgetConfig()])
+    expect(budget?.contributors[0]?.upstreams).toBeUndefined()
+  })
+
   it('carries name, limit, currency, key, and on_exceed through', () => {
     const [budget] = compileBudgets([budgetConfig()])
     expect(budget?.name).toBe('daily-cap')

--- a/packages/proxy/src/budget/parser.ts
+++ b/packages/proxy/src/budget/parser.ts
@@ -76,6 +76,9 @@ function compileContributor(
 
   return {
     match: { tool, ...(input !== undefined && { input }) },
+    ...(contributor.match.upstreams !== undefined && {
+      upstreams: [...contributor.match.upstreams],
+    }),
     field: contributor.field,
   }
 }

--- a/packages/proxy/src/budget/types.ts
+++ b/packages/proxy/src/budget/types.ts
@@ -14,6 +14,13 @@ export interface CompiledBudgetContributor {
     /** Flattened conditions (one per path+operator); absent when unconditioned. */
     readonly input?: readonly InputCondition[]
   }
+  /**
+   * Configured upstream names the contributor is scoped to (issue #293);
+   * absent means every door contributes. A scoped contributor never
+   * participates when the charge context carries no upstream (sideband,
+   * singular mode).
+   */
+  readonly upstreams?: readonly string[]
   /** Dot-path into the tool arguments (e.g. "$.amount"), resolved per call. */
   readonly field: string
 }

--- a/packages/proxy/src/cli-forwarder.ts
+++ b/packages/proxy/src/cli-forwarder.ts
@@ -1,7 +1,7 @@
 import { parseDuration } from './config/schema.js'
 import { SseUpstreamForwarder, StreamableHttpForwarder } from './upstream/index.js'
 import { StdioForwarder } from './transport/stdio-wrapper.js'
-import type { HelioConfig } from './config/index.js'
+import type { SingularHelioConfig } from './config/index.js'
 import type { McpForwarder } from './mcp/types.js'
 
 export interface BuiltForwarder {
@@ -14,7 +14,9 @@ export interface BuiltForwarder {
  * `upstream.headers` are passed to the HTTP transports (`streamable-http`,
  * `sse`); `stdio` is a child process with no request headers.
  */
-export async function createForwarderFromConfig(config: HelioConfig): Promise<BuiltForwarder> {
+export async function createForwarderFromConfig(
+  config: SingularHelioConfig,
+): Promise<BuiltForwarder> {
   switch (config.upstream.transport) {
     case 'streamable-http': {
       // connect() is a no-op (upstream sessions are established lazily), so

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -378,6 +378,23 @@ describe('CLI', () => {
       }
     })
 
+    it('scaffolds a commented upstreams: pointer stub (issue #293)', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+      const outPath = join(dir, 'helio.yaml')
+
+      try {
+        const { code } = await runCli(['init', '-o', outPath])
+        expect(code).toBe(0)
+
+        const contents = readFileSync(outPath, 'utf-8')
+        expect(contents).toContain('\n# upstreams:\n')
+        expect(contents).toContain('# Multiple named upstreams (multi-upstream mode)')
+        expect(contents).toContain('#   - name: files')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
     it('scaffolds every top-level section in canonical order', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
       const outPath = join(dir, 'helio.yaml')
@@ -393,6 +410,7 @@ describe('CLI', () => {
         const canonicalOrder = [
           'version',
           'upstream',
+          'upstreams',
           'listen',
           'environment',
           'session',

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -490,6 +490,126 @@ dashboard:
       }
     })
 
+    describe('named-mode acceptance matrix (issue #293)', () => {
+      const NAMED_HEADER = [
+        'version: "1"',
+        'upstreams:',
+        '  - name: files',
+        '    url: "http://localhost:8081/mcp"',
+        '  - name: search',
+        '    url: "http://localhost:8082/mcp"',
+      ].join('\n')
+      const FOOTER = 'dashboard:\n  enabled: false\n'
+
+      const rejectionCases: Array<[string, string, string[]]> = [
+        [
+          'both upstream: and upstreams:',
+          `version: "1"\nupstream:\n  url: "http://localhost:8080/mcp"\nupstreams:\n  - name: files\n    url: "http://localhost:8081/mcp"\n${FOOTER}`,
+          ['upstreams: Set exactly one of'],
+        ],
+        [
+          'neither upstream: nor upstreams:',
+          `version: "1"\n${FOOTER}`,
+          ['(top level): Missing upstream configuration'],
+        ],
+        [
+          'empty upstreams: list',
+          `version: "1"\nupstreams: []\n${FOOTER}`,
+          ['would serve nothing'],
+        ],
+        [
+          'duplicate entry names',
+          `version: "1"\nupstreams:\n  - name: files\n    url: "http://localhost:8081/mcp"\n  - name: files\n    url: "http://localhost:8082/mcp"\n${FOOTER}`,
+          ['upstreams.1.name: Duplicate upstream name "files"'],
+        ],
+        [
+          'entry name outside the charset',
+          `version: "1"\nupstreams:\n  - name: "bad name"\n    url: "http://localhost:8081/mcp"\n${FOOTER}`,
+          ['upstreams.0.name: Upstream names may only contain letters, digits, "_" and "-"'],
+        ],
+        [
+          'stdio entry missing command',
+          `version: "1"\nupstreams:\n  - name: files\n    url: "unused"\n    transport: stdio\n${FOOTER}`,
+          ['upstreams.0.command: "command" is required when transport is "stdio"'],
+        ],
+        [
+          'rule naming an unknown upstream',
+          `${NAMED_HEADER}\npolicies:\n  rules:\n    - match:\n        tool: "*"\n        upstreams: [ghost]\n      action: deny\n${FOOTER}`,
+          ['policies.rules.0.match.upstreams.0: Rule names upstream "ghost"'],
+        ],
+        [
+          'rule combining upstreams with metadata',
+          `${NAMED_HEADER}\npolicies:\n  rules:\n    - match:\n        upstreams: [files]\n        metadata:\n          channel_id: "C1"\n      action: deny\n${FOOTER}`,
+          ['match.upstreams cannot be combined with match.metadata'],
+        ],
+        [
+          'sender_id budget with only scoped contributors',
+          `${NAMED_HEADER}\nbudgets:\n  - name: cap\n    limit: 100\n    currency: USD\n    window: 24h\n    key: sender_id\n    on_exceed: deny\n    contributors:\n      - match:\n          tool: "stripe_*"\n          upstreams: [files]\n        field: "$.amount"\nsdk:\n  enabled: true\n${FOOTER}`,
+          ['budgets.0.key: budget key "sender_id" requires at least one contributor'],
+        ],
+        [
+          'evidence-gated rule under the default legacy_header chain',
+          `${NAMED_HEADER}\npolicies:\n  rules:\n    - match:\n        tool: "*"\n      action: allow\n      requires: [deploy_ticket]\n${FOOTER}`,
+          ['session.identity.1: session.identity includes "legacy_header"'],
+        ],
+      ]
+
+      it.each(rejectionCases)('rejects %s', async (_name, yamlBody, fragments) => {
+        const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+        const configPath = join(dir, 'helio.yaml')
+        writeFileSync(configPath, yamlBody)
+        try {
+          const { code, stderr } = await runCli(['validate', '-c', configPath])
+          expect(code).toBe(1)
+          expect(stderr).toContain('Invalid config')
+          for (const fragment of fragments) {
+            expect(stderr).toContain(fragment)
+          }
+        } finally {
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
+
+      it('accepts a governance-rich named config end to end', async () => {
+        const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+        const configPath = join(dir, 'helio.yaml')
+        writeFileSync(
+          configPath,
+          `${NAMED_HEADER}\n` +
+            'session:\n' +
+            '  identity:\n' +
+            '    - source: header\n' +
+            '      name: x-helio-session-id\n' +
+            'policies:\n' +
+            '  rules:\n' +
+            '    - match:\n' +
+            '        tool: "send_*"\n' +
+            '        upstreams: [files]\n' +
+            '      action: deny\n' +
+            'budgets:\n' +
+            '  - name: cap\n' +
+            '    limit: 100\n' +
+            '    currency: USD\n' +
+            '    window: 24h\n' +
+            '    key: global\n' +
+            '    on_exceed: deny\n' +
+            '    contributors:\n' +
+            '      - match:\n' +
+            '          tool: "stripe_*"\n' +
+            '          upstreams: [files, search]\n' +
+            '        field: "$.amount"\n' +
+            FOOTER,
+        )
+        try {
+          const { code, stderr } = await runCli(['validate', '-c', configPath])
+          expect(code).toBe(0)
+          expect(stderr).toContain(`Config is valid: ${configPath} (1 policy rule, 1 budget)`)
+        } finally {
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
+    })
+
     it('warns above 16 upstreams while still validating (issue #293)', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
       const configPath = join(dir, 'helio.yaml')

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -472,6 +472,29 @@ dashboard:
       }
     })
 
+    it('warns above 16 upstreams while still validating (issue #293)', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+      const configPath = join(dir, 'helio.yaml')
+
+      const entries = Array.from(
+        { length: 17 },
+        (_, i) => `  - name: up-${String(i)}\n    url: "http://localhost:${String(9000 + i)}/mcp"`,
+      ).join('\n')
+      writeFileSync(
+        configPath,
+        `version: "1"\nupstreams:\n${entries}\ndashboard:\n  enabled: false\n`,
+      )
+
+      try {
+        const { code, stderr } = await runCli(['validate', '-c', configPath])
+        expect(code).toBe(0)
+        expect(stderr).toContain('17 upstreams configured')
+        expect(stderr).toContain('Config is valid')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
     it('rejects invalid config (missing upstream.url)', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
       const configPath = join(dir, 'helio.yaml')

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -446,6 +446,32 @@ dashboard:
       }
     })
 
+    it('accepts a named multi-upstream config fully (issue #293)', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+      const configPath = join(dir, 'helio.yaml')
+
+      const namedConfig = `
+version: "1"
+upstreams:
+  - name: files
+    url: "http://localhost:8081/mcp"
+  - name: search
+    url: "http://localhost:8082/mcp"
+    transport: streamable-http
+dashboard:
+  enabled: false
+`
+      writeFileSync(configPath, namedConfig)
+
+      try {
+        const { code, stderr } = await runCli(['validate', '-c', configPath])
+        expect(code).toBe(0)
+        expect(stderr).toContain(`Config is valid: ${configPath} (0 policy rules, 0 budgets)`)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
     it('rejects invalid config (missing upstream.url)', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
       const configPath = join(dir, 'helio.yaml')
@@ -730,6 +756,40 @@ dashboard:
         await expect(startAndCaptureStderr(['-c', configPath])).rejects.toThrow(
           /sdk: Unrecognized key: "enable"/,
         )
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    it('refuses to start a named multi-upstream config, pointing at #294 (issue #293)', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+      const configPath = join(dir, 'helio.yaml')
+      writeFileSync(
+        configPath,
+        'version: "1"\n' +
+          'upstreams:\n' +
+          '  - name: files\n' +
+          '    url: "http://localhost:8081/mcp"\n' +
+          'dashboard:\n' +
+          '  enabled: false\n',
+      )
+
+      try {
+        const err = await startAndCaptureStderr(['-c', configPath]).then(
+          () => null,
+          (e: unknown) => e,
+        )
+        expect(err).toBeInstanceOf(Error)
+        const message = err instanceof Error ? err.message : ''
+        expect(message).toContain(
+          'Error: this config declares named upstreams (upstreams:), which "helio start" ' +
+            'cannot serve yet — multi-upstream composition and routing land with issue #294. ' +
+            '"helio validate" fully validates named configs; to start today, use the ' +
+            'singular "upstream:" form.',
+        )
+        // A refusal, not a validation failure: helio validate accepts this
+        // exact config (pinned above in the validate suite).
+        expect(message).not.toContain('Invalid configuration')
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -6,7 +6,7 @@ import { randomBytes } from 'node:crypto'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { VERSION } from './version.js'
-import { loadConfig, ConfigError, ConfigWatcher } from './config/index.js'
+import { loadConfig, ConfigError, ConfigWatcher, isNamedConfig } from './config/index.js'
 import { findUnroutableApprovalReferences } from './config/reload-boundary.js'
 import { createApp, startServer, startSidebandServer } from './server.js'
 import { createForwarderFromConfig } from './cli-forwarder.js'
@@ -228,6 +228,19 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
       process.exit(1)
     }
     throw err
+  }
+
+  // Refuse (not reject) named mode: the config is valid, but composition and
+  // routing for multiple upstreams land with issue #294. The exit doubles as
+  // the type narrowing — everything below runs on a singular config.
+  if (isNamedConfig(config)) {
+    console.error(
+      'Error: this config declares named upstreams (upstreams:), which "helio start" ' +
+        'cannot serve yet — multi-upstream composition and routing land with issue #294. ' +
+        '"helio validate" fully validates named configs; to start today, use the ' +
+        'singular "upstream:" form.',
+    )
+    process.exit(1)
   }
 
   const bundledDashboardDistPath = config.dashboard.enabled ? getBundledDashboardDistPath() : null

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -47,6 +47,7 @@ import {
   warnIfDashboardOpenMode,
   warnIfNoEnforcement,
   warnIfBudgetWindowExceedsRetention,
+  warnIfManyUpstreams,
 } from './startup-warnings.js'
 import { closeResources } from './shutdown.js'
 import { drainForCrash, registerCrashDrainHook } from './crash-drain.js'
@@ -669,6 +670,12 @@ async function validateCommand(configPath: string): Promise<void> {
       console.error(`Warning: policy ${label}: ${w.message}`)
     }
     compileBudgets(config.budgets)
+
+    // The start command cannot reach this warning yet — it refuses named
+    // mode outright — so validate is where the operator hears it (#293).
+    if (isNamedConfig(config)) {
+      warnIfManyUpstreams(config)
+    }
 
     if (config.dashboard.enabled && !getBundledDashboardDistPath()) {
       console.error(

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -129,6 +129,12 @@ upstream:
 #   headers:
 #     Authorization: "Bearer \${UPSTREAM_TOKEN}"
 
+# Multiple named upstreams (multi-upstream mode) replace \`upstream:\` —
+# set exactly one of the two. See docs/configuration.md.
+# upstreams:
+#   - name: files
+#     url: "http://localhost:8081/mcp"
+
 # listen:
 #   port: 3000
 #   host: 127.0.0.1

--- a/packages/proxy/src/config-samples-guard.test.ts
+++ b/packages/proxy/src/config-samples-guard.test.ts
@@ -875,6 +875,31 @@ describe('config-samples guard', () => {
   )
 
   it(
+    'still fails a fragment carrying both upstream: and upstreams: (issue #293)',
+    { timeout: 60_000 },
+    async () => {
+      // Displacement replaces the HARNESS upstream only — a fence that
+      // itself declares both modes must keep both keys and fail the
+      // exactly-one-of contract loudly.
+      const root = makeTree({
+        'docs/test.md': doc(
+          [
+            'upstream:',
+            "  url: 'http://localhost:8080/mcp'",
+            'upstreams:',
+            '  - name: files',
+            "    url: 'http://localhost:8081/mcp'",
+          ].join('\n'),
+        ),
+      })
+      const { code, output } = await runGuard(root)
+      expect(code).toBe(1)
+      expect(output).toContain('FAIL')
+      expect(output).toContain('Set exactly one of')
+    },
+  )
+
+  it(
     'still fails an upstreams: fragment carrying a bad entry name (issue #293)',
     { timeout: 60_000 },
     async () => {

--- a/packages/proxy/src/config-samples-guard.test.ts
+++ b/packages/proxy/src/config-samples-guard.test.ts
@@ -837,6 +837,149 @@ describe('config-samples guard', () => {
     },
   )
 
+  it('passes a named full-config fence (issue #293)', { timeout: 60_000 }, async () => {
+    const root = makeTree({
+      'docs/test.md': doc(
+        [
+          "version: '1'",
+          'upstreams:',
+          '  - name: files',
+          "    url: 'http://localhost:8081/mcp'",
+          '  - name: search',
+          "    url: 'http://localhost:8082/mcp'",
+          'dashboard:',
+          `  api_secret: '${FIXTURE_SECRET}'`,
+        ].join('\n'),
+      ),
+    })
+    const { code, output } = await runGuard(root)
+    expect(output).toContain('full-config')
+    expect(output).toContain('PASS')
+    expect(code).toBe(0)
+  })
+
+  it(
+    'passes a bare upstreams: fragment by displacing the harness upstream (issue #293)',
+    { timeout: 60_000 },
+    async () => {
+      const root = makeTree({
+        'docs/test.md': doc(
+          ['upstreams:', '  - name: files', "    url: 'http://localhost:8081/mcp'"].join('\n'),
+        ),
+      })
+      const { code, output } = await runGuard(root)
+      expect(output).toContain('fragment')
+      expect(output).toContain('PASS')
+      expect(code).toBe(0)
+    },
+  )
+
+  it(
+    'still fails an upstreams: fragment carrying a bad entry name (issue #293)',
+    { timeout: 60_000 },
+    async () => {
+      // Overlay displacement must not mask a fence that should fail on its
+      // own content.
+      const root = makeTree({
+        'docs/test.md': doc(
+          ['upstreams:', "  - name: 'with:colon'", "    url: 'http://localhost:8081/mcp'"].join(
+            '\n',
+          ),
+        ),
+      })
+      const { code, output } = await runGuard(root)
+      expect(code).toBe(1)
+      expect(output).toContain('FAIL')
+      expect(output).toContain('Upstream names may only contain letters')
+    },
+  )
+
+  it(
+    'flags upstreams: after a later section as an order violation (issue #293)',
+    { timeout: 60_000 },
+    async () => {
+      const root = makeTree({
+        'examples/misordered/helio.yaml': [
+          "version: '1'",
+          'listen:',
+          '  port: 3000',
+          'upstreams:',
+          '  - name: files',
+          "    url: 'http://localhost:8081/mcp'",
+          'dashboard:',
+          `  api_secret: '${FIXTURE_SECRET}'`,
+          '',
+        ].join('\n'),
+      })
+      const { code, output } = await runGuard(root)
+      expect(code).toBe(0)
+      expect(output).toContain('top-level keys not in canonical order')
+      expect(output).toContain('upstream|upstreams')
+    },
+  )
+
+  it(
+    'accepts the upstream/upstreams slot pair in scaffold order and completeness (issue #293)',
+    { timeout: 60_000 },
+    async () => {
+      // The scaffold legitimately carries BOTH the singular section and the
+      // commented named-mode pointer stub in the same canonical slot; either
+      // key satisfies the slot in configuration.md too, so no uncommented
+      // upstreams: fence is demanded of the docs.
+      const completeConfig = [
+        "version: '1'",
+        'upstream:',
+        "  url: 'http://localhost:8080/mcp'",
+        'listen:',
+        '  port: 3000',
+        'environment: production',
+        'session:',
+        '  on_unresolved: deny',
+        'policies:',
+        '  rules: []',
+        'budgets: []',
+        'approval:',
+        "  timeout: '300s'",
+        'audit:',
+        "  retention: '90d'",
+        'dashboard:',
+        `  api_secret: '${FIXTURE_SECRET}'`,
+        'sdk:',
+        '  enabled: false',
+      ].join('\n')
+      const scaffoldWithBothStubs = [
+        'version: "1"',
+        'upstream:',
+        '  url: "x"',
+        '# upstreams:',
+        '#   - name: files',
+        '#     url: "http://localhost:8081/mcp"',
+        '# listen:',
+        '# environment:',
+        '# session:',
+        '# policies:',
+        '# budgets:',
+        '# approval:',
+        '# audit:',
+        '# dashboard:',
+        '# sdk:',
+        '',
+      ].join('\n')
+      const root = makeTree({
+        'scaffold.yaml': scaffoldWithBothStubs,
+        'docs/configuration.md': doc(completeConfig),
+      })
+      const { code, output } = await runGuard(root, [
+        '--scaffold-file',
+        join(root, 'scaffold.yaml'),
+        '--enforce-order',
+        '--enforce-completeness',
+      ])
+      expect(output).not.toContain('violation')
+      expect(code).toBe(0)
+    },
+  )
+
   it('passes a clean fixture tree with exit 0', { timeout: 120_000 }, async () => {
     const basicPolicies = [
       'policies:',

--- a/packages/proxy/src/config/index.ts
+++ b/packages/proxy/src/config/index.ts
@@ -1,4 +1,9 @@
-export { parseDuration } from './schema.js'
-export type { HelioConfig, PoliciesConfig } from './schema.js'
+export { parseDuration, isSingularConfig, isNamedConfig } from './schema.js'
+export type {
+  HelioConfig,
+  SingularHelioConfig,
+  NamedHelioConfig,
+  PoliciesConfig,
+} from './schema.js'
 export { loadConfig, ConfigError } from './loader.js'
 export { ConfigWatcher } from './watcher.js'

--- a/packages/proxy/src/config/loader.test.ts
+++ b/packages/proxy/src/config/loader.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { loadConfig, ConfigError, interpolateEnvVars } from './loader.js'
+import { isSingularConfig } from './schema.js'
 
 // ---------------------------------------------------------------------------
 // interpolateEnvVars
@@ -81,6 +82,8 @@ dashboard:
     const config = await loadConfig(filePath)
 
     expect(config.version).toBe('1')
+    expect(isSingularConfig(config)).toBe(true)
+    if (!isSingularConfig(config)) return
     expect(config.upstream.url).toBe('http://localhost:8080')
     expect(config.upstream.transport).toBe('streamable-http')
     expect(config.listen.port).toBe(3000)
@@ -128,6 +131,8 @@ dashboard:
     const filePath = await writeTempYaml('helio.yaml', yaml)
     const config = await loadConfig(filePath, { UPSTREAM_TOKEN: 'tok-123' })
 
+    expect(isSingularConfig(config)).toBe(true)
+    if (!isSingularConfig(config)) return
     expect(config.upstream.headers).toEqual({ Authorization: 'Bearer tok-123' })
   })
 

--- a/packages/proxy/src/config/reload-boundary.test.ts
+++ b/packages/proxy/src/config/reload-boundary.test.ts
@@ -144,6 +144,43 @@ describe('diffReloadBoundary', () => {
     const diff = diffReloadBoundary(previous, next)
     expect(diff.restartRequiredPaths).toEqual(['listen'])
   })
+
+  describe('named upstreams (issue #293)', () => {
+    const namedConfig = (upstreams: unknown[]): HelioConfig =>
+      parseConfig({ version: '1', upstreams, dashboard: { enabled: false } })
+
+    it('requires restart when the named upstreams list changes', () => {
+      const previous = namedConfig([{ name: 'files', url: 'http://localhost:8081/mcp' }])
+      const next = namedConfig([{ name: 'files', url: 'http://localhost:9091/mcp' }])
+
+      const diff = diffReloadBoundary(previous, next)
+      expect(diff.restartRequiredPaths).toEqual(['upstreams'])
+    })
+
+    it('does not require restart when named lists are deep-equal', () => {
+      const previous = namedConfig([{ name: 'files', url: 'http://localhost:8081/mcp' }])
+      const next = namedConfig([{ name: 'files', url: 'http://localhost:8081/mcp' }])
+
+      const diff = diffReloadBoundary(previous, next)
+      expect(diff.restartRequiredPaths).toEqual([])
+    })
+
+    it('pushes both section labels on a mode switch, in both directions', () => {
+      // The operator edited both sections (one removed, one added) — naming
+      // only one would misreport half the change.
+      const singular = minimalConfig()
+      const named = namedConfig([{ name: 'files', url: 'http://localhost:8081/mcp' }])
+
+      expect(diffReloadBoundary(singular, named).restartRequiredPaths).toEqual([
+        'upstream',
+        'upstreams',
+      ])
+      expect(diffReloadBoundary(named, singular).restartRequiredPaths).toEqual([
+        'upstream',
+        'upstreams',
+      ])
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/proxy/src/config/reload-boundary.ts
+++ b/packages/proxy/src/config/reload-boundary.ts
@@ -1,4 +1,5 @@
 import { isDeepStrictEqual } from 'node:util'
+import { isNamedConfig, isSingularConfig } from './schema.js'
 import type { HelioConfig } from './schema.js'
 import type { CompiledPolicy } from '../policy/types.js'
 import type { CompiledBudget } from '../budget/types.js'
@@ -25,8 +26,18 @@ export interface ReloadBoundaryDiff {
 export function diffReloadBoundary(previous: HelioConfig, next: HelioConfig): ReloadBoundaryDiff {
   const restartRequiredPaths: string[] = []
 
-  if (!isDeepStrictEqual(previous.upstream, next.upstream)) {
-    restartRequiredPaths.push('upstream')
+  if (isSingularConfig(previous) !== isSingularConfig(next)) {
+    // A mode switch edits both sections (one removed, one added) — naming
+    // only one label would misreport half the change.
+    restartRequiredPaths.push('upstream', 'upstreams')
+  } else if (isSingularConfig(previous) && isSingularConfig(next)) {
+    if (!isDeepStrictEqual(previous.upstream, next.upstream)) {
+      restartRequiredPaths.push('upstream')
+    }
+  } else if (isNamedConfig(previous) && isNamedConfig(next)) {
+    if (!isDeepStrictEqual(previous.upstreams, next.upstreams)) {
+      restartRequiredPaths.push('upstreams')
+    }
   }
   if (!isDeepStrictEqual(previous.listen, next.listen)) {
     restartRequiredPaths.push('listen')

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -574,6 +574,22 @@ describe('helioConfigSchema', () => {
       ])
     })
 
+    it.each([
+      ['null', null, 'null'],
+      ['a string', 'nope', 'string'],
+      ['an array', [], 'array'],
+      ['a number', 3, 'number'],
+    ])('rejects %s root as a type error, not a mode error', (_name, input, received) => {
+      // A non-object document is not a config mapping at all — the diagnosis
+      // is the type, never the exactly-one-of contract.
+      const result = helioConfigSchema.safeParse(input)
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        { path: [], message: `Invalid input: expected object, received ${received}` },
+      ])
+    })
+
     it('rejects a config that sets neither upstream: nor upstreams:', () => {
       const result = helioConfigSchema.safeParse({ version: '1', dashboard: { enabled: false } })
       expect(result.success).toBe(false)

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import type { z } from 'zod'
 import {
   helioConfigSchema,
   durationSchema,
@@ -6,7 +7,19 @@ import {
   upstreamNameSchema,
   namedUpstreamEntrySchema,
   upstreamsListSchema,
+  isSingularConfig,
+  isNamedConfig,
 } from './schema.js'
+import type { HelioConfig } from './schema.js'
+
+// Compile-time insurance: the schema's inferred output must stay exactly the
+// declared HelioConfig union — a drift in the dispatch's return type fails
+// `pnpm typecheck` here instead of silently widening downstream.
+type Equal<A, B> =
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- the single-use T on each side IS the exact-equality probe
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
+const _schemaInfersTheDeclaredUnion: Equal<z.infer<typeof helioConfigSchema>, HelioConfig> = true
+void _schemaInfersTheDeclaredUnion
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -132,6 +145,8 @@ describe('helioConfigSchema', () => {
       const result = helioConfigSchema.safeParse(minimalConfig())
       expect(result.success).toBe(true)
       if (!result.success) return
+      expect(isSingularConfig(result.data)).toBe(true)
+      if (!isSingularConfig(result.data)) return
 
       expect(result.data.upstream.transport).toBe('streamable-http')
       expect(result.data.upstream.connect_timeout).toBe('10s')
@@ -461,6 +476,193 @@ describe('helioConfigSchema', () => {
   })
 
   // -------------------------------------------------------------------------
+  // Mode dispatch: upstream | upstreams (issue #293)
+  // -------------------------------------------------------------------------
+
+  describe('mode dispatch: upstream | upstreams (issue #293)', () => {
+    const namedMinimal = (overrides: Record<string, unknown> = {}) => ({
+      version: '1',
+      upstreams: [
+        { name: 'files', url: 'http://localhost:8081/mcp' },
+        { name: 'search', url: 'http://localhost:8082/mcp' },
+      ],
+      dashboard: { enabled: false },
+      ...overrides,
+    })
+
+    it('parses a minimal named config with entry defaults applied', () => {
+      const result = helioConfigSchema.safeParse(namedMinimal())
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(isNamedConfig(result.data)).toBe(true)
+      if (!isNamedConfig(result.data)) return
+      expect(result.data.upstreams).toHaveLength(2)
+      expect(result.data.upstreams[0]?.name).toBe('files')
+      expect(result.data.upstreams[0]?.transport).toBe('streamable-http')
+      expect(result.data.upstreams[0]?.protocol_version).toBe('auto')
+      expect(result.data.upstreams[1]?.name).toBe('search')
+      expect(result.data.session.on_unresolved).toBe('deny')
+      expect(result.data.policies.default).toBe('allow')
+    })
+
+    it('rejects a bad entry name at the entry path through the root schema', () => {
+      const result = helioConfigSchema.safeParse(
+        namedMinimal({ upstreams: [{ name: 'with:colon', url: 'http://localhost:8081/mcp' }] }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['upstreams', 0, 'name'],
+          message: 'Upstream names may only contain letters, digits, "_" and "-"',
+        },
+      ])
+    })
+
+    it('rejects duplicate entry names at the duplicate index through the root schema', () => {
+      const result = helioConfigSchema.safeParse(
+        namedMinimal({
+          upstreams: [
+            { name: 'files', url: 'http://localhost:8081/mcp' },
+            { name: 'files', url: 'http://localhost:8082/mcp' },
+          ],
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['upstreams', 1, 'name'])
+      expect(result.error.issues[0]?.message).toContain('Duplicate upstream name "files"')
+    })
+
+    it('applies every per-entry refinement at the entry path through the root schema', () => {
+      const result = helioConfigSchema.safeParse(
+        namedMinimal({
+          upstreams: [
+            { name: 'files', url: 'x', transport: 'stdio' },
+            { name: 'search', url: 'x', headers: { 'mcp-session-id': 'y' } },
+          ],
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['upstreams', 0, 'command'],
+          message: '"command" is required when transport is "stdio"',
+        },
+        {
+          path: ['upstreams', 1, 'headers', 'mcp-session-id'],
+          message: 'upstream.headers must not set reserved header "mcp-session-id"',
+        },
+      ])
+    })
+
+    it('rejects a config that sets both upstream: and upstreams:', () => {
+      const result = helioConfigSchema.safeParse(
+        namedMinimal({ upstream: { url: 'http://localhost:8080' } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['upstreams'],
+          message:
+            'Set exactly one of "upstream:" (single upstream) or "upstreams:" (named ' +
+            'multi-upstream list) — not both. To migrate, move the upstream: fields into ' +
+            'an upstreams: entry and give it a name.',
+        },
+      ])
+    })
+
+    it('rejects a config that sets neither upstream: nor upstreams:', () => {
+      const result = helioConfigSchema.safeParse({ version: '1', dashboard: { enabled: false } })
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: [],
+          message:
+            'Missing upstream configuration: set exactly one of "upstream:" (single ' +
+            'upstream) or "upstreams:" (named multi-upstream list).',
+        },
+      ])
+    })
+
+    it('rejects an empty upstreams: list with the pinned message', () => {
+      const result = helioConfigSchema.safeParse(namedMinimal({ upstreams: [] }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['upstreams'],
+          message:
+            'upstreams: must declare at least one upstream — an empty list would serve ' +
+            'nothing. For a single upstream you can keep the "upstream:" form.',
+        },
+      ])
+    })
+
+    it('emits named-mode top-level keys in the canonical section order', () => {
+      // Twin of the singular key-order pin: input keys deliberately reversed,
+      // upstreams in slot 2.
+      const result = helioConfigSchema.safeParse({
+        sdk: {},
+        dashboard: { enabled: false },
+        audit: {},
+        approval: {},
+        budgets: [],
+        policies: {},
+        session: {},
+        environment: 'production',
+        listen: {},
+        upstreams: [{ name: 'files', url: 'http://localhost:8081/mcp' }],
+        version: '1',
+      })
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(Object.keys(result.data)).toEqual([
+        'version',
+        'upstreams',
+        'listen',
+        'environment',
+        'session',
+        'policies',
+        'budgets',
+        'approval',
+        'audit',
+        'dashboard',
+        'sdk',
+      ])
+    })
+
+    it('forwards singular-arm issues verbatim through the dispatch', () => {
+      // The singular arm's error shape is the pre-#293 one — pinned so the
+      // dispatch encoding cannot bury or reword singular errors.
+      const result = helioConfigSchema.safeParse(minimalConfig({ upstream: {} }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['upstream', 'url'],
+          message: 'Invalid input: expected string, received undefined',
+        },
+      ])
+    })
+
+    it('narrows with the mode guards', () => {
+      const singular = helioConfigSchema.safeParse(minimalConfig())
+      const named = helioConfigSchema.safeParse(namedMinimal())
+      expect(singular.success).toBe(true)
+      expect(named.success).toBe(true)
+      if (!singular.success || !named.success) return
+      expect(isSingularConfig(singular.data)).toBe(true)
+      expect(isNamedConfig(singular.data)).toBe(false)
+      expect(isNamedConfig(named.data)).toBe(true)
+      expect(isSingularConfig(named.data)).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // Session identity (issue #218)
   // -------------------------------------------------------------------------
 
@@ -681,6 +883,8 @@ describe('helioConfigSchema', () => {
       )
       expect(result.success).toBe(true)
       if (!result.success) return
+      expect(isSingularConfig(result.data)).toBe(true)
+      if (!isSingularConfig(result.data)) return
       expect(result.data.upstream.headers).toEqual({ Authorization: 'Bearer abc' })
     })
 
@@ -755,6 +959,8 @@ describe('helioConfigSchema', () => {
       const result = helioConfigSchema.safeParse(minimalConfig())
       expect(result.success).toBe(true)
       if (!result.success) return
+      expect(isSingularConfig(result.data)).toBe(true)
+      if (!isSingularConfig(result.data)) return
       expect(result.data.upstream.protocol_version).toBe('auto')
     })
 
@@ -766,6 +972,8 @@ describe('helioConfigSchema', () => {
       )
       expect(result.success).toBe(true)
       if (!result.success) return
+      expect(isSingularConfig(result.data)).toBe(true)
+      if (!isSingularConfig(result.data)) return
       expect(result.data.upstream.protocol_version).toBe(version)
     })
 

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -836,6 +836,154 @@ describe('helioConfigSchema', () => {
   })
 
   // -------------------------------------------------------------------------
+  // Budget contributor upstreams scoping (issue #293)
+  // -------------------------------------------------------------------------
+
+  describe('budget contributor upstreams scoping (issue #293)', () => {
+    const namedWithBudgets = (
+      budgets: unknown[],
+      overrides: Record<string, unknown> = {},
+    ): Record<string, unknown> => ({
+      version: '1',
+      upstreams: [
+        { name: 'files', url: 'http://localhost:8081/mcp' },
+        { name: 'search', url: 'http://localhost:8082/mcp' },
+      ],
+      budgets,
+      dashboard: { enabled: false },
+      ...overrides,
+    })
+
+    const budget = (
+      contributors: unknown[],
+      overrides: Record<string, unknown> = {},
+    ): Record<string, unknown> => ({
+      name: 'cap',
+      limit: 100,
+      currency: 'USD',
+      window: '24h',
+      key: 'global',
+      on_exceed: 'deny',
+      contributors,
+      ...overrides,
+    })
+
+    it('accepts a contributor scoped to configured upstream names', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithBudgets([
+          budget([{ match: { tool: 'stripe_*', upstreams: ['files'] }, field: '$.amount' }]),
+        ]),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects a scoped contributor in singular mode', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          budgets: [
+            budget([{ match: { tool: 'stripe_*', upstreams: ['files'] }, field: '$.amount' }]),
+          ],
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['budgets', 0, 'contributors', 0, 'match', 'upstreams'],
+          message:
+            'Contributor sets match.upstreams but the config declares a single "upstream:", ' +
+            'which has no name on purpose. Upstream-scoped contributors require the named ' +
+            '"upstreams:" list.',
+        },
+      ])
+    })
+
+    it('rejects an unknown upstream name at the contributor entry index', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithBudgets([
+          budget([
+            { match: { tool: 'stripe_*', upstreams: ['files', 'ghost'] }, field: '$.amount' },
+          ]),
+        ]),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['budgets', 0, 'contributors', 0, 'match', 'upstreams', 1],
+          message:
+            'Contributor names upstream "ghost" in match.upstreams but no configured ' +
+            'upstream has that name. Every entry must name an upstream from the upstreams: list.',
+        },
+      ])
+    })
+
+    it('rejects an empty contributor upstreams list with the pinned message', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithBudgets([
+          budget([{ match: { tool: 'stripe_*', upstreams: [] }, field: '$.amount' }]),
+        ]),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['budgets', 0, 'contributors', 0, 'match', 'upstreams'],
+          message:
+            'match.upstreams must name at least one upstream — an empty list matches nothing.',
+        },
+      ])
+    })
+
+    it('rejects a sender_id budget whose contributors are all upstream-scoped', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithBudgets(
+          [
+            budget(
+              [
+                { match: { tool: 'stripe_*', upstreams: ['files'] }, field: '$.amount' },
+                { match: { tool: 'paypal_*', upstreams: ['search'] }, field: '$.total' },
+              ],
+              { key: 'sender_id' },
+            ),
+          ],
+          { sdk: { enabled: true } },
+        ),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['budgets', 0, 'key'],
+          message:
+            'budget key "sender_id" requires at least one contributor without an ' +
+            '"upstreams" scope — upstream-scoped contributors only match MCP calls, which ' +
+            'never carry a sender, so every charge would land in the shared "unknown" pot ' +
+            'while sideband calls (the only ones with real senders) never feed this budget.',
+        },
+      ])
+    })
+
+    it('accepts a sender_id budget with at least one unscoped contributor', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithBudgets(
+          [
+            budget(
+              [
+                { match: { tool: 'stripe_*', upstreams: ['files'] }, field: '$.amount' },
+                { match: { tool: 'paypal_*' }, field: '$.total' },
+              ],
+              { key: 'sender_id' },
+            ),
+          ],
+          { sdk: { enabled: true } },
+        ),
+      )
+      expect(result.success).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // Session identity (issue #218)
   // -------------------------------------------------------------------------
 

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -984,6 +984,134 @@ describe('helioConfigSchema', () => {
   })
 
   // -------------------------------------------------------------------------
+  // Named-mode legacy_header identity guard (issue #293)
+  // -------------------------------------------------------------------------
+
+  describe('named-mode legacy_header identity guard (issue #293)', () => {
+    const identityGuardMessage =
+      'session.identity includes "legacy_header" while named upstreams and evidence-gated ' +
+      'rules ("evidence"/"requires") are configured. On the legacy relay flow the ' +
+      'Mcp-Session-Id a client echoes was minted by the upstream itself, so with multiple ' +
+      'upstreams a hostile server could collide session identities across doors and ' +
+      "pollute another door's evidence gates. Remove legacy_header from session.identity " +
+      'and use a caller-owned source such as the default "x-helio-session-id" header.'
+
+    const namedConfig = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+      version: '1',
+      upstreams: [{ name: 'files', url: 'http://localhost:8081/mcp' }],
+      dashboard: { enabled: false },
+      ...overrides,
+    })
+
+    const explicitLegacyChain = {
+      identity: [{ source: 'header', name: 'x-helio-session-id' }, { source: 'legacy_header' }],
+    }
+
+    it('rejects named + evidence rule + explicit legacy_header chain at the legacy index', () => {
+      const result = helioConfigSchema.safeParse(
+        namedConfig({
+          session: explicitLegacyChain,
+          policies: {
+            rules: [
+              { match: { tool: '*' }, action: 'allow', evidence: { requires: ['fact-check'] } },
+            ],
+          },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        { path: ['session', 'identity', 1], message: identityGuardMessage },
+      ])
+    })
+
+    it('rejects named + bare requires rule under the DEFAULT session chain', () => {
+      // The default identity chain carries legacy_header at index 1 — the
+      // guard deliberately fires here too, and the message spells the remedy.
+      const result = helioConfigSchema.safeParse(
+        namedConfig({
+          policies: {
+            rules: [{ match: { tool: '*' }, action: 'allow', requires: ['deploy_ticket'] }],
+          },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        { path: ['session', 'identity', 1], message: identityGuardMessage },
+      ])
+    })
+
+    it('accepts singular + evidence rule + legacy_header', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          session: explicitLegacyChain,
+          policies: {
+            rules: [
+              { match: { tool: '*' }, action: 'allow', evidence: { requires: ['fact-check'] } },
+            ],
+          },
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts named + evidence rule + header-only chain', () => {
+      const result = helioConfigSchema.safeParse(
+        namedConfig({
+          session: { identity: [{ source: 'header', name: 'x-helio-session-id' }] },
+          policies: {
+            rules: [
+              { match: { tool: '*' }, action: 'allow', evidence: { requires: ['fact-check'] } },
+            ],
+          },
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts named + requires_success-only rule + legacy_header', () => {
+      // requires_success alone is inert at runtime — it only modifies a
+      // non-empty requires list, so it must not trip the guard.
+      const result = helioConfigSchema.safeParse(
+        namedConfig({
+          session: explicitLegacyChain,
+          policies: {
+            rules: [{ match: { tool: '*' }, action: 'allow', requires_success: true }],
+          },
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts named + empty evidence.requires + legacy_header (runtime-gate alignment)', () => {
+      // An empty requires list never gates at runtime; a key-presence
+      // predicate would reject configs the pipeline treats as ungated.
+      const result = helioConfigSchema.safeParse(
+        namedConfig({
+          session: explicitLegacyChain,
+          policies: {
+            rules: [{ match: { tool: '*' }, action: 'allow', evidence: { requires: [] } }],
+          },
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts named + empty bare requires + legacy_header (runtime-gate alignment)', () => {
+      const result = helioConfigSchema.safeParse(
+        namedConfig({
+          session: explicitLegacyChain,
+          policies: {
+            rules: [{ match: { tool: '*' }, action: 'allow', requires: [] }],
+          },
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // Session identity (issue #218)
   // -------------------------------------------------------------------------
 

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { helioConfigSchema, durationSchema, parseDuration } from './schema.js'
+import {
+  helioConfigSchema,
+  durationSchema,
+  parseDuration,
+  upstreamNameSchema,
+  namedUpstreamEntrySchema,
+  upstreamsListSchema,
+} from './schema.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -239,6 +246,217 @@ describe('helioConfigSchema', () => {
         },
         sdk: { enabled: false, port: 3200, host: '127.0.0.1', evaluation_ttl: '10m' },
       })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Named upstream leaf schemas (issue #293)
+  // -------------------------------------------------------------------------
+
+  describe('singular upstream refinement fold parity (issue #293)', () => {
+    it('emits every refinement issue family, stdio-command first, in one parse', () => {
+      // Pins the pre-#293 issue order and content for a singular upstream that
+      // trips all four per-entry checks at once. The shared-superRefine fold
+      // must keep this array identical — a diff means the fold changed
+      // singular error behavior.
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          upstream: {
+            url: 'x',
+            transport: 'stdio',
+            protocol_version: '2026-07-28',
+            forward_headers: ['nope'],
+            headers: { 'content-type': 'y' },
+          },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(
+        result.error.issues.map((i) => ({ code: i.code, path: i.path, message: i.message })),
+      ).toStrictEqual([
+        {
+          code: 'custom',
+          path: ['upstream', 'command'],
+          message: '"command" is required when transport is "stdio"',
+        },
+        {
+          code: 'custom',
+          path: ['upstream', 'protocol_version'],
+          message:
+            'protocol_version "2026-07-28" requires transport "streamable-http" — ' +
+            'stdio modern-era support is tracked in #256.',
+        },
+        {
+          code: 'custom',
+          path: ['upstream', 'forward_headers', 0],
+          message: 'Forwarded caller headers must start with "x-"',
+        },
+        {
+          code: 'custom',
+          path: ['upstream', 'headers', 'content-type'],
+          message: 'upstream.headers must not set reserved header "content-type"',
+        },
+      ])
+    })
+  })
+
+  describe('upstreamNameSchema (issue #293)', () => {
+    it.each(['files', 'files-2', 'files_2', 'A1', 'a'.repeat(64)])('accepts "%s"', (name) => {
+      expect(upstreamNameSchema.safeParse(name).success).toBe(true)
+    })
+
+    it('rejects the empty string', () => {
+      expect(upstreamNameSchema.safeParse('').success).toBe(false)
+    })
+
+    it('rejects names longer than 64 characters', () => {
+      expect(upstreamNameSchema.safeParse('a'.repeat(65)).success).toBe(false)
+    })
+
+    it.each(['with space', 'with:colon', 'with/slash', 'with.dot', 'naïve'])(
+      'rejects "%s" with the charset message',
+      (name) => {
+        const result = upstreamNameSchema.safeParse(name)
+        expect(result.success).toBe(false)
+        if (result.success) return
+        expect(result.error.issues.map((i) => i.message)).toContain(
+          'Upstream names may only contain letters, digits, "_" and "-"',
+        )
+      },
+    )
+  })
+
+  describe('namedUpstreamEntrySchema (issue #293)', () => {
+    const entry = (overrides: Record<string, unknown> = {}) => ({
+      name: 'files',
+      url: 'http://localhost:8081/mcp',
+      ...overrides,
+    })
+
+    it('parses a minimal entry with name first and singular defaults applied', () => {
+      const result = namedUpstreamEntrySchema.safeParse(entry())
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(Object.keys(result.data)).toEqual([
+        'name',
+        'url',
+        'transport',
+        'protocol_version',
+        'connect_timeout',
+        'request_timeout',
+        'forward_headers',
+        'headers',
+      ])
+      expect(result.data.transport).toBe('streamable-http')
+      expect(result.data.protocol_version).toBe('auto')
+      expect(result.data.connect_timeout).toBe('10s')
+      expect(result.data.request_timeout).toBe('30s')
+      expect(result.data.forward_headers).toEqual([])
+      expect(result.data.headers).toEqual({})
+    })
+
+    it('requires the name', () => {
+      const result = namedUpstreamEntrySchema.safeParse({ url: 'http://localhost:8081/mcp' })
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['name'])
+    })
+
+    it('stays strict: an unknown entry key is rejected', () => {
+      const result = namedUpstreamEntrySchema.safeParse(entry({ urll: 'typo' }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => i.message)).toContain('Unrecognized key: "urll"')
+    })
+
+    it('requires command for stdio transport, same message and path as singular', () => {
+      const result = namedUpstreamEntrySchema.safeParse(entry({ transport: 'stdio' }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(
+        result.error.issues.map((i) => ({ code: i.code, path: i.path, message: i.message })),
+      ).toStrictEqual([
+        {
+          code: 'custom',
+          path: ['command'],
+          message: '"command" is required when transport is "stdio"',
+        },
+      ])
+    })
+
+    it('applies the modern-pin transport check per entry', () => {
+      const result = namedUpstreamEntrySchema.safeParse(
+        entry({ transport: 'sse', protocol_version: '2026-07-28' }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['protocol_version'])
+      expect(result.error.issues[0]?.message).toBe(
+        'protocol_version "2026-07-28" requires transport "streamable-http" — ' +
+          'the SSE upstream transport is the deprecated legacy transport.',
+      )
+    })
+
+    it('applies the forward_headers x- prefix check per entry', () => {
+      const result = namedUpstreamEntrySchema.safeParse(entry({ forward_headers: ['bad'] }))
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['forward_headers', 0])
+      expect(result.error.issues[0]?.message).toBe('Forwarded caller headers must start with "x-"')
+    })
+
+    it('applies the reserved-header guard per entry', () => {
+      const result = namedUpstreamEntrySchema.safeParse(
+        entry({ headers: { 'mcp-session-id': 'x' } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.path).toEqual(['headers', 'mcp-session-id'])
+      expect(result.error.issues[0]?.message).toBe(
+        'upstream.headers must not set reserved header "mcp-session-id"',
+      )
+    })
+  })
+
+  describe('upstreamsListSchema (issue #293)', () => {
+    it('accepts a list of uniquely named entries', () => {
+      const result = upstreamsListSchema.safeParse([
+        { name: 'files', url: 'http://localhost:8081/mcp' },
+        { name: 'search', url: 'http://localhost:8082/mcp' },
+      ])
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects an empty list with the pinned message', () => {
+      const result = upstreamsListSchema.safeParse([])
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.message).toBe(
+        'upstreams: must declare at least one upstream — an empty list would serve nothing. ' +
+          'For a single upstream you can keep the "upstream:" form.',
+      )
+    })
+
+    it('rejects duplicate names at the duplicate index', () => {
+      const result = upstreamsListSchema.safeParse([
+        { name: 'files', url: 'http://localhost:8081/mcp' },
+        { name: 'search', url: 'http://localhost:8082/mcp' },
+        { name: 'files', url: 'http://localhost:8083/mcp' },
+      ])
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(
+        result.error.issues.map((i) => ({ code: i.code, path: i.path, message: i.message })),
+      ).toStrictEqual([
+        {
+          code: 'custom',
+          path: [2, 'name'],
+          message:
+            'Duplicate upstream name "files". Upstream names embed in mount paths, limiter ' +
+            'keys, and audit records — each upstream needs its own.',
+        },
+      ])
     })
   })
 

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -194,6 +194,55 @@ describe('helioConfigSchema', () => {
   })
 
   // -------------------------------------------------------------------------
+  // Golden singular parse (issue #293)
+  // -------------------------------------------------------------------------
+
+  describe('golden singular parse (issue #293)', () => {
+    it('parses a minimal singular config to exactly this defaulted object', () => {
+      // Byte-identity pin for the multi-upstream schema work: singular configs
+      // must keep parsing to exactly this object. A diff here means a schema
+      // refactor changed singular behavior — fix the refactor, not this test.
+      const result = helioConfigSchema.safeParse(minimalConfig())
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(result.data).toStrictEqual({
+        version: '1',
+        upstream: {
+          url: 'http://localhost:8080',
+          transport: 'streamable-http',
+          protocol_version: 'auto',
+          connect_timeout: '10s',
+          request_timeout: '30s',
+          forward_headers: [],
+          headers: {},
+        },
+        listen: { port: 3000, host: '127.0.0.1', allowed_origins: [] },
+        session: {
+          identity: [{ source: 'header', name: 'x-helio-session-id' }, { source: 'legacy_header' }],
+          on_unresolved: 'deny',
+        },
+        policies: { default: 'allow', dry_run: false, rules: [] },
+        budgets: [],
+        approval: { timeout: '300s', default_on_timeout: 'deny', channels: [] },
+        audit: {
+          storage: 'sqlite',
+          path: './helio-audit.db',
+          retention: '90d',
+          include_responses: true,
+        },
+        dashboard: {
+          enabled: false,
+          port: 3100,
+          host: '127.0.0.1',
+          allow_open_mode: false,
+          sse_heartbeat_interval: '30s',
+        },
+        sdk: { enabled: false, port: 3200, host: '127.0.0.1', evaluation_ttl: '10m' },
+      })
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // Session identity (issue #218)
   // -------------------------------------------------------------------------
 

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -663,6 +663,179 @@ describe('helioConfigSchema', () => {
   })
 
   // -------------------------------------------------------------------------
+  // match.upstreams vocabulary (issue #293)
+  // -------------------------------------------------------------------------
+
+  describe('match.upstreams vocabulary (issue #293)', () => {
+    const namedWithRules = (
+      rules: unknown[],
+      overrides: Record<string, unknown> = {},
+    ): Record<string, unknown> => ({
+      version: '1',
+      upstreams: [
+        { name: 'files', url: 'http://localhost:8081/mcp' },
+        { name: 'search', url: 'http://localhost:8082/mcp' },
+      ],
+      policies: { rules },
+      dashboard: { enabled: false },
+      ...overrides,
+    })
+
+    it('accepts a rule scoped to configured upstream names', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithRules([{ match: { tool: '*', upstreams: ['files', 'search'] }, action: 'deny' }]),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects match.upstreams in singular mode', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          policies: { rules: [{ match: { tool: '*', upstreams: ['files'] }, action: 'deny' }] },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['policies', 'rules', 0, 'match', 'upstreams'],
+          message:
+            'Rule sets match.upstreams but the config declares a single "upstream:", which ' +
+            'has no name on purpose. Upstream-scoped rules require the named "upstreams:" list.',
+        },
+      ])
+    })
+
+    it('rejects an unknown upstream name at the entry index', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithRules([{ match: { tool: '*', upstreams: ['files', 'ghost'] }, action: 'deny' }]),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['policies', 'rules', 0, 'match', 'upstreams', 1],
+          message:
+            'Rule names upstream "ghost" in match.upstreams but no configured upstream has ' +
+            'that name. Every entry must name an upstream from the upstreams: list.',
+        },
+      ])
+    })
+
+    it('rejects an empty match.upstreams list with the pinned message', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithRules([{ match: { tool: '*', upstreams: [] }, action: 'deny' }]),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['policies', 'rules', 0, 'match', 'upstreams'],
+          message:
+            'match.upstreams must name at least one upstream — an empty list matches nothing.',
+        },
+      ])
+    })
+
+    it('rejects match.upstreams combined with match.metadata', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithRules([
+          {
+            match: { upstreams: ['files'], metadata: { channel_id: 'C1' } },
+            action: 'deny',
+          },
+        ]),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['policies', 'rules', 0, 'match', 'upstreams'],
+          message:
+            'match.upstreams cannot be combined with match.metadata — metadata rules only ' +
+            'match on the sideband (host) path and upstream-scoped rules only on the MCP ' +
+            'path, so the combination can never match. Split it into two rules.',
+        },
+      ])
+    })
+
+    it('rejects match.upstreams combined with limits.key sender_id', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithRules(
+          [
+            {
+              match: { tool: '*', upstreams: ['files'] },
+              action: 'allow',
+              limits: { key: 'sender_id', max_calls: 10, window: '60s' },
+            },
+          ],
+          { sdk: { enabled: true } },
+        ),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['policies', 'rules', 0, 'limits', 'key'],
+          message:
+            'limits.key "sender_id" cannot be combined with match.upstreams — an ' +
+            'upstream-scoped rule only matches on the MCP path, where sender_id is absent ' +
+            'and the key would silently collapse to tool scope.',
+        },
+      ])
+    })
+
+    it('rejects match.upstreams combined with limits.max_spend.key sender_id', () => {
+      const result = helioConfigSchema.safeParse(
+        namedWithRules(
+          [
+            {
+              match: { tool: '*', upstreams: ['files'] },
+              action: 'allow',
+              limits: {
+                max_spend: {
+                  field: '$.amount',
+                  limit: 100,
+                  currency: 'USD',
+                  window: '24h',
+                  key: 'sender_id',
+                },
+              },
+            },
+          ],
+          { sdk: { enabled: true } },
+        ),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['policies', 'rules', 0, 'limits', 'max_spend', 'key'],
+          message:
+            'limits.max_spend.key "sender_id" cannot be combined with match.upstreams — an ' +
+            'upstream-scoped rule only matches on the MCP path, where sender_id is absent ' +
+            'and the key would silently collapse to tool scope.',
+        },
+      ])
+    })
+
+    it('adds no new rejection for agent keys on an upstream-scoped rule', () => {
+      // Pinned exemption: agent keys stay warn-only at compile time; the
+      // schema must not invent a rejection for them.
+      const result = helioConfigSchema.safeParse(
+        namedWithRules([
+          {
+            match: { tool: '*', upstreams: ['files'] },
+            action: 'allow',
+            limits: { key: 'agent', max_calls: 10, window: '60s' },
+          },
+        ]),
+      )
+      expect(result.success).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // Session identity (issue #218)
   // -------------------------------------------------------------------------
 

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -72,7 +72,7 @@ const transportSchema = z.enum(['streamable-http', 'sse', 'stdio'])
  */
 const protocolVersionSchema = z.enum(['auto', '2025-06-18', '2026-07-28'])
 
-const upstreamSchema = z
+const upstreamObjectSchema = z
   .object({
     url: z.string(),
     transport: transportSchema.default('streamable-http'),
@@ -85,46 +85,107 @@ const upstreamSchema = z
     headers: z.record(z.string(), z.string()).default({}),
   })
   .strict()
-  .refine((data) => data.transport !== 'stdio' || data.command !== undefined, {
-    message: '"command" is required when transport is "stdio"',
-    path: ['command'],
-  })
-  .superRefine((data, ctx) => {
-    // The modern pin only makes sense on Streamable HTTP: the SSE upstream
-    // transport is the deprecated legacy transport and will never be modern,
-    // and stdio modern-era support is tracked separately (#256).
-    if (data.protocol_version === '2026-07-28' && data.transport !== 'streamable-http') {
+
+// Shared by the singular `upstream:` schema and every named `upstreams:` entry
+// (issue #293). Messages, paths, and check order are pinned by tests —
+// singular configs must keep erroring byte-identically.
+function upstreamEntryChecks(
+  data: z.output<typeof upstreamObjectSchema>,
+  ctx: z.core.$RefinementCtx,
+): void {
+  if (data.transport === 'stdio' && data.command === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['command'],
+      message: '"command" is required when transport is "stdio"',
+    })
+  }
+
+  // The modern pin only makes sense on Streamable HTTP: the SSE upstream
+  // transport is the deprecated legacy transport and will never be modern,
+  // and stdio modern-era support is tracked separately (#256).
+  if (data.protocol_version === '2026-07-28' && data.transport !== 'streamable-http') {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['protocol_version'],
+      message:
+        data.transport === 'stdio'
+          ? 'protocol_version "2026-07-28" requires transport "streamable-http" — ' +
+            'stdio modern-era support is tracked in #256.'
+          : 'protocol_version "2026-07-28" requires transport "streamable-http" — ' +
+            'the SSE upstream transport is the deprecated legacy transport.',
+    })
+  }
+  for (const [index, header] of data.forward_headers.entries()) {
+    if (!header.toLowerCase().startsWith('x-')) {
       ctx.addIssue({
         code: 'custom',
-        path: ['protocol_version'],
-        message:
-          data.transport === 'stdio'
-            ? 'protocol_version "2026-07-28" requires transport "streamable-http" — ' +
-              'stdio modern-era support is tracked in #256.'
-            : 'protocol_version "2026-07-28" requires transport "streamable-http" — ' +
-              'the SSE upstream transport is the deprecated legacy transport.',
+        path: ['forward_headers', index],
+        message: 'Forwarded caller headers must start with "x-"',
       })
     }
-    for (const [index, header] of data.forward_headers.entries()) {
-      if (!header.toLowerCase().startsWith('x-')) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['forward_headers', index],
-          message: 'Forwarded caller headers must start with "x-"',
-        })
-      }
-    }
+  }
 
-    // Reserved transport/protocol headers must not be operator-overridden via
-    // upstream.headers — the forwarders own these.
-    for (const name of Object.keys(data.headers)) {
-      if (RESERVED_TRANSPORT_HEADERS.has(name.toLowerCase())) {
+  // Reserved transport/protocol headers must not be operator-overridden via
+  // upstream.headers — the forwarders own these.
+  for (const name of Object.keys(data.headers)) {
+    if (RESERVED_TRANSPORT_HEADERS.has(name.toLowerCase())) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['headers', name],
+        message: `upstream.headers must not set reserved header "${name}"`,
+      })
+    }
+  }
+}
+
+const upstreamSchema = upstreamObjectSchema.superRefine(upstreamEntryChecks)
+
+/**
+ * Upstream entry names embed in mount paths, limiter keys
+ * (`upstream:<name>:…`), and audit records — the budget-name charset keeps
+ * them delimiter-free so those keys stay parseable (issue #293).
+ */
+export const upstreamNameSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-zA-Z0-9_-]+$/, {
+    message: 'Upstream names may only contain letters, digits, "_" and "-"',
+  })
+
+/**
+ * One entry of the named `upstreams:` list: every singular `upstream:` field
+ * plus a required unique `name`. The name is declared first so parsed entries
+ * render name-first; the per-entry refinements are the singular schema's,
+ * shared verbatim (issue #293).
+ */
+export const namedUpstreamEntrySchema = z
+  .object({ name: upstreamNameSchema, ...upstreamObjectSchema.shape })
+  .strict()
+  .superRefine(upstreamEntryChecks)
+
+/** The named `upstreams:` list — non-empty, with unique entry names (issue #293). */
+export const upstreamsListSchema = z
+  .array(namedUpstreamEntrySchema)
+  .min(1, {
+    message:
+      'upstreams: must declare at least one upstream — an empty list would serve nothing. ' +
+      'For a single upstream you can keep the "upstream:" form.',
+  })
+  .superRefine((entries, ctx) => {
+    const seen = new Set<string>()
+    for (const [index, entry] of entries.entries()) {
+      if (seen.has(entry.name)) {
         ctx.addIssue({
           code: 'custom',
-          path: ['headers', name],
-          message: `upstream.headers must not set reserved header "${name}"`,
+          path: [index, 'name'],
+          message:
+            `Duplicate upstream name "${entry.name}". Upstream names embed in mount paths, ` +
+            'limiter keys, and audit records — each upstream needs its own.',
         })
       }
+      seen.add(entry.name)
     }
   })
 

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -1383,6 +1383,36 @@ function upstreamVocabularyChecks(
       })
     }
   }
+
+  // Named mode + evidence gating + legacy_header identity is fail-closed:
+  // the guard fires under the DEFAULT identity chain too, so the message
+  // must spell the exact remedy. The gating predicate mirrors the decision
+  // pipeline's runtime gate verbatim — only a NON-EMPTY requires list (in
+  // either spelling) gates a session; requires_success alone is inert.
+  if (configuredNames !== null) {
+    const hasEvidenceGatedRule = cfg.policies.rules.some(
+      (rule) => (rule.evidence?.requires.length ?? 0) > 0 || (rule.requires?.length ?? 0) > 0,
+    )
+    if (hasEvidenceGatedRule) {
+      const legacyIndex = cfg.session.identity.findIndex(
+        (source) => source.source === 'legacy_header',
+      )
+      if (legacyIndex !== -1) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['session', 'identity', legacyIndex],
+          message:
+            'session.identity includes "legacy_header" while named upstreams and ' +
+            'evidence-gated rules ("evidence"/"requires") are configured. On the legacy ' +
+            'relay flow the Mcp-Session-Id a client echoes was minted by the upstream ' +
+            'itself, so with multiple upstreams a hostile server could collide session ' +
+            "identities across doors and pollute another door's evidence gates. Remove " +
+            'legacy_header from session.identity and use a caller-owned source such as ' +
+            'the default "x-helio-session-id" header.',
+        })
+      }
+    }
+  }
 }
 
 const singularConfigSchema = singularConfigBase.superRefine((cfg, ctx) => {

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -1438,13 +1438,27 @@ export type NamedHelioConfig = z.output<typeof namedConfigSchema>
  * the exactly-one-of contract and forwards the chosen arm's issues verbatim,
  * so every error keeps its real path and message.
  */
+// Produces zod's canonical invalid_type issue for a non-object root — the
+// same message the pre-dispatch root schema generated, kept so a garbage
+// document is diagnosed as a type error, never as a mode error.
+const objectRootSchema = z.object({})
+
 function dispatchByMode(
   raw: unknown,
   ctx: z.core.$RefinementCtx,
 ): SingularHelioConfig | NamedHelioConfig {
   const isObject = raw !== null && typeof raw === 'object' && !Array.isArray(raw)
-  const hasUpstream = isObject && 'upstream' in raw
-  const hasUpstreams = isObject && 'upstreams' in raw
+  if (!isObject) {
+    const typeResult = objectRootSchema.safeParse(raw)
+    if (!typeResult.success) {
+      for (const issue of typeResult.error.issues) {
+        ctx.addIssue(issue as z.core.$ZodRawIssue)
+      }
+    }
+    return z.NEVER
+  }
+  const hasUpstream = 'upstream' in raw
+  const hasUpstreams = 'upstreams' in raw
 
   if (hasUpstream && hasUpstreams) {
     ctx.addIssue({

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -430,6 +430,13 @@ const matchSchema = z
     input: z.record(z.string(), inputConditionSchema).optional(),
     environment: z.string().optional(),
     metadata: z.record(z.string(), metadataConditionSchema).optional(),
+    /** Configured upstream names the rule is scoped to (issue #293). */
+    upstreams: z
+      .array(z.string().min(1))
+      .min(1, {
+        message: 'match.upstreams must name at least one upstream — an empty list matches nothing.',
+      })
+      .optional(),
   })
   .strict()
 
@@ -1232,8 +1239,89 @@ function rootConfigChecks(cfg: RootConfigSections, ctx: z.core.$RefinementCtx): 
   }
 }
 
-const singularConfigSchema = singularConfigBase.superRefine(rootConfigChecks)
-const namedConfigSchema = namedConfigBase.superRefine(rootConfigChecks)
+/**
+ * The upstream-vocabulary validations (issue #293). One function, run by BOTH
+ * mode arms — `configuredNames` is null in singular mode and the declared
+ * name set in named mode — so a mode-dependent rule can never be attached to
+ * one arm and silently skipped in the other.
+ */
+function upstreamVocabularyChecks(
+  cfg: RootConfigSections,
+  ctx: z.core.$RefinementCtx,
+  configuredNames: ReadonlySet<string> | null,
+): void {
+  for (const [ruleIndex, rule] of cfg.policies.rules.entries()) {
+    const upstreams = rule.match.upstreams
+    if (upstreams === undefined) continue
+
+    if (configuredNames === null) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['policies', 'rules', ruleIndex, 'match', 'upstreams'],
+        message:
+          'Rule sets match.upstreams but the config declares a single "upstream:", which ' +
+          'has no name on purpose. Upstream-scoped rules require the named "upstreams:" list.',
+      })
+    } else {
+      for (const [entryIndex, name] of upstreams.entries()) {
+        if (!configuredNames.has(name)) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['policies', 'rules', ruleIndex, 'match', 'upstreams', entryIndex],
+            message:
+              `Rule names upstream "${name}" in match.upstreams but no configured upstream ` +
+              'has that name. Every entry must name an upstream from the upstreams: list.',
+          })
+        }
+      }
+    }
+
+    // Metadata only exists on the sideband and upstream scoping only on the
+    // MCP path — the combination is a rule that can never match.
+    if (rule.match.metadata !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['policies', 'rules', ruleIndex, 'match', 'upstreams'],
+        message:
+          'match.upstreams cannot be combined with match.metadata — metadata rules only ' +
+          'match on the sideband (host) path and upstream-scoped rules only on the MCP ' +
+          'path, so the combination can never match. Split it into two rules.',
+      })
+    }
+
+    // sender_id is sideband-only for the same reason — an upstream-scoped
+    // sender key could only ever collapse to tool scope.
+    if (rule.limits?.key === 'sender_id') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['policies', 'rules', ruleIndex, 'limits', 'key'],
+        message:
+          'limits.key "sender_id" cannot be combined with match.upstreams — an ' +
+          'upstream-scoped rule only matches on the MCP path, where sender_id is absent ' +
+          'and the key would silently collapse to tool scope.',
+      })
+    }
+    if (rule.limits?.max_spend?.key === 'sender_id') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['policies', 'rules', ruleIndex, 'limits', 'max_spend', 'key'],
+        message:
+          'limits.max_spend.key "sender_id" cannot be combined with match.upstreams — an ' +
+          'upstream-scoped rule only matches on the MCP path, where sender_id is absent ' +
+          'and the key would silently collapse to tool scope.',
+      })
+    }
+  }
+}
+
+const singularConfigSchema = singularConfigBase.superRefine((cfg, ctx) => {
+  rootConfigChecks(cfg, ctx)
+  upstreamVocabularyChecks(cfg, ctx, null)
+})
+const namedConfigSchema = namedConfigBase.superRefine((cfg, ctx) => {
+  rootConfigChecks(cfg, ctx)
+  upstreamVocabularyChecks(cfg, ctx, new Set(cfg.upstreams.map((entry) => entry.name)))
+})
 
 /** A fully validated and defaulted singular-mode (`upstream:`) configuration. */
 export type SingularHelioConfig = z.output<typeof singularConfigSchema>

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -796,28 +796,49 @@ const sdkSchema = z
 // Root config
 // ---------------------------------------------------------------------------
 
-const helioConfigBaseSchema = z
+// Every root section except the upstream slot, shared by both mode arms
+// below. Declaration order is the canonical section order — zod emits output
+// keys in declaration order and the key-order pins depend on it.
+const rootSectionSchemas = {
+  listen: listenSchema.prefault({}),
+  environment: z.string().optional(),
+  // Session precedes policies deliberately: upstream/listen/environment say
+  // where and as-what Helio runs, session says who is calling, and
+  // policies/budgets then govern those calls (issue #218).
+  session: sessionSchema.prefault({}),
+  policies: policiesSchema.prefault({}),
+  // Budgets sit beside policies deliberately: they are the second half of the
+  // governance declaration (policy decision → budget gate), not plumbing.
+  budgets: z.array(budgetSchema).default([]),
+  approval: approvalSchema.prefault({}),
+  audit: auditSchema.prefault({}),
+  // Dashboard follows audit deliberately: an operator surface, not part of
+  // the request path (canonical section order, #89/#163).
+  dashboard: dashboardSchema.prefault({}),
+  sdk: sdkSchema.prefault({}),
+}
+
+// The two mode arms of the config (issue #293): identical except for slot 2,
+// `upstream:` (singular) vs `upstreams:` (named list). dispatchByMode below
+// routes every parse to exactly one arm.
+const singularConfigBase = z
   .object({
     version: z.literal('1'),
     upstream: upstreamSchema,
-    listen: listenSchema.prefault({}),
-    environment: z.string().optional(),
-    // Session precedes policies deliberately: upstream/listen/environment say
-    // where and as-what Helio runs, session says who is calling, and
-    // policies/budgets then govern those calls (issue #218).
-    session: sessionSchema.prefault({}),
-    policies: policiesSchema.prefault({}),
-    // Budgets sit beside policies deliberately: they are the second half of the
-    // governance declaration (policy decision → budget gate), not plumbing.
-    budgets: z.array(budgetSchema).default([]),
-    approval: approvalSchema.prefault({}),
-    audit: auditSchema.prefault({}),
-    // Dashboard follows audit deliberately: an operator surface, not part of
-    // the request path (canonical section order, #89/#163).
-    dashboard: dashboardSchema.prefault({}),
-    sdk: sdkSchema.prefault({}),
+    ...rootSectionSchemas,
   })
   .strict()
+
+const namedConfigBase = z
+  .object({
+    version: z.literal('1'),
+    upstreams: upstreamsListSchema,
+    ...rootSectionSchemas,
+  })
+  .strict()
+
+/** The root sections every mode arm shares — what {@link rootConfigChecks} reads. */
+type RootConfigSections = Omit<z.output<typeof singularConfigBase>, 'upstream'>
 
 /**
  * Top-level keys matching `^x-` are extension keys: schema-ignored holders
@@ -834,7 +855,11 @@ function stripRootExtensionKeys(value: unknown): unknown {
   )
 }
 
-const helioConfigRefinedSchema = helioConfigBaseSchema.superRefine((cfg, ctx) => {
+// The cross-section validations both mode arms run (issue #293 moved the
+// body out of a single root schema's superRefine; the checks themselves are
+// unchanged). One function, called by each arm, so a check can never be
+// attached to one mode and silently skipped in the other.
+function rootConfigChecks(cfg: RootConfigSections, ctx: z.core.$RefinementCtx): void {
   const hasConfiguredEnvironment =
     typeof cfg.environment === 'string' && cfg.environment.trim().length > 0
 
@@ -1205,17 +1230,91 @@ const helioConfigRefinedSchema = helioConfigBaseSchema.superRefine((cfg, ctx) =>
       }
     }
   }
-})
+}
+
+const singularConfigSchema = singularConfigBase.superRefine(rootConfigChecks)
+const namedConfigSchema = namedConfigBase.superRefine(rootConfigChecks)
+
+/** A fully validated and defaulted singular-mode (`upstream:`) configuration. */
+export type SingularHelioConfig = z.output<typeof singularConfigSchema>
+
+/** A fully validated and defaulted named-mode (`upstreams:`) configuration. */
+export type NamedHelioConfig = z.output<typeof namedConfigSchema>
+
+/**
+ * Route a raw config document to exactly one mode arm (issue #293). A plain
+ * z.union cannot do this job: zod's arm selection is heuristic, and a common
+ * mistake like a named entry missing `url` surfaces as a buried
+ * "(top level): Invalid input" instead of its real issue. The dispatch owns
+ * the exactly-one-of contract and forwards the chosen arm's issues verbatim,
+ * so every error keeps its real path and message.
+ */
+function dispatchByMode(
+  raw: unknown,
+  ctx: z.core.$RefinementCtx,
+): SingularHelioConfig | NamedHelioConfig {
+  const isObject = raw !== null && typeof raw === 'object' && !Array.isArray(raw)
+  const hasUpstream = isObject && 'upstream' in raw
+  const hasUpstreams = isObject && 'upstreams' in raw
+
+  if (hasUpstream && hasUpstreams) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['upstreams'],
+      message:
+        'Set exactly one of "upstream:" (single upstream) or "upstreams:" (named ' +
+        'multi-upstream list) — not both. To migrate, move the upstream: fields into ' +
+        'an upstreams: entry and give it a name.',
+    })
+    return z.NEVER
+  }
+  if (!hasUpstream && !hasUpstreams) {
+    ctx.addIssue({
+      code: 'custom',
+      message:
+        'Missing upstream configuration: set exactly one of "upstream:" (single ' +
+        'upstream) or "upstreams:" (named multi-upstream list).',
+    })
+    return z.NEVER
+  }
+
+  const result = hasUpstreams
+    ? namedConfigSchema.safeParse(raw)
+    : singularConfigSchema.safeParse(raw)
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      // A finished $ZodIssue is runtime-compatible with addIssue (it
+      // normalizes and pushes), but the declared parameter type only admits
+      // raw issues — forward verbatim under the raw-issue type.
+      ctx.addIssue(issue as z.core.$ZodRawIssue)
+    }
+    return z.NEVER
+  }
+  return result.data
+}
 
 /** Zod schema for the complete `helio.yaml` configuration file. */
-export const helioConfigSchema = z.preprocess(stripRootExtensionKeys, helioConfigRefinedSchema)
+export const helioConfigSchema = z.preprocess(
+  stripRootExtensionKeys,
+  z.unknown().transform(dispatchByMode),
+)
 
 // ---------------------------------------------------------------------------
 // Inferred types
 // ---------------------------------------------------------------------------
 
-/** Fully validated and defaulted Helio configuration. */
-export type HelioConfig = z.infer<typeof helioConfigSchema>
+/** Fully validated and defaulted Helio configuration — one of the two mode arms. */
+export type HelioConfig = SingularHelioConfig | NamedHelioConfig
+
+/** Narrow a parsed config to the singular-mode (`upstream:`) arm. */
+export function isSingularConfig(config: HelioConfig): config is SingularHelioConfig {
+  return !('upstreams' in config)
+}
+
+/** Narrow a parsed config to the named-mode (`upstreams:`) arm. */
+export function isNamedConfig(config: HelioConfig): config is NamedHelioConfig {
+  return 'upstreams' in config
+}
 
 /** A single policy rule from the `policies.rules` array. */
 export type PolicyRule = z.infer<typeof policyRuleSchema>

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -623,6 +623,13 @@ const budgetContributorMatchSchema = z
     // matchers (annotations, environment, metadata) stay strict-rejected
     // until the budget charge context can actually evaluate them.
     input: z.record(z.string(), inputConditionSchema).optional(),
+    /** Configured upstream names the contributor is scoped to (issue #293). */
+    upstreams: z
+      .array(z.string().min(1))
+      .min(1, {
+        message: 'match.upstreams must name at least one upstream — an empty list matches nothing.',
+      })
+      .optional(),
   })
   .strict()
 
@@ -1309,6 +1316,70 @@ function upstreamVocabularyChecks(
           'limits.max_spend.key "sender_id" cannot be combined with match.upstreams — an ' +
           'upstream-scoped rule only matches on the MCP path, where sender_id is absent ' +
           'and the key would silently collapse to tool scope.',
+      })
+    }
+  }
+
+  for (const [budgetIndex, budget] of cfg.budgets.entries()) {
+    let hasUnscopedContributor = false
+    for (const [contributorIndex, contributor] of budget.contributors.entries()) {
+      // The legacy flat contributor shape ({ tool, field }) reaches these
+      // checks unparsed: its migration rejection sits behind a
+      // z.unknown() pipe, and z.unknown() lets the raw object through the
+      // field parse. Treat it as unscoped — the migration message is the
+      // real issue and the config is already rejected.
+      const upstreams = (contributor as { match?: { upstreams?: readonly string[] } }).match
+        ?.upstreams
+      if (upstreams === undefined) {
+        hasUnscopedContributor = true
+        continue
+      }
+
+      if (configuredNames === null) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['budgets', budgetIndex, 'contributors', contributorIndex, 'match', 'upstreams'],
+          message:
+            'Contributor sets match.upstreams but the config declares a single "upstream:", ' +
+            'which has no name on purpose. Upstream-scoped contributors require the named ' +
+            '"upstreams:" list.',
+        })
+      } else {
+        for (const [entryIndex, name] of upstreams.entries()) {
+          if (!configuredNames.has(name)) {
+            ctx.addIssue({
+              code: 'custom',
+              path: [
+                'budgets',
+                budgetIndex,
+                'contributors',
+                contributorIndex,
+                'match',
+                'upstreams',
+                entryIndex,
+              ],
+              message:
+                `Contributor names upstream "${name}" in match.upstreams but no configured ` +
+                'upstream has that name. Every entry must name an upstream from the ' +
+                'upstreams: list.',
+            })
+          }
+        }
+      }
+    }
+
+    // A sender-keyed pot fed only by upstream-scoped contributors is dead
+    // config: MCP calls never carry a sender and sideband calls never carry
+    // an upstream, so the two scopes can never meet.
+    if (budget.key === 'sender_id' && !hasUnscopedContributor) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['budgets', budgetIndex, 'key'],
+        message:
+          'budget key "sender_id" requires at least one contributor without an ' +
+          '"upstreams" scope — upstream-scoped contributors only match MCP calls, which ' +
+          'never carry a sender, so every charge would land in the shared "unknown" pot ' +
+          'while sideband calls (the only ones with real senders) never feed this budget.',
       })
     }
   }

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -1,7 +1,7 @@
 export { VERSION } from './version.js'
 
-export { loadConfig, ConfigError } from './config/index.js'
-export type { HelioConfig } from './config/index.js'
+export { loadConfig, ConfigError, isSingularConfig, isNamedConfig } from './config/index.js'
+export type { HelioConfig, SingularHelioConfig, NamedHelioConfig } from './config/index.js'
 export { createApp, startServer, startSidebandServer } from './server.js'
 export type { ServerHandle, CreateAppOptions } from './server.js'
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- deliberate compat re-export of the deprecated alias

--- a/packages/proxy/src/policy/bucket-key.test.ts
+++ b/packages/proxy/src/policy/bucket-key.test.ts
@@ -17,10 +17,12 @@ describe('upstreamFromLimitKey (issue #292)', () => {
     expect(upstreamFromLimitKey('tool:upstream:github:oddname')).toBeNull()
   })
 
-  it('truncates a colon-bearing name at the first colon (documented until #293 validates the charset)', () => {
-    // GovernedForwarderOptions.upstreamName is an unconstrained string until
-    // #293's config validation lands; this pins the parse behavior for a
-    // name that embeds a colon rather than guessing rejection semantics.
+  it('truncates a colon-bearing name at the first colon (embedder-facing)', () => {
+    // Config names are charset-validated (#293), but
+    // GovernedForwarderOptions.upstreamName is a public embedder surface and
+    // deliberately stays an unconstrained string; this pins the parse
+    // behavior for a name that embeds a colon rather than guessing rejection
+    // semantics.
     expect(upstreamFromLimitKey('upstream:foo:bar:tool:x')).toBe('foo')
   })
 })

--- a/packages/proxy/src/policy/bucket-key.ts
+++ b/packages/proxy/src/policy/bucket-key.ts
@@ -55,9 +55,11 @@ const UPSTREAM_PREFIX_RE = /^upstream:([^:]+):/
  * `sender:`) returns null — only a named tool key ever starts `upstream:`,
  * and client-influenced substrings (tool names, session ids) only appear
  * AFTER those fixed prefixes, so the prefix is unambiguous. A name embedding
- * a colon truncates at the first colon: the colon-free charset is #293's
- * config-validation promise, so this parse documents today's behavior
- * instead of guessing at rejection semantics.
+ * a colon truncates at the first colon: config validation pins the colon-free
+ * charset for `upstreams:` entry names (#293), while the embedder-facing
+ * `GovernedForwarderOptions.upstreamName` stays deliberately unconstrained —
+ * this parse documents that surface's behavior instead of guessing at
+ * rejection semantics.
  */
 export function upstreamFromLimitKey(key: string): string | null {
   const match = UPSTREAM_PREFIX_RE.exec(key)

--- a/packages/proxy/src/policy/decision-pipeline-upstream.test.ts
+++ b/packages/proxy/src/policy/decision-pipeline-upstream.test.ts
@@ -43,6 +43,29 @@ beforeEach(() => {
   vi.mocked(evaluatePolicy).mockClear()
 })
 
+describe('decide — match.upstreams scoping (issue #293)', () => {
+  const scopedDeny = () =>
+    compile({
+      default: 'allow',
+      rules: [{ match: { upstreams: ['a'] }, action: 'deny' }],
+    })
+
+  it('fires for the named door', () => {
+    const { decision } = decide(input({ policy: scopedDeny(), upstream: 'a' }))
+    expect(decision.action).toBe('deny')
+  })
+
+  it('does not fire for another door', () => {
+    const { decision } = decide(input({ policy: scopedDeny(), upstream: 'b' }))
+    expect(decision.action).toBe('allow')
+  })
+
+  it('does not fire on the sideband, where upstream is unset', () => {
+    const { decision } = decide(input({ policy: scopedDeny() }))
+    expect(decision.action).toBe('allow')
+  })
+})
+
 describe('decide — upstream threading (issue #295)', () => {
   it('threads upstream into the base evaluatePolicy match context', () => {
     const policy = compile({ default: 'allow', rules: [] })

--- a/packages/proxy/src/policy/matchers.test.ts
+++ b/packages/proxy/src/policy/matchers.test.ts
@@ -7,6 +7,7 @@ import {
   matchInput,
   matchEnvironment,
   matchMetadata,
+  matchUpstreams,
 } from './matchers.js'
 import type { PoliciesConfig } from '../config/schema.js'
 import type {
@@ -705,6 +706,29 @@ describe('matchEnvironment', () => {
 })
 
 // ---------------------------------------------------------------------------
+// matchUpstreams (issue #293)
+// ---------------------------------------------------------------------------
+
+describe('matchUpstreams (issue #293)', () => {
+  it('matches when ctx.upstream is in the list (OR within the list)', () => {
+    expect(matchUpstreams(['files', 'search'], ctx({ upstream: 'search' }))).toBe(true)
+  })
+
+  it('does not match when ctx.upstream is not in the list', () => {
+    expect(matchUpstreams(['files'], ctx({ upstream: 'search' }))).toBe(false)
+  })
+
+  it('returns false when ctx.upstream is undefined (sideband and singular inertness)', () => {
+    expect(matchUpstreams(['files'], ctx())).toBe(false)
+  })
+
+  it('is case-sensitive exact matching, no globs', () => {
+    expect(matchUpstreams(['Files'], ctx({ upstream: 'files' }))).toBe(false)
+    expect(matchUpstreams(['files*'], ctx({ upstream: 'files' }))).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // matchRule — integration
 // ---------------------------------------------------------------------------
 
@@ -760,6 +784,21 @@ describe('matchRule', () => {
   it('combined tool + environment — environment matches, tool does not', () => {
     const rule = compileRule({ tool: 'deploy_*', environment: 'production' })
     expect(matchRule(rule, ctx({ toolName: 'read_config', environment: 'production' }))).toBe(false)
+  })
+
+  it('combined tool + upstreams — both match (issue #293)', () => {
+    const rule = compileRule({ tool: 'send_*', upstreams: ['files'] })
+    expect(matchRule(rule, ctx({ toolName: 'send_email', upstream: 'files' }))).toBe(true)
+  })
+
+  it('combined tool + upstreams — tool matches, upstream not in list (issue #293)', () => {
+    const rule = compileRule({ tool: 'send_*', upstreams: ['files'] })
+    expect(matchRule(rule, ctx({ toolName: 'send_email', upstream: 'search' }))).toBe(false)
+  })
+
+  it('upstreams-only rule is inert when ctx carries no upstream (issue #293)', () => {
+    const rule = compileRule({ upstreams: ['files'] })
+    expect(matchRule(rule, ctx({ toolName: 'send_email' }))).toBe(false)
   })
 
   it('rule with input conditions matches correct arguments', () => {

--- a/packages/proxy/src/policy/matchers.ts
+++ b/packages/proxy/src/policy/matchers.ts
@@ -159,6 +159,18 @@ export function matchEnvironment(required: string, ctx: MatchContext): boolean {
 }
 
 /**
+ * Test whether the context's upstream name is in the rule's list (OR within
+ * the list; exact, case-sensitive — config validation pins the charset).
+ * Returns false when `ctx.upstream` is undefined: the sideband and singular
+ * mode carry no upstream name, so upstream-scoped rules are inert there by
+ * construction (issue #293).
+ */
+export function matchUpstreams(required: readonly string[], ctx: MatchContext): boolean {
+  if (ctx.upstream === undefined) return false
+  return required.includes(ctx.upstream)
+}
+
+/**
  * Test whether ALL metadata conditions match against the adapter-supplied context
  * (issue #13 — `match.metadata.*`). Conditions are AND'd; every condition must pass.
  *
@@ -213,6 +225,7 @@ export function matchRule(rule: CompiledPolicyRule, ctx: MatchContext): boolean 
   if (match.input !== undefined && !matchInput(match.input, ctx)) return false
   if (match.environment !== undefined && !matchEnvironment(match.environment, ctx)) return false
   if (match.metadata !== undefined && !matchMetadata(match.metadata, ctx)) return false
+  if (match.upstreams !== undefined && !matchUpstreams(match.upstreams, ctx)) return false
 
   return true
 }

--- a/packages/proxy/src/policy/parser.test.ts
+++ b/packages/proxy/src/policy/parser.test.ts
@@ -136,6 +136,24 @@ describe('tool glob compilation', () => {
     )
     expect(rule.match.tool).toBeUndefined()
   })
+
+  it('passes match.upstreams through to the compiled match (issue #293)', () => {
+    const { rule } = firstRule(
+      minimalPolicies({
+        rules: [{ match: { tool: '*', upstreams: ['files', 'search'] }, action: 'deny' }],
+      }),
+    )
+    expect(rule.match.upstreams).toEqual(['files', 'search'])
+  })
+
+  it('rule without upstreams has no upstreams field (issue #293)', () => {
+    const { rule } = firstRule(
+      minimalPolicies({
+        rules: [{ match: { tool: '*' }, action: 'deny' }],
+      }),
+    )
+    expect(rule.match.upstreams).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/proxy/src/policy/parser.ts
+++ b/packages/proxy/src/policy/parser.ts
@@ -139,6 +139,7 @@ function compileMatch(
     ...(match.metadata !== undefined && {
       metadata: flattenMetadataConditions(match.metadata, ruleIndex, ruleName),
     }),
+    ...(match.upstreams !== undefined && { upstreams: [...match.upstreams] }),
   }
 }
 

--- a/packages/proxy/src/policy/types.ts
+++ b/packages/proxy/src/policy/types.ts
@@ -66,6 +66,8 @@ export interface CompiledMatch {
   readonly environment?: string
   /** Flattened list of metadata conditions (one entry per key+operator pair). */
   readonly metadata?: readonly MetadataCondition[]
+  /** Configured upstream names the rule is scoped to, OR within the list (issue #293). */
+  readonly upstreams?: readonly string[]
 }
 
 /** Compiled approval configuration with durations as milliseconds. */

--- a/packages/proxy/src/server.test.ts
+++ b/packages/proxy/src/server.test.ts
@@ -74,6 +74,55 @@ describe('createApp', () => {
     expect(json).toEqual({ status: 'ok' })
   })
 
+  it('throws on a named multi-upstream config (issue #293)', () => {
+    // Library-level darkness: an embedder handing createApp a named config
+    // must get a loud pointer at createMultiApp, never a silent single-mount
+    // app serving only one of the declared upstreams.
+    const named = {
+      version: '1',
+      upstreams: [
+        {
+          name: 'files',
+          url: 'http://localhost:8081/mcp',
+          transport: 'streamable-http',
+          protocol_version: 'auto',
+          connect_timeout: '10s',
+          request_timeout: '30s',
+          forward_headers: [],
+          headers: {},
+        },
+      ],
+      listen: { port: 3000, host: '127.0.0.1', allowed_origins: [] },
+      dashboard: {
+        enabled: false,
+        port: 3100,
+        host: '127.0.0.1',
+        allow_open_mode: false,
+        sse_heartbeat_interval: '30s',
+      },
+      session: {
+        identity: [{ source: 'header', name: 'x-helio-session-id' }, { source: 'legacy_header' }],
+        on_unresolved: 'deny',
+      },
+      policies: { default: 'allow', dry_run: false, rules: [] },
+      approval: { timeout: '300s', default_on_timeout: 'deny', channels: [] },
+      audit: {
+        storage: 'sqlite',
+        path: './helio-audit.db',
+        retention: '90d',
+        include_responses: true,
+      },
+      sdk: { enabled: false, port: 3200, host: '127.0.0.1', evaluation_ttl: '10m' },
+      budgets: [],
+    } as HelioConfig
+    const forwarder = createMockForwarder({ status: 200, headers: {}, body: {} })
+
+    expect(() => createApp(named, forwarder)).toThrow(
+      'createApp serves a single-upstream (upstream:) config only. Named multi-upstream ' +
+        'configs are composed by createMultiApp, which lands with issue #294.',
+    )
+  })
+
   it('routes POST /mcp to the forwarder', async () => {
     const forwarder = createMockForwarder({
       status: 200,

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -5,6 +5,7 @@ import type { Socket } from 'node:net'
 import { createStreamableHttpRoute } from './transport/streamable-http.js'
 import { createSseRoute } from './transport/sse.js'
 import { compileSessionIdentity } from './mcp/session-resolver.js'
+import { isNamedConfig } from './config/index.js'
 import type { HelioConfig } from './config/index.js'
 import type { HeaderMismatchRejection, McpForwarder } from './mcp/types.js'
 
@@ -146,6 +147,14 @@ export function createApp(
   forwarder: McpForwarder,
   options?: CreateAppOptions,
 ): Hono {
+  if (isNamedConfig(config)) {
+    // One app serves one upstream; silently mounting a single door for a
+    // named config would drop every other declared upstream.
+    throw new Error(
+      'createApp serves a single-upstream (upstream:) config only. Named multi-upstream ' +
+        'configs are composed by createMultiApp, which lands with issue #294.',
+    )
+  }
   const app = new Hono()
   const forwardHeadersAllowlist = config.upstream.forward_headers
   const allowedOrigins = config.listen.allowed_origins

--- a/packages/proxy/src/startup-warnings.test.ts
+++ b/packages/proxy/src/startup-warnings.test.ts
@@ -5,7 +5,35 @@ import {
   warnIfDashboardOpenMode,
   warnIfNoEnforcement,
   warnIfBudgetWindowExceedsRetention,
+  warnIfManyUpstreams,
 } from './startup-warnings.js'
+
+describe('warnIfManyUpstreams', () => {
+  const upstreams = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+      name: `up-${String(i)}`,
+      url: `http://localhost:${String(9000 + i)}/mcp`,
+    }))
+
+  it('warns above 16 upstream entries', () => {
+    const messages: string[] = []
+    const warned = warnIfManyUpstreams({ upstreams: upstreams(17) }, (m) => messages.push(m))
+    expect(warned).toBe(true)
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toBe(
+      '[helio] Warning: 17 upstreams configured. Each upstream runs its own upstream ' +
+        'connection or child process plus an annotation prime loop; consider whether one ' +
+        'proxy should govern this many.',
+    )
+  })
+
+  it('does not warn at exactly 16 entries', () => {
+    const messages: string[] = []
+    const warned = warnIfManyUpstreams({ upstreams: upstreams(16) }, (m) => messages.push(m))
+    expect(warned).toBe(false)
+    expect(messages).toHaveLength(0)
+  })
+})
 
 describe('warnIfWebhookChannelUnreachable', () => {
   function makeConfig(

--- a/packages/proxy/src/startup-warnings.ts
+++ b/packages/proxy/src/startup-warnings.ts
@@ -46,14 +46,6 @@ export function warnIfBudgetWindowExceedsRetention(
 }
 
 /**
- * Emit a startup warning if a webhook approval channel is configured while
- * the dashboard sideband is bound to localhost only. Webhook callbacks
- * originate from outside the host, so they cannot reach
- * `/api/approvals/:id/approve` on a 127.0.0.1-bound sideband. Surfacing this
- * at boot prevents silent mis-configurations where tickets are created but
- * can never be resolved via webhook.
- */
-/**
  * Emit a warning when a named config declares more than 16 upstreams. Each
  * upstream runs its own connection or child process plus an annotation prime
  * loop, so a very wide proxy multiplies that cost — the guardrail nudges the
@@ -74,6 +66,14 @@ export function warnIfManyUpstreams(
   return true
 }
 
+/**
+ * Emit a startup warning if a webhook approval channel is configured while
+ * the dashboard sideband is bound to localhost only. Webhook callbacks
+ * originate from outside the host, so they cannot reach
+ * `/api/approvals/:id/approve` on a 127.0.0.1-bound sideband. Surfacing this
+ * at boot prevents silent mis-configurations where tickets are created but
+ * can never be resolved via webhook.
+ */
 export function warnIfWebhookChannelUnreachable(
   config: {
     approval: { channels: ReadonlyArray<{ type: string }> }

--- a/packages/proxy/src/startup-warnings.ts
+++ b/packages/proxy/src/startup-warnings.ts
@@ -53,6 +53,27 @@ export function warnIfBudgetWindowExceedsRetention(
  * at boot prevents silent mis-configurations where tickets are created but
  * can never be resolved via webhook.
  */
+/**
+ * Emit a warning when a named config declares more than 16 upstreams. Each
+ * upstream runs its own connection or child process plus an annotation prime
+ * loop, so a very wide proxy multiplies that cost — the guardrail nudges the
+ * operator to consider splitting the deployment. Warning-only: nothing
+ * refuses to run (issue #293).
+ */
+export function warnIfManyUpstreams(
+  config: { upstreams: ReadonlyArray<unknown> },
+  log: (message: string) => void = console.error,
+): boolean {
+  const count = config.upstreams.length
+  if (count <= 16) return false
+  log(
+    `[helio] Warning: ${String(count)} upstreams configured. Each upstream runs its own ` +
+      'upstream connection or child process plus an annotation prime loop; consider ' +
+      'whether one proxy should govern this many.',
+  )
+  return true
+}
+
 export function warnIfWebhookChannelUnreachable(
   config: {
     approval: { channels: ReadonlyArray<{ type: string }> }

--- a/scripts/validate-config-samples.mjs
+++ b/scripts/validate-config-samples.mjs
@@ -45,21 +45,29 @@ import yaml from 'js-yaml'
 // Vocabulary
 // ---------------------------------------------------------------------------
 
-/** Canonical top-level section order (docs/configuration.md is the reference). */
-const CANONICAL_ORDER = [
-  'version',
-  'upstream',
-  'listen',
-  'environment',
-  'session',
-  'policies',
-  'budgets',
-  'approval',
-  'audit',
-  'dashboard',
-  'sdk',
+/**
+ * Canonical top-level section order (docs/configuration.md is the
+ * reference), as slots: `upstream` (singular) and `upstreams` (named list)
+ * share one slot because a config declares exactly one of the two
+ * (issue #293) — and the init scaffold legitimately shows both, the live
+ * section plus the commented pointer stub.
+ */
+const CANONICAL_SLOTS = [
+  ['version'],
+  ['upstream', 'upstreams'],
+  ['listen'],
+  ['environment'],
+  ['session'],
+  ['policies'],
+  ['budgets'],
+  ['approval'],
+  ['audit'],
+  ['dashboard'],
+  ['sdk'],
 ]
+const CANONICAL_ORDER = CANONICAL_SLOTS.flat()
 const ROOT_KEYS = new Set(CANONICAL_ORDER)
+const SLOT_OF = new Map(CANONICAL_SLOTS.flatMap((keys, slot) => keys.map((key) => [key, slot])))
 
 /** Top-level keys of a policy rule (policyRuleSchema in config/schema.ts). */
 const RULE_KEYS = new Set([
@@ -470,12 +478,16 @@ function classifyFence(text) {
 
   if (isPlainObject(node)) {
     const keys = Object.keys(node)
-    if (keys.includes('version') && keys.includes('upstream')) {
+    if (keys.includes('version') && (keys.includes('upstream') || keys.includes('upstreams'))) {
       // Full config: validate the fence text as-is, byte for byte.
       return { kind: 'full-config', candidateText: text, doc: node, ownKeys: keys }
     }
     if (keys.length > 0 && keys.every((key) => ROOT_KEYS.has(key) || key.startsWith('x-'))) {
       const merged = { ...HARNESS, ...node }
+      // A named-mode fragment displaces the harness's singular upstream —
+      // without this the overlay would build a both-modes doc that fails
+      // the exactly-one-of contract (issue #293).
+      if ('upstreams' in node) delete merged.upstream
       return {
         kind: 'fragment',
         candidateText: yaml.dump(merged, DUMP_OPTS),
@@ -537,12 +549,14 @@ function expectedCounts(doc) {
 
 /** Canonical-order subsequence check over a document's own top-level keys. */
 function orderViolation(ownKeys) {
-  const indices = ownKeys
-    .filter((key) => ROOT_KEYS.has(key))
-    .map((key) => CANONICAL_ORDER.indexOf(key))
-  for (let i = 1; i < indices.length; i++) {
-    if (indices[i] <= indices[i - 1]) {
-      return `top-level keys not in canonical order (${CANONICAL_ORDER.join(' → ')})`
+  const slots = ownKeys.filter((key) => ROOT_KEYS.has(key)).map((key) => SLOT_OF.get(key))
+  for (let i = 1; i < slots.length; i++) {
+    // Strictly earlier slots violate; an equal slot is the upstream/upstreams
+    // pair sharing slot 2 (a parsed object cannot repeat a key, and the
+    // scaffold matcher finds each key once — issue #293).
+    if (slots[i] < slots[i - 1]) {
+      const order = CANONICAL_SLOTS.map((keys) => keys.join('|')).join(' → ')
+      return `top-level keys not in canonical order (${order})`
     }
   }
   return null
@@ -636,17 +650,21 @@ function scaffoldOrderViolation(scaffoldText) {
 }
 
 /**
- * Check 4: all 10 root keys present in the init scaffold (commented stubs
- * count) and, uncommented at column 0, in at least one configuration.md
- * fence. Returns violation strings.
+ * Check 4: every canonical slot present in the init scaffold (commented
+ * stubs count) and, uncommented at column 0, in at least one
+ * configuration.md fence. Returns violation strings.
  */
 function checkCompleteness(scaffoldText, configurationFences) {
   const violations = []
 
+  // Slots, not keys: either spelling of the upstream slot satisfies it
+  // (issue #293), so the scaffold's commented `# upstreams:` stub and
+  // configuration.md's existing `upstream:` fences both count.
   if (scaffoldText !== null) {
-    for (const key of CANONICAL_ORDER) {
-      if (!new RegExp(`^(?:#\\s*)?${key}:`, 'm').test(scaffoldText)) {
-        violations.push(`init scaffold is missing a top-level \`${key}:\` stub`)
+    for (const slotKeys of CANONICAL_SLOTS) {
+      const label = slotKeys.join('|')
+      if (!new RegExp(`^(?:#\\s*)?(?:${slotKeys.join('|')}):`, 'm').test(scaffoldText)) {
+        violations.push(`init scaffold is missing a top-level \`${label}:\` stub`)
       }
     }
   }
@@ -654,12 +672,13 @@ function checkCompleteness(scaffoldText, configurationFences) {
   if (configurationFences === undefined) {
     violations.push('docs/configuration.md not found — cannot check root-key completeness')
   } else {
-    for (const key of CANONICAL_ORDER) {
+    for (const slotKeys of CANONICAL_SLOTS) {
+      const label = slotKeys.join('|')
       const shown = configurationFences.some((fence) =>
-        new RegExp(`^${key}:`, 'm').test(fence.text),
+        new RegExp(`^(?:${slotKeys.join('|')}):`, 'm').test(fence.text),
       )
       if (!shown) {
-        violations.push(`docs/configuration.md shows no fence with a top-level \`${key}:\``)
+        violations.push(`docs/configuration.md shows no fence with a top-level \`${label}:\``)
       }
     }
   }

--- a/scripts/validate-config-samples.mjs
+++ b/scripts/validate-config-samples.mjs
@@ -484,10 +484,12 @@ function classifyFence(text) {
     }
     if (keys.length > 0 && keys.every((key) => ROOT_KEYS.has(key) || key.startsWith('x-'))) {
       const merged = { ...HARNESS, ...node }
-      // A named-mode fragment displaces the harness's singular upstream —
+      // A named-mode fragment displaces the HARNESS's singular upstream —
       // without this the overlay would build a both-modes doc that fails
-      // the exactly-one-of contract (issue #293).
-      if ('upstreams' in node) delete merged.upstream
+      // the exactly-one-of contract. A fence that itself declares both
+      // modes keeps both keys, so its own defect still fails loudly
+      // (issue #293).
+      if ('upstreams' in node && !('upstream' in node)) delete merged.upstream
       return {
         kind: 'fragment',
         candidateText: yaml.dump(merged, DUMP_OPTS),


### PR DESCRIPTION
## Description

Named multi-upstream configuration, shipped dark. `helio.yaml` accepts a top-level `upstreams:` list of named entries as an alternative to the singular `upstream:` section, with an exactly-one-of contract and crisp mode-aware errors. Policy rules gain `match.upstreams`, budget contributors gain the same optional scope, and validation rejects every dead combination up front: singular-mode scoping, unknown names, combination with `match.metadata`, sender-keyed limits on scoped rules, the all-scoped `sender_id` budget, and `legacy_header` identity beside evidence-gated rules. `helio validate` accepts named configs fully and warns, without refusing, above 16 entries; `helio init` scaffolds a commented `# upstreams:` pointer; the docs samples guard understands both forms (`upstreams` shares the canonical slot of `upstream`).

The darkness bar: singular configs parse byte-identically (golden pin, key-order pins, fold-parity pin, zero assertion-value changes in existing tests), `helio start` refuses named mode with an error naming #294, and `createApp` throws on a named config pointing at `createMultiApp` and #294. No routing file is touched and no mounts exist.

Boundaries: composition, mounts, the start loop, refusal removal, and the `startCommand` warning wiring are #294; dashboard columns and filters are #297; the docs overhaul (configuration.md `upstreams` section, policies and budgets docs) is #298.

Notes from the work: externally reviewed over two rounds (READY; two minor findings folded: the webhook warning JSDoc reattachment, and non-object config roots keeping their type-error diagnosis instead of the mode message). A workspace test flake during verification was triaged against a clean-main worktree and commented on #271 (tenth occurrence). Follow-up handoff comments for #294 and #298 land with the issue close-out.

Closes #293

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `pnpm build && pnpm test` (the proxy suite includes a named-mode acceptance matrix in `cli.test.ts` covering every rejection family through the built CLI).
2. Write a named config (`upstreams:` with two entries) and run `helio validate -c` on it: it validates fully, and prints a warning above 16 entries.
3. Run `helio start -c` on the same config: it refuses with an error naming #294 and exits 1 before listening.
4. `pnpm docs:check:samples`: the shipped singular sample set passes untouched, and the guard's self-tests cover the named fences.

## Additional Context

The config template stays singular by default; multi-upstream is an explicit opt-in with the migration spelled out in the exactly-one-of error message. Singular `upstream:` is a permanent first-class mode, not a legacy form.
