### PR TITLE
feat(proxy): serve named upstreams at /mcp/<name> and /sse/<name>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ Maintainer notes:
 
 ### Changed
 
+- Internal groundwork for multi-upstream composition (#294):
+  `helio start` now assembles its upstream stack (transport connect,
+  governance wrap, annotation prime loop) through two extracted
+  per-upstream helpers. Singular-mode behavior, construction order,
+  and log output are unchanged.
 - First use of the ratified additive-migration path (#292): a v0.12.0
   audit database missing only the new `upstream` column is migrated in
   place on first open with a single `ALTER TABLE` and one stderr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,11 @@ Maintainer notes:
 - Internal groundwork for multi-upstream composition (#294):
   `helio start` now assembles its upstream stack (transport connect,
   governance wrap, annotation prime loop) through two extracted
-  per-upstream helpers. Singular-mode behavior, construction order,
-  and log output are unchanged.
+  per-upstream helpers. The stdio forwarder's max-retries death line
+  and the protocol-pin confirmation line can now carry the
+  operator-chosen upstream label, joining the #295 substrate; nothing
+  sets a label yet. Singular-mode behavior, construction order, and
+  log output are unchanged.
 - First use of the ratified additive-migration path (#292): a v0.12.0
   audit database missing only the new `upstream` column is migrated in
   place on first open with a single `ALTER TABLE` and one stderr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,14 @@ Maintainer notes:
 
 ### Fixed
 
+- A configuration reload that leaves `policies.tool_revalidation`
+  unchanged no longer restarts the revalidation clock, so frequent
+  saves cannot keep pushing the next definition check a full interval
+  out. A revalidation, retry, or startup prime attempt that rejects
+  outright (instead of reporting a failure result) is now logged and
+  survived with the cadence and backoff intact; previously such a
+  rejection crashed the proxy, or for a prime attempt landing after
+  the startup wait, vanished silently.
 - The Streamable HTTP forwarder no longer forwards a caller-supplied
   `mcp-session-id` on its request sends. Merge residue from caller
   headers and constructor static headers alike is now cleared on every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,9 @@ Maintainer notes:
   the dashboard queue, and budget event listings read `upstream` from
   the referenced audit record. New filters: `upstream` on `/api/audit`,
   `/api/audit/export`, and `/api/feed`, plus `helio export --upstream`.
-  Every upstream value is null or absent until the multi-upstream
-  composition ships; `session_source` on tickets is live immediately.
+  Every upstream value is null in singular mode; named multi-upstream
+  serving (#294, below) is what populates them. `session_source` on
+  tickets is live in both modes.
 
 - Multi-upstream serving (#294): `helio start` now serves named
   multi-upstream configs. Each entry gets its own `/mcp/<name>` and
@@ -94,10 +95,11 @@ Maintainer notes:
   every entry, shutdown stops every prime loop first and closes every
   forwarder last, startup prints one `Upstream[<name>]:` line per
   entry, the upstream lifecycle log lines (era detection, priming,
-  the `/sse` cap refusal, the stdio max-retries death line, the
-  protocol-pin confirmation) carry the entry's `[helio][<name>]` tag,
-  and the more-than-16-upstreams warning now prints from start as
-  well as validate. The dashboard Limits page renders an
+  the stdio max-retries death line, the protocol-pin confirmation)
+  carry the entry's `[helio][<name>]` tag, the `/sse` cap-refusal
+  line names the door that refused (`[helio] /sse/<name> at session
+cap ...`), and the more-than-16-upstreams warning now prints from
+  start as well as validate. The dashboard Limits page renders an
   upstream-prefixed tool key as the tool with the door as a qualifier
   (`send_email (files)`); the full grouping and filtering UX is
   tracked separately (#297). For library embedders,
@@ -110,9 +112,9 @@ Maintainer notes:
   the tool-scope limiter keys, budget charges and peek entries, and
   the upstream lifecycle log lines (era detection, annotation priming,
   the `/sse` cap refusal) can now carry an operator-chosen upstream
-  label. Nothing sets a label yet; it lights up when the multi-upstream
-  composition ships. Singular-mode behavior, key formats, and log
-  lines are byte-identical.
+  label. Named multi-upstream serving (#294, below) is what sets the
+  labels. Singular-mode behavior, key formats, and log lines are
+  byte-identical.
 - Type-level compatibility note for library embedders (#295): the
   `BudgetChargeContext` passed to `BudgetEngine.resolveCharges()` has
   a new required `upstream: string | null` field, so charge-context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,11 +97,15 @@ Maintainer notes:
   the `/sse` cap refusal, the stdio max-retries death line, the
   protocol-pin confirmation) carry the entry's `[helio][<name>]` tag,
   and the more-than-16-upstreams warning now prints from start as
-  well as validate. For library embedders, `createMultiApp(config,
-forwarders)` is exported beside `createApp`; its forwarder record
-  must match the configured names exactly (missing or extra keys
-  throw at composition). Singular-mode serving is byte-identical,
-  including its log lines and limiter key formats.
+  well as validate. The dashboard Limits page renders an
+  upstream-prefixed tool key as the tool with the door as a qualifier
+  (`send_email (files)`); the full grouping and filtering UX is
+  tracked separately (#297). For library embedders,
+  `createMultiApp(config, forwarders)` is exported beside
+  `createApp`; its forwarder record must match the configured names
+  exactly (missing or extra keys throw at composition).
+  Singular-mode serving is byte-identical, including its log lines
+  and limiter key formats.
 - Internal multi-upstream substrate (#295): the policy match context,
   the tool-scope limiter keys, budget charges and peek entries, and
   the upstream lifecycle log lines (era detection, annotation priming,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,12 @@ Maintainer notes:
   alternative to the singular `upstream:` section; exactly one of the
   two must be set. Each entry takes every `upstream.*` field plus a
   required `name` (letters, digits, `_`, `-`; unique within the list).
-  `helio validate` fully validates named configs. `helio start` does
-  not serve them yet: it refuses named mode with an error pointing at
-  the composition work (#294). For library embedders, `HelioConfig` is
+  `helio validate` fully validates named configs, and `helio start`
+  serves them through the multi-upstream composition (#294, below).
+  For library embedders, `HelioConfig` is
   now a union of the two modes with `isSingularConfig` /
   `isNamedConfig` guards exported, and `createApp` throws on a named
-  config, pointing at the upcoming `createMultiApp`. A mode switch is
+  config, pointing at `createMultiApp`. A mode switch is
   restart-required at the reload boundary. Policy rules gain
   `match.upstreams`, a non-empty list of configured upstream names
   (exact match, OR within the list, AND with the other match
@@ -77,6 +77,31 @@ Maintainer notes:
   Every upstream value is null or absent until the multi-upstream
   composition ships; `session_source` on tickets is live immediately.
 
+- Multi-upstream serving (#294): `helio start` now serves named
+  multi-upstream configs. Each entry gets its own `/mcp/<name>` and
+  `/sse/<name>` mounts wrapping that entry's forwarder with a fresh
+  governed route stack (own annotation cache, era cache, prime loop,
+  header/body agreement door, and per-door `/sse` session cap);
+  `/healthz` and `/slack/actions` stay global. There is no bare-path
+  default: bare `/mcp`, `/sse`, and unknown names return an explicit
+  HTTP 404 with an id-less JSON-RPC `-32600` envelope stating the
+  path shape, never enumerating configured names. Startup is
+  all-or-nothing in config order — a connect failure aborts boot
+  naming the entry (`upstream "<name>": …`) after best-effort closing
+  the entries that did connect — and boot waits each entry's
+  annotation-prime window in turn, so a slow upstream can add up to
+  1.5 seconds per entry. Hot reload fans policy updates out across
+  every entry, shutdown stops every prime loop first and closes every
+  forwarder last, startup prints one `Upstream[<name>]:` line per
+  entry, the upstream lifecycle log lines (era detection, priming,
+  the `/sse` cap refusal, the stdio max-retries death line, the
+  protocol-pin confirmation) carry the entry's `[helio][<name>]` tag,
+  and the more-than-16-upstreams warning now prints from start as
+  well as validate. For library embedders, `createMultiApp(config,
+forwarders)` is exported beside `createApp`; its forwarder record
+  must match the configured names exactly (missing or extra keys
+  throw at composition). Singular-mode serving is byte-identical,
+  including its log lines and limiter key formats.
 - Internal multi-upstream substrate (#295): the policy match context,
   the tool-scope limiter keys, budget charges and peek entries, and
   the upstream lifecycle log lines (era detection, annotation priming,
@@ -92,14 +117,6 @@ Maintainer notes:
 
 ### Changed
 
-- Internal groundwork for multi-upstream composition (#294):
-  `helio start` now assembles its upstream stack (transport connect,
-  governance wrap, annotation prime loop) through two extracted
-  per-upstream helpers. The stdio forwarder's max-retries death line
-  and the protocol-pin confirmation line can now carry the
-  operator-chosen upstream label, joining the #295 substrate; nothing
-  sets a label yet. Singular-mode behavior, construction order, and
-  log output are unchanged.
 - First use of the ratified additive-migration path (#292): a v0.12.0
   audit database missing only the new `upstream` column is migrated in
   place on first open with a single `ALTER TABLE` and one stderr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,9 +97,10 @@ Maintainer notes:
   entry, the upstream lifecycle log lines (era detection, priming,
   the stdio max-retries death line, the protocol-pin confirmation)
   carry the entry's `[helio][<name>]` tag, the `/sse` cap-refusal
-  line names the door that refused (`[helio] /sse/<name> at session
-cap ...`), and the more-than-16-upstreams warning now prints from
-  start as well as validate. The dashboard Limits page renders an
+  line names the door that refused
+  (`[helio] /sse/<name> at session cap ...`), and the
+  more-than-16-upstreams warning now prints from start as well as
+  validate. The dashboard Limits page renders an
   upstream-prefixed tool key as the tool with the door as a qualifier
   (`send_email (files)`); the full grouping and filtering UX is
   tracked separately (#297). For library embedders,
@@ -112,7 +113,7 @@ cap ...`), and the more-than-16-upstreams warning now prints from
   the tool-scope limiter keys, budget charges and peek entries, and
   the upstream lifecycle log lines (era detection, annotation priming,
   the `/sse` cap refusal) can now carry an operator-chosen upstream
-  label. Named multi-upstream serving (#294, below) is what sets the
+  label. Named multi-upstream serving (#294, above) is what sets the
   labels. Singular-mode behavior, key formats, and log lines are
   byte-identical.
 - Type-level compatibility note for library embedders (#295): the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,14 @@ Maintainer notes:
 
 ### Fixed
 
+- Diagnosed startup failures now exit cleanly instead of crash-dumping
+  (#233): when `helio start` refuses to boot for a stated reason — an
+  audit database from an older build with a mismatched schema, or an
+  upstream that fails to connect — stderr carries the diagnosis alone
+  and the process exits 1, without the
+  `[helio] Unhandled promise rejection:` wrapper and stack trace that
+  previously buried the recovery instructions. Genuine crashes keep
+  the full stack and the crash-drain path.
 - A configuration reload that leaves `policies.tool_revalidation`
   unchanged no longer restarts the revalidation clock, so frequent
   saves cannot keep pushing the next definition check a full interval

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,9 @@ export default tseslint.config(
       'packages/python-sdk/',
       '**/*.config.js',
       '**/*.config.ts',
+      // Plain-JS child-process fixtures spawned by e2e tests; not part of
+      // any TypeScript project, so the typed lint cannot parse them.
+      '**/__tests__/helpers/*.cjs',
       '**/scripts/**',
       '.local/',
       'docker/',

--- a/packages/dashboard/src/pages/LimitsPage.test.tsx
+++ b/packages/dashboard/src/pages/LimitsPage.test.tsx
@@ -67,6 +67,46 @@ describe('LimitsPage', () => {
     })
   })
 
+  it('renders upstream-prefixed tool keys as the tool with a door qualifier (issue #294)', async () => {
+    mockFetchLimits.mockResolvedValue({
+      rate_limits: [
+        {
+          key: 'upstream:files:tool:send_email',
+          current: 1,
+          limit: 10,
+          window_ms: MS_PER_HOUR,
+          reset_at_ms: Date.now() + 30 * MS_PER_MINUTE,
+        },
+        {
+          key: 'upstream:files:tool:send_email:rule:2',
+          current: 2,
+          limit: 10,
+          window_ms: MS_PER_HOUR,
+          reset_at_ms: Date.now() + 30 * MS_PER_MINUTE,
+        },
+        {
+          key: 'tool:list_files',
+          current: 3,
+          limit: 10,
+          window_ms: MS_PER_HOUR,
+          reset_at_ms: Date.now() + 30 * MS_PER_MINUTE,
+        },
+      ],
+      spend_limits: [],
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('send_email (files)')).toBeTruthy()
+      expect(screen.getByText('send_email:rule:2 (files)')).toBeTruthy()
+      // Singular keys keep today's first-colon split byte-identically.
+      expect(screen.getByText('list_files')).toBeTruthy()
+      // All three render as TOOL rows — the door prefix is a qualifier, not
+      // a type of its own.
+      expect(screen.getAllByText('tool')).toHaveLength(3)
+    })
+  })
+
   it('renders spend limit cards', async () => {
     mockFetchLimits.mockResolvedValue({
       rate_limits: [],

--- a/packages/dashboard/src/pages/LimitsPage.tsx
+++ b/packages/dashboard/src/pages/LimitsPage.tsx
@@ -32,6 +32,17 @@ function formatWindow(ms: number): string {
 }
 
 function parseKeyLabel(key: string): { type: string; name: string } {
+  // Named-mode tool keys (`upstream:<door>:tool:<rest>`) render as the TOOL
+  // with the door as a qualifier, matching the singular rendering of the
+  // same tool. The full grouping/filter UX is issue #297; every other key
+  // shape keeps the first-colon split.
+  const upstreamTool = /^upstream:([^:]+):tool:(.*)$/.exec(key)
+  if (upstreamTool) {
+    const [, door, rest] = upstreamTool
+    if (door !== undefined && rest !== undefined) {
+      return { type: 'tool', name: `${rest} (${door})` }
+    }
+  }
   const idx = key.indexOf(':')
   if (idx === -1) return { type: '', name: key }
   return { type: key.slice(0, idx), name: key.slice(idx + 1) }

--- a/packages/proxy/src/__tests__/helpers/stdio-mcp-fixture.cjs
+++ b/packages/proxy/src/__tests__/helpers/stdio-mcp-fixture.cjs
@@ -1,0 +1,35 @@
+// Minimal MCP-speaking stdio child for multi-upstream CLI e2e tests.
+//
+// Speaks newline-delimited JSON-RPC on stdin/stdout (the StdioForwarder
+// framing — NOT LSP Content-Length). Answers `initialize` and `tools/list`
+// immediately so annotation priming completes in milliseconds instead of
+// eating the 1.5s startup window. The advertised tool is NAMED by argv so
+// each entry's child is distinguishable end to end — a door's response can
+// never be mistaken for another door's.
+const toolName = process.argv[2] ?? 'fixture_ping'
+const readline = require('readline')
+const rl = readline.createInterface({ input: process.stdin })
+rl.on('line', (line) => {
+  let req
+  try {
+    req = JSON.parse(line)
+  } catch {
+    return
+  }
+  if (req.id === undefined || req.id === null) return
+  let result
+  if (req.method === 'initialize') {
+    result = {
+      protocolVersion: '2025-06-18',
+      capabilities: { tools: {} },
+      serverInfo: { name: `fixture-${toolName}`, version: '0.0.0' },
+    }
+  } else if (req.method === 'tools/list') {
+    result = {
+      tools: [{ name: toolName, description: 'e2e fixture tool', inputSchema: { type: 'object' } }],
+    }
+  } else {
+    result = {}
+  }
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: req.id, result }) + '\n')
+})

--- a/packages/proxy/src/__tests__/integration-multi.test.ts
+++ b/packages/proxy/src/__tests__/integration-multi.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest'
+import { Hono } from 'hono'
+import { createMultiApp } from '../server.js'
+import { makeConfig } from './helpers/test-utils.js'
+import type { HelioConfig } from '../config/index.js'
+import type { McpForwarder, McpRequest } from '../mcp/types.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * A forwarder stand-in whose canned tools/list payload advertises a single
+ * tool named after its door, so a response can never be mistaken for a
+ * different door's (the routing assertions read the tool NAME).
+ */
+function stubForwarder(toolName: string): McpForwarder & { calls: McpRequest[] } {
+  const calls: McpRequest[] = []
+  return {
+    calls,
+    forward(req: McpRequest) {
+      calls.push(req)
+      return Promise.resolve({
+        response: {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: {
+            jsonrpc: '2.0' as const,
+            id: req.id ?? 1,
+            result: { tools: [{ name: toolName }] },
+          },
+        },
+        durationMs: 0,
+      })
+    },
+  }
+}
+
+/** Build a validated-shape named config for the given entry names. */
+function makeNamedConfig(names: string[]): HelioConfig {
+  return {
+    version: '1',
+    upstreams: names.map((name) => ({
+      name,
+      url: `http://localhost:8081/${name}`,
+      transport: 'streamable-http',
+      protocol_version: 'auto',
+      connect_timeout: '10s',
+      request_timeout: '30s',
+      forward_headers: [],
+      headers: {},
+    })),
+    listen: { port: 3000, host: '127.0.0.1', allowed_origins: [] },
+    dashboard: {
+      enabled: false,
+      port: 3100,
+      host: '127.0.0.1',
+      allow_open_mode: false,
+      sse_heartbeat_interval: '30s',
+    },
+    session: {
+      identity: [{ source: 'header', name: 'x-helio-session-id' }, { source: 'legacy_header' }],
+      on_unresolved: 'deny',
+    },
+    policies: { default: 'allow', dry_run: false, rules: [] },
+    approval: { timeout: '300s', default_on_timeout: 'deny', channels: [] },
+    audit: {
+      storage: 'sqlite',
+      path: './helio-audit.db',
+      retention: '90d',
+      include_responses: true,
+    },
+    sdk: { enabled: false, port: 3200, host: '127.0.0.1', evaluation_ttl: '10m' },
+    budgets: [],
+  } as HelioConfig
+}
+
+const MCP_CATCH_ALL_MESSAGE =
+  'No MCP endpoint answers this request: this Helio serves named upstreams at /mcp/<name>.'
+const SSE_CATCH_ALL_MESSAGE =
+  'No MCP endpoint answers this request: this Helio serves named upstreams at /sse/<name>.'
+
+function postJson(app: Hono, path: string, body: unknown) {
+  return app.request(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const toolsList = (id: number) => ({ jsonrpc: '2.0', id, method: 'tools/list' })
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createMultiApp', () => {
+  describe('guards', () => {
+    it('throws on a singular config', () => {
+      expect(() => createMultiApp(makeConfig(), { files: stubForwarder('files_ping') })).toThrow(
+        'createMultiApp composes a named multi-upstream (upstreams:) config only. ' +
+          'Singular configs are served by createApp.',
+      )
+    })
+
+    it('throws when the forwarder record is missing a configured name', () => {
+      expect(() =>
+        createMultiApp(makeNamedConfig(['files', 'github']), {
+          files: stubForwarder('files_ping'),
+        }),
+      ).toThrow(
+        'createMultiApp forwarders must match the configured upstream names exactly — ' +
+          'missing: [github], unexpected: [].',
+      )
+    })
+
+    it('throws when the forwarder record carries an unconfigured name', () => {
+      expect(() =>
+        createMultiApp(makeNamedConfig(['files']), {
+          files: stubForwarder('files_ping'),
+          ghost: stubForwarder('ghost_ping'),
+        }),
+      ).toThrow(
+        'createMultiApp forwarders must match the configured upstream names exactly — ' +
+          'missing: [], unexpected: [ghost].',
+      )
+    })
+  })
+
+  describe('routing', () => {
+    it('serves each door from its own forwarder, in mount order over catch-alls', async () => {
+      const files = stubForwarder('files_ping')
+      const github = stubForwarder('github_ping')
+      const app = createMultiApp(makeNamedConfig(['files', 'github']), { files, github })
+
+      const filesRes = await postJson(app, '/mcp/files', toolsList(1))
+      expect(filesRes.status).toBe(200)
+      const filesBody = (await filesRes.json()) as {
+        result: { tools: Array<{ name: string }> }
+      }
+      expect(filesBody.result.tools[0]?.name).toBe('files_ping')
+
+      const githubRes = await postJson(app, '/mcp/github', toolsList(2))
+      expect(githubRes.status).toBe(200)
+      const githubBody = (await githubRes.json()) as {
+        result: { tools: Array<{ name: string }> }
+      }
+      expect(githubBody.result.tools[0]?.name).toBe('github_ping')
+
+      // Door isolation: each stub saw exactly its own door's request.
+      expect(files.calls).toHaveLength(1)
+      expect(files.calls[0]?.id).toBe(1)
+      expect(github.calls).toHaveLength(1)
+      expect(github.calls[0]?.id).toBe(2)
+    })
+
+    it('keeps /healthz global', async () => {
+      const app = createMultiApp(makeNamedConfig(['files']), {
+        files: stubForwarder('files_ping'),
+      })
+      const res = await app.request('/healthz')
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ status: 'ok' })
+    })
+
+    it('mounts the Slack action app globally', async () => {
+      const slackActionApp = new Hono()
+      slackActionApp.post('/', (c) => c.json({ slack: true }))
+      const app = createMultiApp(
+        makeNamedConfig(['files']),
+        { files: stubForwarder('files_ping') },
+        { slackActionApp },
+      )
+      const res = await app.request('/slack/actions', { method: 'POST' })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ slack: true })
+    })
+
+    it('serves the SSE door with a mount-relative endpoint event (issue #294)', async () => {
+      const files = stubForwarder('files_ping')
+      const github = stubForwarder('github_ping')
+      const app = createMultiApp(makeNamedConfig(['files', 'github']), { files, github })
+
+      const sseRes = await app.request('/sse/files')
+      expect(sseRes.status).toBe(200)
+      expect(sseRes.headers.get('content-type')).toBe('text/event-stream')
+
+      const reader = sseRes.body?.getReader() as ReadableStreamDefaultReader<Uint8Array>
+      const chunk = await reader.read()
+      reader.releaseLock()
+      const text = new TextDecoder().decode(chunk.value)
+      expect(text).toContain('event: endpoint')
+      // The endpoint reference is RELATIVE (`?sessionId=…`), so a client at
+      // /sse/files resolves it to /sse/files?sessionId=… by construction.
+      const match = /data: (\S+)/.exec(text)
+      const endpointRef = match?.[1] ?? ''
+      expect(endpointRef.startsWith('?sessionId=')).toBe(true)
+
+      const sessionId = endpointRef.slice('?sessionId='.length)
+      const postRes = await postJson(app, `/sse/files?sessionId=${sessionId}`, toolsList(3))
+      expect(postRes.status).toBe(202)
+      expect(files.calls).toHaveLength(1)
+      expect(files.calls[0]?.id).toBe(3)
+      expect(github.calls).toHaveLength(0)
+    })
+  })
+
+  describe('catch-alls', () => {
+    const envelope = (message: string) => ({
+      jsonrpc: '2.0',
+      error: { code: -32600, message },
+    })
+
+    it.each([
+      ['POST', '/mcp', 'bare prefix'],
+      ['POST', '/mcp/ghost', 'unknown name'],
+      ['POST', '/mcp/files/extra', 'extra segments'],
+      ['DELETE', '/mcp/files', 'method miss on a valid door'],
+    ])('%s %s (%s) gets the /mcp envelope', async (method, path) => {
+      const app = createMultiApp(makeNamedConfig(['files']), {
+        files: stubForwarder('files_ping'),
+      })
+      const res = await app.request(path, { method })
+      expect(res.status).toBe(404)
+      expect(res.headers.get('content-type')).toContain('application/json')
+      const body = (await res.json()) as Record<string, unknown>
+      expect(body).toEqual(envelope(MCP_CATCH_ALL_MESSAGE))
+      expect('id' in body).toBe(false)
+    })
+
+    it.each([
+      ['GET', '/sse', 'bare prefix'],
+      ['GET', '/sse/ghost', 'unknown name'],
+      ['POST', '/sse/files/extra', 'extra segments'],
+    ])('%s %s (%s) gets the /sse envelope', async (method, path) => {
+      const app = createMultiApp(makeNamedConfig(['files']), {
+        files: stubForwarder('files_ping'),
+      })
+      const res = await app.request(path, { method })
+      expect(res.status).toBe(404)
+      expect(res.headers.get('content-type')).toContain('application/json')
+      const body = (await res.json()) as Record<string, unknown>
+      expect(body).toEqual(envelope(SSE_CATCH_ALL_MESSAGE))
+      expect('id' in body).toBe(false)
+    })
+
+    it('omits the id even when the request body carries one (issue #294)', async () => {
+      const app = createMultiApp(makeNamedConfig(['files']), {
+        files: stubForwarder('files_ping'),
+      })
+      const res = await postJson(app, '/mcp/ghost', { jsonrpc: '2.0', id: 7, method: 'x' })
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as Record<string, unknown>
+      expect('id' in body).toBe(false)
+      expect(body).toEqual(envelope(MCP_CATCH_ALL_MESSAGE))
+    })
+
+    it('never names a configured upstream in the envelope', async () => {
+      const app = createMultiApp(makeNamedConfig(['zephyr-door']), {
+        'zephyr-door': stubForwarder('zephyr_ping'),
+      })
+      for (const path of ['/mcp/nope', '/sse/nope']) {
+        const res = await app.request(path, { method: 'POST' })
+        expect(res.status).toBe(404)
+        const text = await res.text()
+        expect(text).not.toContain('zephyr-door')
+      }
+    })
+  })
+})

--- a/packages/proxy/src/audit/store.test.ts
+++ b/packages/proxy/src/audit/store.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import Database from 'better-sqlite3'
 import { AuditStore, EXPORT_MAX_RECORDS, migrateAuditUpstreamColumn } from './store.js'
+import { StartupError } from '../startup-error.js'
 import type { AuditRecord } from './types.js'
 
 // ---------------------------------------------------------------------------
@@ -173,6 +174,39 @@ CREATE TABLE IF NOT EXISTS audit_records (
         ).toThrow(
           /Audit DB schema mismatch: missing required columns .*"block_reason".*Delete ".*audit\.db".*then restart Helio\./,
         )
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('throws a StartupError on a schema mismatch, for the CLI clean-exit path (issue #233)', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-audit-startup-error-'))
+      const dbPath = join(dir, 'audit.db')
+      const legacyDb = new Database(dbPath)
+      // MANY required columns missing: a DB missing only `upstream` is
+      // silently repaired on open (the #292 additive exception) and would
+      // never reach the mismatch throw.
+      legacyDb.exec(
+        'CREATE TABLE audit_records (' +
+          'id TEXT PRIMARY KEY, timestamp TEXT NOT NULL, tool_name TEXT NOT NULL, ' +
+          'policy_decision TEXT NOT NULL, matched_rule TEXT, tool_input TEXT, ' +
+          'flagged_destructive INTEGER, dry_run INTEGER)',
+      )
+      legacyDb.close()
+
+      try {
+        let caught: unknown
+        try {
+          new AuditStore({
+            path: dbPath,
+            retention: '90d',
+            includeResponses: true,
+            cleanupIntervalMs: 0,
+          })
+        } catch (err) {
+          caught = err
+        }
+        expect(caught).toBeInstanceOf(StartupError)
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }

--- a/packages/proxy/src/audit/store.ts
+++ b/packages/proxy/src/audit/store.ts
@@ -3,6 +3,7 @@ import type { Database as DatabaseType, Statement } from 'better-sqlite3'
 import { randomUUID } from 'node:crypto'
 import { chmodSync } from 'node:fs'
 import { parseDuration } from '../config/schema.js'
+import { StartupError } from '../startup-error.js'
 import { extractResponseSummary } from '../upstream/response-summary.js'
 import { clamp } from '../util/clamp.js'
 import type {
@@ -491,7 +492,9 @@ export class AuditStore {
     if (missing.length === 0) return
 
     const quotedColumns = missing.map((name) => `"${name}"`).join(', ')
-    throw new Error(
+    // StartupError: the message is the complete operator diagnosis; the CLI
+    // prints it clean and exits instead of crash-dumping (issue #233).
+    throw new StartupError(
       '[helio] Audit DB schema mismatch: missing required columns ' +
         `${quotedColumns}. ` +
         `This local database was created by an older Helio build. ` +

--- a/packages/proxy/src/cli-forwarder.test.ts
+++ b/packages/proxy/src/cli-forwarder.test.ts
@@ -3,6 +3,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const upstreamCtor = vi.fn()
 const sseCtor = vi.fn()
 const streamableCtor = vi.fn()
+const stdioCtor = vi.fn()
+
+vi.mock('./transport/stdio-wrapper.js', () => ({
+  StdioForwarder: class {
+    start = vi.fn().mockResolvedValue(undefined)
+    close = vi.fn().mockResolvedValue(undefined)
+    constructor(opts: unknown) {
+      stdioCtor(opts)
+    }
+  },
+}))
 
 vi.mock('./upstream/index.js', () => ({
   UpstreamForwarder: upstreamCtor,
@@ -30,6 +41,7 @@ describe('createForwarderFromConfig', () => {
     upstreamCtor.mockClear()
     sseCtor.mockClear()
     streamableCtor.mockClear()
+    stdioCtor.mockClear()
   })
 
   it('passes upstream.headers to the streamable-http forwarder', async () => {
@@ -95,5 +107,77 @@ describe('createForwarderFromConfig', () => {
     expect(sseCtor).toHaveBeenCalledWith(
       expect.objectContaining({ headers: { Authorization: 'Bearer t' } }),
     )
+  })
+
+  it('tags the protocol-pin confirmation line with the upstream name (issue #294)', async () => {
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logged.push(String(args[0]))
+    })
+    try {
+      const config = makeConfig({
+        upstream: {
+          url: 'http://upstream/mcp',
+          transport: 'streamable-http',
+          request_timeout: '30s',
+          protocol_version: '2025-06-18',
+        },
+      })
+
+      await createForwarderFromConfig(config, 'files')
+
+      expect(logged).toContain(
+        '[helio][files] Upstream MCP protocol version pinned: 2025-06-18 (upstream.protocol_version)',
+      )
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('keeps the protocol-pin confirmation line bare without an upstream name', async () => {
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logged.push(String(args[0]))
+    })
+    try {
+      const config = makeConfig({
+        upstream: {
+          url: 'http://upstream/mcp',
+          transport: 'streamable-http',
+          request_timeout: '30s',
+          protocol_version: '2025-06-18',
+        },
+      })
+
+      await createForwarderFromConfig(config)
+
+      expect(logged).toContain(
+        '[helio] Upstream MCP protocol version pinned: 2025-06-18 (upstream.protocol_version)',
+      )
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('passes the upstream name into the stdio and streamable forwarder options (issue #294)', async () => {
+    const streamable = makeConfig({
+      upstream: {
+        url: 'http://upstream/mcp',
+        transport: 'streamable-http',
+        request_timeout: '30s',
+      },
+    })
+    await createForwarderFromConfig(streamable, 'files')
+    expect(streamableCtor).toHaveBeenCalledWith(expect.objectContaining({ upstreamName: 'files' }))
+
+    const stdio = makeConfig({
+      upstream: {
+        transport: 'stdio',
+        command: 'node',
+        request_timeout: '30s',
+      },
+    })
+    await createForwarderFromConfig(stdio, 'github')
+    expect(stdioCtor).toHaveBeenCalledWith(expect.objectContaining({ upstreamName: 'github' }))
   })
 })

--- a/packages/proxy/src/cli-forwarder.ts
+++ b/packages/proxy/src/cli-forwarder.ts
@@ -1,4 +1,5 @@
 import { parseDuration } from './config/schema.js'
+import { helioLogTag } from './util/log-label.js'
 import { SseUpstreamForwarder, StreamableHttpForwarder } from './upstream/index.js'
 import { StdioForwarder } from './transport/stdio-wrapper.js'
 import type { SingularHelioConfig } from './config/index.js'
@@ -18,6 +19,7 @@ export interface BuiltForwarder {
  */
 export async function createForwarderFromConfig(
   config: Pick<SingularHelioConfig, 'upstream'>,
+  upstreamName?: string,
 ): Promise<BuiltForwarder> {
   switch (config.upstream.transport) {
     case 'streamable-http': {
@@ -29,13 +31,14 @@ export async function createForwarderFromConfig(
         headers: config.upstream.headers,
         requestTimeoutMs: parseDuration(config.upstream.request_timeout),
         protocolVersion: config.upstream.protocol_version,
+        upstreamName,
       })
       if (config.upstream.protocol_version !== 'auto') {
         // A pin is never probed, so no era-detected line will ever appear;
         // this line is the operator's confirmation the pin took effect.
         // eslint-disable-next-line no-console -- operator-visible startup detail
         console.error(
-          `[helio] Upstream MCP protocol version pinned: ` +
+          `${helioLogTag(upstreamName)} Upstream MCP protocol version pinned: ` +
             `${config.upstream.protocol_version} (upstream.protocol_version)`,
         )
       }
@@ -57,6 +60,7 @@ export async function createForwarderFromConfig(
         command: config.upstream.command as string,
         args: config.upstream.args,
         requestTimeoutMs: parseDuration(config.upstream.request_timeout),
+        upstreamName,
       })
       await stdio.start()
       return { forwarder: stdio, close: () => stdio.close() }

--- a/packages/proxy/src/cli-forwarder.ts
+++ b/packages/proxy/src/cli-forwarder.ts
@@ -12,10 +12,12 @@ export interface BuiltForwarder {
 /**
  * Construct the upstream forwarder for the configured transport. Static
  * `upstream.headers` are passed to the HTTP transports (`streamable-http`,
- * `sse`); `stdio` is a child process with no request headers.
+ * `sse`); `stdio` is a child process with no request headers. Only the
+ * `upstream` section is read, so callers may pass any object carrying one —
+ * a full singular config, or a named entry wrapped as `{ upstream: entry }`.
  */
 export async function createForwarderFromConfig(
-  config: SingularHelioConfig,
+  config: Pick<SingularHelioConfig, 'upstream'>,
 ): Promise<BuiltForwarder> {
   switch (config.upstream.transport) {
     case 'streamable-http': {

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -5,6 +5,7 @@ import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import Database from 'better-sqlite3'
 import { AuditStore } from './audit/store.js'
 import type { AuditRecord } from './audit/types.js'
 import { BudgetLedger } from './budget/ledger.js'
@@ -951,6 +952,81 @@ dashboard:
         // A refusal, not a validation failure: helio validate accepts this
         // exact config (pinned above in the validate suite).
         expect(message).not.toContain('Invalid configuration')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    it('start with a stale legacy audit DB exits 1 with the recovery message alone (issue #233)', async () => {
+      const { dir, configPath } = writeStdioStartConfig('30s')
+      const auditPath = join(dir, 'audit.db')
+      const staleDb = new Database(auditPath)
+      // The issue's repro table: MANY required columns missing. A DB missing
+      // only `upstream` is silently repaired on open (the #292 additive
+      // exception) and would boot clean instead of reproducing.
+      staleDb.exec(
+        'CREATE TABLE audit_records (' +
+          'id TEXT PRIMARY KEY, timestamp TEXT NOT NULL, tool_name TEXT NOT NULL, ' +
+          'policy_decision TEXT NOT NULL, matched_rule TEXT, tool_input TEXT, ' +
+          'flagged_destructive INTEGER, dry_run INTEGER)',
+      )
+      staleDb.close()
+
+      try {
+        const result = await runCli(['start', '-c', configPath])
+        expect(result.code).toBe(1)
+        expect(result.stderr).toContain(
+          '[helio] Audit DB schema mismatch: missing required columns',
+        )
+        expect(result.stderr).toContain('then restart Helio.')
+        expect(result.stderr).not.toContain('Unhandled promise rejection')
+        expect(result.stderr).not.toMatch(/\n\s+at /)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    it('start with an unreachable singular sse upstream exits 1 with the connect error alone (issue #233)', async () => {
+      // Grab a port that was just free, so the connect fails fast with
+      // ECONNREFUSED instead of eating the connect timeout.
+      const closedPort = await new Promise<number>((resolve) => {
+        const srv = createServer()
+        srv.listen(0, '127.0.0.1', () => {
+          const port = (srv.address() as AddressInfo).port
+          srv.close(() => {
+            resolve(port)
+          })
+        })
+      })
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-sse-conn-'))
+      const configPath = join(dir, 'helio.yaml')
+      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      writeFileSync(
+        configPath,
+        `
+version: "1"
+upstream:
+  url: "http://127.0.0.1:${String(closedPort)}/sse"
+  transport: sse
+  connect_timeout: "2s"
+listen:
+  port: ${String(listenPort)}
+  host: 127.0.0.1
+dashboard:
+  enabled: false
+audit:
+  path: "${join(dir, 'audit.db')}"
+`,
+      )
+
+      try {
+        const result = await runCli(['start', '-c', configPath])
+        expect(result.code).toBe(1)
+        expect(result.stderr).toContain('is unreachable (ECONNREFUSED)')
+        // Singular mode: the underlying message alone — no minted upstream
+        // name, no crash dump.
+        expect(result.stderr).not.toContain('upstream "')
+        expect(result.stderr).not.toContain('Unhandled promise rejection')
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -184,6 +184,64 @@ audit:
   return { dir, configPath, listenPort }
 }
 
+/** Grab a port that was just free, for fast-ECONNREFUSED connect failures. */
+function getClosedPort(): Promise<number> {
+  return new Promise<number>((resolve) => {
+    const srv = createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port
+      srv.close(() => {
+        resolve(port)
+      })
+    })
+  })
+}
+
+/** Path of the MCP-speaking stdio child fixture (see the file's header). */
+const STDIO_MCP_FIXTURE = join(import.meta.dirname, '__tests__', 'helpers', 'stdio-mcp-fixture.cjs')
+
+/**
+ * Write a two-entry named-mode config whose stdio children each advertise a
+ * tool named after their entry (`files_ping` / `github_ping`).
+ */
+function writeTwoUpstreamConfig(): { dir: string; configPath: string; listenPort: number } {
+  const dir = mkdtempSync(join(tmpdir(), 'helio-cli-multi-'))
+  const configPath = join(dir, 'helio.yaml')
+  const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+  writeFileSync(
+    configPath,
+    `
+version: "1"
+upstreams:
+  - name: files
+    url: "http://127.0.0.1:1/mcp"
+    transport: stdio
+    command: "node"
+    args: ["${STDIO_MCP_FIXTURE}", "files_ping"]
+  - name: github
+    url: "http://127.0.0.1:1/mcp"
+    transport: stdio
+    command: "node"
+    args: ["${STDIO_MCP_FIXTURE}", "github_ping"]
+listen:
+  port: ${String(listenPort)}
+  host: 127.0.0.1
+dashboard:
+  enabled: false
+policies:
+  default: allow
+  rules:
+    - name: deny-probe
+      match:
+        tool: "denied_probe"
+      action: deny
+audit:
+  path: "${join(dir, 'audit.db')}"
+`,
+  )
+  return { dir, configPath, listenPort }
+}
+
 /** Wait until the proxy health endpoint responds, to avoid startup races. */
 async function waitForProxyHealth(baseUrl: string, timeoutMs: number): Promise<void> {
   const started = Date.now()
@@ -923,35 +981,177 @@ dashboard:
       }
     }, 15_000)
 
-    it('refuses to start a named multi-upstream config, pointing at #294 (issue #293)', async () => {
-      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+    it('serves a two-entry named config end to end (issue #294)', async () => {
+      const { dir, configPath, listenPort } = writeTwoUpstreamConfig()
+      const baseUrl = `http://127.0.0.1:${String(listenPort)}`
+      const child = spawn('node', [CLI_PATH, 'start', '-c', configPath], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+      })
+      let stderr = ''
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf-8')
+      })
+      try {
+        // A pre-healthy exit (e.g. a boot refusal) must surface its stderr
+        // instead of a bare health-poll timeout.
+        await Promise.race([
+          waitForProxyHealth(baseUrl, 8_000),
+          new Promise<never>((_, reject) => {
+            child.on('close', (code) => {
+              reject(
+                new Error(`helio start exited ${String(code)} before healthy. stderr:\n${stderr}`),
+              )
+            })
+          }),
+        ])
+
+        // The acceptance leg: each door serves ITS OWN child's entry-named
+        // tool over real HTTP. Status alone cannot prove the mount wiring;
+        // the tool NAME can. Content-Type is required or the door 415s.
+        for (const [name, toolName, id] of [
+          ['files', 'files_ping', 1],
+          ['github', 'github_ping', 2],
+        ] as const) {
+          const res = await fetch(`${baseUrl}/mcp/${name}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ jsonrpc: '2.0', id, method: 'tools/list' }),
+          })
+          expect(res.status).toBe(200)
+          const body = (await res.json()) as { result: { tools: Array<{ name: string }> } }
+          expect(body.result.tools[0]?.name).toBe(toolName)
+        }
+
+        // Catch-alls over real HTTP: bare prefix and unknown name get the
+        // exact id-less envelope.
+        for (const path of ['/mcp', '/mcp/ghost']) {
+          const res = await fetch(`${baseUrl}${path}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'tools/list' }),
+          })
+          expect(res.status).toBe(404)
+          expect(res.headers.get('content-type')).toContain('application/json')
+          const body = (await res.json()) as Record<string, unknown>
+          expect(body).toEqual({
+            jsonrpc: '2.0',
+            error: {
+              code: -32600,
+              message:
+                'No MCP endpoint answers this request: this Helio serves named upstreams at /mcp/<name>.',
+            },
+          })
+          expect('id' in body).toBe(false)
+        }
+
+        // The door serves the GOVERNED forwarder, not the raw transport: a
+        // deny rule answers with the policy envelope instead of relaying.
+        const deniedRes = await fetch(`${baseUrl}/mcp/files`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 9,
+            method: 'tools/call',
+            params: { name: 'denied_probe', arguments: {} },
+          }),
+        })
+        const deniedBody = (await deniedRes.json()) as {
+          error?: { code: number; data?: { blocked?: boolean } }
+        }
+        expect(deniedBody.error?.code).toBe(-32001)
+        expect(deniedBody.error?.data?.blocked).toBe(true)
+
+        // Per-entry startup lines and name-tagged prime lines.
+        expect(stderr).toContain('Upstream[files]: node (stdio)')
+        expect(stderr).toContain('Upstream[github]: node (stdio)')
+        expect(stderr).toMatch(/\[helio\]\[files\] Annotation cache primed/)
+        expect(stderr).toMatch(/\[helio\]\[github\] Annotation cache primed/)
+
+        // Clean shutdown.
+        const exitCode = await new Promise<number | null>((resolve) => {
+          if (child.exitCode !== null) {
+            resolve(child.exitCode)
+            return
+          }
+          child.on('close', (code) => {
+            resolve(code)
+          })
+          child.kill('SIGTERM')
+        })
+        expect(exitCode).toBe(0)
+      } finally {
+        if (child.exitCode === null) child.kill('SIGKILL')
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    it('all-or-nothing boot: an unreachable entry fails startup naming it (issue #294)', async () => {
+      const closedPort = await getClosedPort()
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-multi-fail-'))
       const configPath = join(dir, 'helio.yaml')
+      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
       writeFileSync(
         configPath,
-        'version: "1"\n' +
-          'upstreams:\n' +
-          '  - name: files\n' +
-          '    url: "http://localhost:8081/mcp"\n' +
-          'dashboard:\n' +
-          '  enabled: false\n',
+        `
+version: "1"
+upstreams:
+  - name: files
+    url: "http://127.0.0.1:1/mcp"
+    transport: stdio
+    command: "node"
+    args: ["${STDIO_MCP_FIXTURE}", "files_ping"]
+  - name: backend
+    url: "http://127.0.0.1:${String(closedPort)}/sse"
+    transport: sse
+    connect_timeout: "2s"
+listen:
+  port: ${String(listenPort)}
+  host: 127.0.0.1
+dashboard:
+  enabled: false
+audit:
+  path: "${join(dir, 'audit.db')}"
+`,
       )
-
       try {
-        const err = await startAndCaptureStderr(['-c', configPath]).then(
-          () => null,
-          (e: unknown) => e,
-        )
-        expect(err).toBeInstanceOf(Error)
-        const message = err instanceof Error ? err.message : ''
-        expect(message).toContain(
-          'Error: this config declares named upstreams (upstreams:), which "helio start" ' +
-            'cannot serve yet — multi-upstream composition and routing land with issue #294. ' +
-            '"helio validate" fully validates named configs; to start today, use the ' +
-            'singular "upstream:" form.',
-        )
-        // A refusal, not a validation failure: helio validate accepts this
-        // exact config (pinned above in the validate suite).
-        expect(message).not.toContain('Invalid configuration')
+        const result = await runCli(['start', '-c', configPath])
+        expect(result.code).toBe(1)
+        expect(result.stderr).toContain('upstream "backend": ')
+        expect(result.stderr).toContain('is unreachable (ECONNREFUSED)')
+        expect(result.stderr).not.toContain('Unhandled promise rejection')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    it('warns before connecting when more than 16 upstreams are configured (issue #294)', async () => {
+      const closedPort = await getClosedPort()
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-multi-many-'))
+      const configPath = join(dir, 'helio.yaml')
+      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const entries = Array.from(
+        { length: 17 },
+        (_, i) =>
+          `  - name: u${String(i)}\n` +
+          `    url: "http://127.0.0.1:${String(closedPort)}/sse"\n` +
+          '    transport: sse\n' +
+          '    connect_timeout: "2s"\n',
+      ).join('')
+      writeFileSync(
+        configPath,
+        `version: "1"\nupstreams:\n${entries}listen:\n  port: ${String(listenPort)}\n  host: 127.0.0.1\ndashboard:\n  enabled: false\naudit:\n  path: "${join(dir, 'audit.db')}"\n`,
+      )
+      try {
+        const result = await runCli(['start', '-c', configPath])
+        expect(result.code).toBe(1)
+        const warningIndex = result.stderr.indexOf('[helio] Warning: 17 upstreams configured.')
+        const failureIndex = result.stderr.indexOf('upstream "u0": ')
+        expect(warningIndex).toBeGreaterThanOrEqual(0)
+        expect(failureIndex).toBeGreaterThanOrEqual(0)
+        // The operator hears the warning even though entry 1 fails: it
+        // prints BEFORE the connect loop.
+        expect(warningIndex).toBeLessThan(failureIndex)
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -229,8 +229,11 @@ function printConfigErrorDetails(error: ConfigError, prefix = ''): void {
  * every upstream connects before any shared service is constructed — a bad
  * upstream fails boot without side effects (no audit DB is created).
  */
-async function connectUpstream(upstream: SingularHelioConfig['upstream']): Promise<BuiltForwarder> {
-  return createForwarderFromConfig({ upstream })
+async function connectUpstream(
+  upstream: SingularHelioConfig['upstream'],
+  upstreamName?: string,
+): Promise<BuiltForwarder> {
+  return createForwarderFromConfig({ upstream }, upstreamName)
 }
 
 /** One governed upstream stack: the forwarder wrapped in governance plus
@@ -249,15 +252,16 @@ async function governUpstream(options: {
   forwarder: McpForwarder
   policy: CompiledPolicy
   governance: GovernedForwarderOptions
+  upstreamName?: string
 }): Promise<UpstreamStack> {
-  const governedForwarder = new GovernedForwarder(
-    options.forwarder,
-    options.policy,
-    options.governance,
-  )
+  const governedForwarder = new GovernedForwarder(options.forwarder, options.policy, {
+    ...options.governance,
+    upstreamName: options.upstreamName,
+  })
   const annotationPrime = await startAnnotationPrimeLoop(
     governedForwarder,
     options.policy.toolRevalidation,
+    options.upstreamName,
   )
   return { governedForwarder, annotationPrime }
 }

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -9,7 +9,9 @@ import { VERSION } from './version.js'
 import { loadConfig, ConfigError, ConfigWatcher, isNamedConfig } from './config/index.js'
 import type { SingularHelioConfig } from './config/index.js'
 import { findUnroutableApprovalReferences } from './config/reload-boundary.js'
-import { createApp, startServer, startSidebandServer } from './server.js'
+import type { Hono } from 'hono'
+import { createApp, createMultiApp, startServer, startSidebandServer } from './server.js'
+import { applyReloadedPolicy } from './reload-fanout.js'
 import { createForwarderFromConfig } from './cli-forwarder.js'
 import type { BuiltForwarder } from './cli-forwarder.js'
 import type { McpForwarder } from './mcp/types.js'
@@ -296,19 +298,6 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     throw err
   }
 
-  // Refuse (not reject) named mode: the config is valid, but composition and
-  // routing for multiple upstreams land with issue #294. The exit doubles as
-  // the type narrowing — everything below runs on a singular config.
-  if (isNamedConfig(config)) {
-    console.error(
-      'Error: this config declares named upstreams (upstreams:), which "helio start" ' +
-        'cannot serve yet — multi-upstream composition and routing land with issue #294. ' +
-        '"helio validate" fully validates named configs; to start today, use the ' +
-        'singular "upstream:" form.',
-    )
-    process.exit(1)
-  }
-
   const bundledDashboardDistPath = config.dashboard.enabled ? getBundledDashboardDistPath() : null
   if (config.dashboard.enabled && !bundledDashboardDistPath) {
     console.error(
@@ -318,8 +307,47 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     process.exit(1)
   }
 
-  // Create the right forwarder based on upstream transport
-  const { forwarder, close: closeForwarder } = await connectUpstream(config.upstream)
+  // The capacity guardrail prints BEFORE the connect loop, so the operator
+  // hears it even when an early entry fails to connect.
+  if (isNamedConfig(config)) {
+    warnIfManyUpstreams(config)
+  }
+
+  // Phase 1 of per-upstream assembly: connect EVERY upstream before any
+  // shared service is constructed — a bad upstream fails boot with no side
+  // effects (no audit DB is created). Sequential, in config order, and
+  // all-or-nothing: the first failure closes whatever already connected
+  // (best-effort) and aborts the boot naming the entry. Singular mode is
+  // the same loop over one nameless entry.
+  const upstreamSections: Array<{
+    name: string | undefined
+    upstream: SingularHelioConfig['upstream']
+  }> = isNamedConfig(config)
+    ? config.upstreams.map((entry) => ({ name: entry.name, upstream: entry }))
+    : [{ name: undefined, upstream: config.upstream }]
+
+  const doors: Array<{
+    name: string | undefined
+    forwarder: McpForwarder
+    close?: () => Promise<void>
+  }> = []
+  for (const { name, upstream } of upstreamSections) {
+    try {
+      const built = await connectUpstream(upstream, name)
+      doors.push({ name, forwarder: built.forwarder, close: built.close })
+    } catch (err) {
+      for (const door of doors) {
+        try {
+          await door.close?.()
+        } catch (closeErr) {
+          console.error(
+            `[helio] Ignoring a forwarder close failure while aborting startup: ${String(closeErr)}`,
+          )
+        }
+      }
+      throw err
+    }
+  }
 
   // Compile policies and wrap the forwarder with governance
   const { policy, warnings } = compilePolicies(config.policies)
@@ -421,20 +449,33 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   // restart-required at the reload boundary (issue #218).
   const session = compileSessionIdentity(config.session)
 
-  const { governedForwarder, annotationPrime } = await governUpstream({
-    forwarder,
-    policy,
-    governance: {
-      environment: config.environment,
-      auditWriter,
-      evidenceStore,
-      approvalRouter,
-      rateLimiter,
-      spendLimiter,
-      budgetEngine,
-      session,
-    },
-  })
+  // Phase 2 of per-upstream assembly: wrap every connected forwarder with
+  // governance and start its annotation prime loop. Sequential in config
+  // order; each door waits its prime loop's startup window, so a slow
+  // upstream costs up to 1.5s per entry at boot (accepted v1). The shared
+  // services are constructed once and every stack composes them.
+  const governance: GovernedForwarderOptions = {
+    environment: config.environment,
+    auditWriter,
+    evidenceStore,
+    approvalRouter,
+    rateLimiter,
+    spendLimiter,
+    budgetEngine,
+    session,
+  }
+  const stacks: Array<{ name: string | undefined } & UpstreamStack> = []
+  for (const door of doors) {
+    stacks.push({
+      name: door.name,
+      ...(await governUpstream({
+        forwarder: door.forwarder,
+        policy,
+        governance,
+        upstreamName: door.name,
+      })),
+    })
+  }
 
   // Conditionally create Slack action handler if any Slack channels exist
   const hasSlackChannels = [...channels.values()].some((ch) => ch.type === 'slack')
@@ -442,12 +483,34 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     ? createSlackActionApp({ router: approvalRouter, channels })
     : undefined
 
-  const app = createApp(config, governedForwarder, {
-    slackActionApp,
-    onHeaderMismatch: (rejection) => {
-      auditWriter.pushImmediate(buildHeaderMismatchAuditRecord(rejection, config.environment))
-    },
-  })
+  // The apps serve the GOVERNED forwarders — mounting a raw transport
+  // forwarder would silently bypass policy, approval, and audit.
+  let app: Hono
+  if (isNamedConfig(config)) {
+    const forwarders: Record<string, McpForwarder> = {}
+    for (const stack of stacks) {
+      if (stack.name !== undefined) forwarders[stack.name] = stack.governedForwarder
+    }
+    app = createMultiApp(config, forwarders, {
+      slackActionApp,
+      onHeaderMismatch: (rejection, upstreamName) => {
+        auditWriter.pushImmediate(
+          buildHeaderMismatchAuditRecord(rejection, config.environment, upstreamName),
+        )
+      },
+    })
+  } else {
+    const stack = stacks[0]
+    if (stack === undefined) {
+      throw new Error('unreachable: singular mode connects exactly one upstream')
+    }
+    app = createApp(config, stack.governedForwarder, {
+      slackActionApp,
+      onHeaderMismatch: (rejection) => {
+        auditWriter.pushImmediate(buildHeaderMismatchAuditRecord(rejection, config.environment))
+      },
+    })
+  }
   const handle = startServer(app, config)
 
   // Conditionally start the sideband server for SDK communication.
@@ -559,7 +622,15 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
     `Policies: ${String(ruleCount)} rule${ruleCount !== 1 ? 's' : ''} loaded (default: ${policy.defaultAction})`,
   )
   warnIfNoEnforcement(policy)
-  if (config.upstream.transport === 'stdio') {
+  if (isNamedConfig(config)) {
+    for (const entry of config.upstreams) {
+      if (entry.transport === 'stdio') {
+        console.error(`Upstream[${entry.name}]: ${entry.command ?? ''} (stdio)`)
+      } else {
+        console.error(`Upstream[${entry.name}]: ${entry.url} (${entry.transport})`)
+      }
+    }
+  } else if (config.upstream.transport === 'stdio') {
     console.error(`Upstream: ${config.upstream.command ?? ''} (stdio)`)
   } else {
     console.error(`Upstream: ${config.upstream.url} (${config.upstream.transport})`)
@@ -645,8 +716,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
         // watcher's onError keeps the current config) before any policy
         // swap — the reload applies all-or-nothing across the file.
         budgetEngine.reconcile(newBudgets)
-        governedForwarder.updatePolicy(newPolicy)
-        annotationPrime.reconfigure(newPolicy.toolRevalidation)
+        applyReloadedPolicy(stacks, newPolicy)
         governanceService?.updatePolicy(newPolicy)
         const budgetTotal = newBudgets.length
         console.error(
@@ -689,8 +759,8 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
 
   registerShutdown(
     handle,
-    annotationPrime,
-    closeForwarder,
+    stacks.map((stack) => stack.annotationPrime),
+    doors.flatMap((door) => (door.close ? [door.close] : [])),
     auditWriter,
     configWatcher,
     sidebandHandle,
@@ -738,8 +808,8 @@ async function validateCommand(configPath: string): Promise<void> {
     }
     compileBudgets(config.budgets)
 
-    // The start command cannot reach this warning yet — it refuses named
-    // mode outright — so validate is where the operator hears it (#293).
+    // Start warns too (before its connect loop); validate is the cheap
+    // preflight an operator runs first, so it warns as well.
     if (isNamedConfig(config)) {
       warnIfManyUpstreams(config)
     }
@@ -909,8 +979,8 @@ function writeCsv(records: readonly AuditRecord[]): void {
 
 function registerShutdown(
   handle: ServerHandle,
-  annotationPrime?: AnnotationPrimeController,
-  closeForwarder?: () => Promise<void>,
+  annotationPrimes?: ReadonlyArray<AnnotationPrimeController>,
+  closeForwarders?: ReadonlyArray<() => Promise<void>>,
   auditWriter?: AuditWriter,
   configWatcher?: ConfigWatcher,
   sidebandHandle?: ServerHandle,
@@ -938,8 +1008,8 @@ function registerShutdown(
 
     void closeResources({
       handle,
-      annotationPrime,
-      closeForwarder,
+      annotationPrimes,
+      closeForwarders,
       auditWriter,
       configWatcher,
       sidebandHandle,

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -7,11 +7,16 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { VERSION } from './version.js'
 import { loadConfig, ConfigError, ConfigWatcher, isNamedConfig } from './config/index.js'
+import type { SingularHelioConfig } from './config/index.js'
 import { findUnroutableApprovalReferences } from './config/reload-boundary.js'
 import { createApp, startServer, startSidebandServer } from './server.js'
 import { createForwarderFromConfig } from './cli-forwarder.js'
+import type { BuiltForwarder } from './cli-forwarder.js'
+import type { McpForwarder } from './mcp/types.js'
 import { compilePolicies, PolicyParseError } from './policy/index.js'
+import type { CompiledPolicy } from './policy/index.js'
 import { GovernedForwarder } from './policy/governed-forwarder.js'
+import type { GovernedForwarderOptions } from './policy/governed-forwarder.js'
 import { compileSessionIdentity } from './mcp/session-resolver.js'
 import { startAnnotationPrimeLoop } from './policy/annotation-prime-loop.js'
 import type { AnnotationPrimeController } from './policy/annotation-prime-loop.js'
@@ -218,6 +223,45 @@ function printConfigErrorDetails(error: ConfigError, prefix = ''): void {
   }
 }
 
+/**
+ * Phase 1 of per-upstream stack assembly: build and connect the transport
+ * forwarder for one upstream section. Kept separate from governUpstream so
+ * every upstream connects before any shared service is constructed — a bad
+ * upstream fails boot without side effects (no audit DB is created).
+ */
+async function connectUpstream(upstream: SingularHelioConfig['upstream']): Promise<BuiltForwarder> {
+  return createForwarderFromConfig({ upstream })
+}
+
+/** One governed upstream stack: the forwarder wrapped in governance plus
+ *  its running annotation prime loop. */
+interface UpstreamStack {
+  readonly governedForwarder: GovernedForwarder
+  readonly annotationPrime: AnnotationPrimeController
+}
+
+/**
+ * Phase 2 of per-upstream stack assembly: wrap a connected forwarder with
+ * governance and start its annotation prime loop. Runs after the shared
+ * services exist; `governance` carries the services every stack shares.
+ */
+async function governUpstream(options: {
+  forwarder: McpForwarder
+  policy: CompiledPolicy
+  governance: GovernedForwarderOptions
+}): Promise<UpstreamStack> {
+  const governedForwarder = new GovernedForwarder(
+    options.forwarder,
+    options.policy,
+    options.governance,
+  )
+  const annotationPrime = await startAnnotationPrimeLoop(
+    governedForwarder,
+    options.policy.toolRevalidation,
+  )
+  return { governedForwarder, annotationPrime }
+}
+
 interface StartOptions {
   config: string
   /** When true, do not start the config file watcher. Overrides the YAML. */
@@ -260,7 +304,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   }
 
   // Create the right forwarder based on upstream transport
-  const { forwarder, close: closeForwarder } = await createForwarderFromConfig(config)
+  const { forwarder, close: closeForwarder } = await connectUpstream(config.upstream)
 
   // Compile policies and wrap the forwarder with governance
   const { policy, warnings } = compilePolicies(config.policies)
@@ -362,18 +406,20 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
   // restart-required at the reload boundary (issue #218).
   const session = compileSessionIdentity(config.session)
 
-  const governedForwarder = new GovernedForwarder(forwarder, policy, {
-    environment: config.environment,
-    auditWriter,
-    evidenceStore,
-    approvalRouter,
-    rateLimiter,
-    spendLimiter,
-    budgetEngine,
-    session,
+  const { governedForwarder, annotationPrime } = await governUpstream({
+    forwarder,
+    policy,
+    governance: {
+      environment: config.environment,
+      auditWriter,
+      evidenceStore,
+      approvalRouter,
+      rateLimiter,
+      spendLimiter,
+      budgetEngine,
+      session,
+    },
   })
-
-  const annotationPrime = await startAnnotationPrimeLoop(governedForwarder, policy.toolRevalidation)
 
   // Conditionally create Slack action handler if any Slack channels exist
   const hasSlackChannels = [...channels.values()].some((ch) => ch.type === 'slack')

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -56,6 +56,7 @@ import {
 } from './startup-warnings.js'
 import { closeResources } from './shutdown.js'
 import { drainForCrash, registerCrashDrainHook } from './crash-drain.js'
+import { StartupError } from './startup-error.js'
 
 // ---------------------------------------------------------------------------
 // Process-level error handlers — ensure crashes are logged, and let every
@@ -233,7 +234,17 @@ async function connectUpstream(
   upstream: SingularHelioConfig['upstream'],
   upstreamName?: string,
 ): Promise<BuiltForwarder> {
-  return createForwarderFromConfig({ upstream }, upstreamName)
+  try {
+    return await createForwarderFromConfig({ upstream }, upstreamName)
+  } catch (err) {
+    // A connect failure is a diagnosed boot failure, not a crash (#233). A
+    // named entry's failure names the entry; singular mode prints the
+    // underlying message ALONE — no name is ever minted for it.
+    const message = err instanceof Error ? err.message : String(err)
+    throw new StartupError(
+      upstreamName === undefined ? message : `upstream "${upstreamName}": ${message}`,
+    )
+  }
 }
 
 /** One governed upstream stack: the forwarder wrapped in governance plus
@@ -972,7 +983,18 @@ program
   .option('-c, --config <path>', 'Path to helio.yaml', DEFAULT_CONFIG_PATH)
   .option('--no-hot-reload', 'Disable policy hot-reload — config edits will require a restart')
   .action((opts: { config: string; hotReload?: boolean }) =>
-    startCommand(opts.config, { config: opts.config, noHotReload: opts.hotReload === false }),
+    startCommand(opts.config, { config: opts.config, noHotReload: opts.hotReload === false }).catch(
+      (err: unknown) => {
+        // A StartupError message is the complete operator diagnosis: print
+        // it verbatim and exit — no stack, no rejection wrapper (#233).
+        // Anything else rethrows into the unhandledRejection crash path.
+        if (err instanceof StartupError) {
+          console.error(err.message)
+          process.exit(1)
+        }
+        throw err
+      },
+    ),
   )
 
 program

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -2,8 +2,8 @@ export { VERSION } from './version.js'
 
 export { loadConfig, ConfigError, isSingularConfig, isNamedConfig } from './config/index.js'
 export type { HelioConfig, SingularHelioConfig, NamedHelioConfig } from './config/index.js'
-export { createApp, startServer, startSidebandServer } from './server.js'
-export type { ServerHandle, CreateAppOptions } from './server.js'
+export { createApp, createMultiApp, startServer, startSidebandServer } from './server.js'
+export type { ServerHandle, CreateAppOptions, CreateMultiAppOptions } from './server.js'
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- deliberate compat re-export of the deprecated alias
 export { UpstreamForwarder } from './upstream/index.js'
 export type { UpstreamForwarderOptions } from './upstream/index.js'

--- a/packages/proxy/src/policy/annotation-prime-loop.test.ts
+++ b/packages/proxy/src/policy/annotation-prime-loop.test.ts
@@ -7,8 +7,14 @@ import type { CompiledToolRevalidation } from './types.js'
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** A prime result the fake forwarder can hand back, sync or deferred. */
-type PrimeResponse = AnnotationCachePrimeResult | Promise<AnnotationCachePrimeResult>
+/** A prime result the fake forwarder can hand back, sync or deferred. A
+ *  thunk entry is invoked at call time, so a rejected promise can be minted
+ *  the moment the loop consumes it rather than sitting unhandled from test
+ *  start. */
+type PrimeResponse =
+  | AnnotationCachePrimeResult
+  | Promise<AnnotationCachePrimeResult>
+  | (() => Promise<AnnotationCachePrimeResult>)
 
 interface FakeForwarder {
   primeAnnotationCache: () => Promise<AnnotationCachePrimeResult>
@@ -28,21 +34,30 @@ function fakeForwarder(script: PrimeResponse[], fallback: PrimeResponse): FakeFo
     primeAnnotationCache: () => {
       const next = script[calls] ?? fallback
       calls += 1
-      return Promise.resolve(next)
+      return typeof next === 'function' ? next() : Promise.resolve(next)
     },
   }
 }
 
-/** A promise plus its resolver, for keeping a prime attempt in flight. */
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+/** A promise plus its settlers, for keeping a prime attempt in flight. */
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+} {
   let settle: ((value: T) => void) | undefined
-  const promise = new Promise<T>((res) => {
+  let fail: ((reason: unknown) => void) | undefined
+  const promise = new Promise<T>((res, rej) => {
     settle = res
+    fail = rej
   })
   return {
     promise,
     resolve: (value: T) => {
       settle?.(value)
+    },
+    reject: (reason: unknown) => {
+      fail?.(reason)
     },
   }
 }
@@ -372,6 +387,115 @@ describe('startAnnotationPrimeLoop', () => {
     expect(messages().some((m) => m.includes('Tool revalidation failed'))).toBe(false)
     expect(vi.getTimerCount()).toBe(0)
     await vi.advanceTimersByTimeAsync(600_000)
+    expect(forwarder.calls).toBe(2)
+    controller.stop()
+  })
+
+  it('reconfigure() with an identical revalidation keeps the pending timer (issue #257)', async () => {
+    const forwarder = fakeForwarder([], ok(2))
+    const controller = await startAnnotationPrimeLoop(forwarder, revalidation(300_000))
+    expect(forwarder.calls).toBe(1)
+
+    // One tick shy of the interval, a reload delivers identical values in a
+    // fresh object (the compiler mints a new CompiledToolRevalidation every
+    // reload, so this is value equality, not reference equality).
+    await vi.advanceTimersByTimeAsync(299_999)
+    expect(forwarder.calls).toBe(1)
+    controller.reconfigure(revalidation(300_000))
+
+    // The clock must not restart: the tick fires on the original schedule.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(forwarder.calls).toBe(2)
+    controller.stop()
+  })
+
+  it('a revalidation attempt that rejects logs, keeps the cadence, and does not crash (issue #257)', async () => {
+    const forwarder = fakeForwarder(
+      [ok(2), () => Promise.reject(new Error('tools/list exploded'))],
+      ok(2),
+    )
+    const controller = await startAnnotationPrimeLoop(forwarder, revalidation(300_000))
+
+    await vi.advanceTimersByTimeAsync(300_000)
+    expect(forwarder.calls).toBe(2)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(messages()).toContain(
+      '[helio] Tool revalidation attempt failed unexpectedly: tools/list exploded — keeping the cadence',
+    )
+
+    // The cadence survives the rejection: the next tick still fires.
+    await vi.advanceTimersByTimeAsync(300_000)
+    expect(forwarder.calls).toBe(3)
+    controller.stop()
+  })
+
+  it('a retry attempt that rejects logs and keeps the backoff (issue #257)', async () => {
+    const forwarder = fakeForwarder(
+      [fail('still down'), () => Promise.reject(new Error('socket torn'))],
+      ok(2),
+    )
+    const controller = await startAnnotationPrimeLoop(forwarder, revalidation(300_000))
+    expect(forwarder.calls).toBe(1)
+
+    // Retry 1 rejects outright (not a clean failure result).
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(forwarder.calls).toBe(2)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(messages()).toContain(
+      '[helio] Tool revalidation attempt failed unexpectedly: socket torn — keeping the cadence',
+    )
+
+    // The backoff chain survives: retry 2 fires and succeeds.
+    expect(messages()).toContain('[helio] Annotation cache prime retry 2 scheduled in 2000ms')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(forwarder.calls).toBe(3)
+    expect(messages()).toContain(
+      '[helio] Annotation cache primed after retry 2: 2 tool definitions baselined for drift detection (baselines are per-process; a restart re-baselines — review tool_drift audit records before restarting)',
+    )
+    controller.stop()
+  })
+
+  it('an initial prime attempt that rejects resolves startup, logs tagged, and enters retry (issue #257)', async () => {
+    const forwarder = fakeForwarder([() => Promise.reject(new Error('handshake exploded'))], ok(2))
+    const controller = await startAnnotationPrimeLoop(forwarder, revalidation(300_000), 'payments')
+
+    expect(messages()).toContain(
+      '[helio][payments] Tool revalidation attempt failed unexpectedly: handshake exploded — keeping the cadence',
+    )
+    expect(messages()).toContain(
+      '[helio][payments] Annotation cache prime retry 1 scheduled in 1000ms',
+    )
+
+    // Boot continued fail-closed; the armed retry succeeds.
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(forwarder.calls).toBe(2)
+    expect(messages()).toContain(
+      '[helio][payments] Annotation cache primed after retry 1: 2 tool definitions baselined for drift detection (baselines are per-process; a restart re-baselines — review tool_drift audit records before restarting)',
+    )
+    controller.stop()
+  })
+
+  it('an initial prime rejection landing after the startup window logs and keeps the retry chain (issue #257)', async () => {
+    const slowInitial = deferred<AnnotationCachePrimeResult>()
+    const forwarder = fakeForwarder([slowInitial.promise], ok(2))
+
+    const startPromise = startAnnotationPrimeLoop(forwarder, revalidation(300_000))
+    await vi.advanceTimersByTimeAsync(INITIAL_WAIT_MS)
+    const controller = await startPromise
+    expect(messages()).toContain(
+      '[helio] Annotation cache priming did not complete within 1500ms; continuing startup fail-closed and retrying in background',
+    )
+
+    // The detached attempt rejects after the race window: the rejection must
+    // be reported, not swallowed, and must not double-arm the retry.
+    slowInitial.reject(new Error('late explosion'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(messages()).toContain(
+      '[helio] Tool revalidation attempt failed unexpectedly: late explosion — keeping the cadence',
+    )
+
+    // The retry armed at the timeout fires once and succeeds.
+    await vi.advanceTimersByTimeAsync(1_000)
     expect(forwarder.calls).toBe(2)
     controller.stop()
   })

--- a/packages/proxy/src/policy/annotation-prime-loop.ts
+++ b/packages/proxy/src/policy/annotation-prime-loop.ts
@@ -16,9 +16,30 @@ export interface AnnotationPrimeController {
   stop(): void
   /**
    * Apply a hot-reloaded `policies.tool_revalidation` section. Enabling,
-   * disabling, or retiming takes effect on the next tick — no restart.
+   * disabling, or retiming takes effect on the next tick — no restart. An
+   * unchanged section is a no-op: the pending timer keeps its clock, so a
+   * reload that does not touch revalidation cannot push the next check out.
    */
   reconfigure(revalidation: CompiledToolRevalidation | undefined): void
+}
+
+/** Value equality for reload-delivered revalidation sections: the compiler
+ *  mints a fresh object every reload, so reference equality never holds. */
+function sameRevalidation(
+  a: CompiledToolRevalidation | undefined,
+  b: CompiledToolRevalidation | undefined,
+): boolean {
+  if (a === undefined || b === undefined) return a === b
+  return (
+    a.enabled === b.enabled &&
+    a.intervalMs === b.intervalMs &&
+    a.maxAdvertisedTtlMs === b.maxAdvertisedTtlMs
+  )
+}
+
+/** Render a rejection reason for the unexpected-failure defense lines. */
+function describeRejection(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
 }
 
 function computePrimeRetryDelayMs(attempt: number): number {
@@ -80,15 +101,27 @@ export async function startAnnotationPrimeLoop(
     const epoch = revalidateEpoch
     revalidateTimer = setTimeout(() => {
       revalidateTimer = undefined
-      void forwarder.primeAnnotationCache().then((result) => {
-        if (epoch !== revalidateEpoch) return // reconfigured or stopped mid-flight
-        if (!result.success) {
+      void forwarder
+        .primeAnnotationCache()
+        .then((result) => {
+          if (epoch !== revalidateEpoch) return // reconfigured or stopped mid-flight
+          if (!result.success) {
+            console.error(
+              `${tag} Tool revalidation failed: ${result.reason ?? 'unknown reason'} — keeping the last baselines; next attempt in ${String(rv.intervalMs)}ms`,
+            )
+          }
+          scheduleRevalidation()
+        })
+        .catch((reason: unknown) => {
+          // primeAnnotationCache's contract is to swallow throws into failure
+          // results; a rejection is a contract breach the loop survives —
+          // uncaught it would reach unhandledRejection and exit the process.
+          if (epoch !== revalidateEpoch) return
           console.error(
-            `${tag} Tool revalidation failed: ${result.reason ?? 'unknown reason'} — keeping the last baselines; next attempt in ${String(rv.intervalMs)}ms`,
+            `${tag} Tool revalidation attempt failed unexpectedly: ${describeRejection(reason)} — keeping the cadence`,
           )
-        }
-        scheduleRevalidation()
-      })
+          scheduleRevalidation()
+        })
     }, rv.intervalMs)
     revalidateTimer.unref()
   }
@@ -101,6 +134,10 @@ export async function startAnnotationPrimeLoop(
   }
 
   const reconfigure = (next: CompiledToolRevalidation | undefined) => {
+    // Every successful reload lands here whether or not the section changed;
+    // restarting the clock on an unchanged section would push the next check
+    // a full interval out on every save (issue #257).
+    if (sameRevalidation(current, next)) return
     current = next
     revalidateEpoch += 1 // any in-flight completion returns without rescheduling
     clearRevalidateTimer()
@@ -152,8 +189,21 @@ export async function startAnnotationPrimeLoop(
   }
 
   const runPrimeAttempt = async (phase: 'initial' | 'retry') => {
-    const result = await forwarder.primeAnnotationCache()
-    handlePrimeResult(phase, result)
+    try {
+      const result = await forwarder.primeAnnotationCache()
+      handlePrimeResult(phase, result)
+    } catch (reason) {
+      // Same contract-breach defense as the revalidation chain. The initial
+      // attempt runs detached once the startup race times out, and the retry
+      // chain is void-dropped — a rejection on either must be survived, not
+      // crash the process. Late rejections after stop/prime stay silent,
+      // mirroring handlePrimeResult's orphan discipline.
+      if (stopped || primed) return
+      console.error(
+        `${tag} Tool revalidation attempt failed unexpectedly: ${describeRejection(reason)} — keeping the cadence`,
+      )
+      scheduleRetry()
+    }
   }
 
   const initialAttempt = runPrimeAttempt('initial')

--- a/packages/proxy/src/policy/governed-forwarder.ts
+++ b/packages/proxy/src/policy/governed-forwarder.ts
@@ -96,8 +96,8 @@ export interface GovernedForwarderOptions {
   /**
    * The operator-chosen upstream entry name (issue #295, multi-upstream
    * substrate). Unset in singular mode — every governance surface then
-   * behaves exactly as today. Nothing in the proxy passes it yet; the
-   * multi-upstream composition loop (issue #294) is what will.
+   * behaves exactly as today. The multi-upstream composition loop (issue
+   * #294) passes each entry's name.
    */
   upstreamName?: string
 }

--- a/packages/proxy/src/reload-fanout.test.ts
+++ b/packages/proxy/src/reload-fanout.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { applyReloadedPolicy } from './reload-fanout.js'
+import { compilePolicies } from './policy/index.js'
+import type { CompiledPolicy, CompiledToolRevalidation } from './policy/types.js'
+
+function stubStack(name: string, log: string[]) {
+  return {
+    governedForwarder: {
+      updatePolicy: (policy: CompiledPolicy) => {
+        log.push(`${name}:updatePolicy:${policy.defaultAction}`)
+      },
+    },
+    annotationPrime: {
+      reconfigure: (revalidation: CompiledToolRevalidation | undefined) => {
+        log.push(`${name}:reconfigure:${String(revalidation?.enabled ?? 'none')}`)
+      },
+    },
+  }
+}
+
+describe('applyReloadedPolicy', () => {
+  it('applies update and reconfigure to every stack, paired, in order (issue #294)', () => {
+    const log: string[] = []
+    const stacks = [stubStack('files', log), stubStack('github', log)]
+    const { policy } = compilePolicies({
+      default: 'deny',
+      dry_run: false,
+      rules: [],
+      tool_revalidation: { enabled: false, interval: '5m' },
+    })
+
+    applyReloadedPolicy(stacks, policy)
+
+    // Paired per stack (update then reconfigure), stacks in config order —
+    // matching the singular sequence, so a future partial failure surfaces
+    // adjacent to its door.
+    expect(log).toEqual([
+      'files:updatePolicy:deny',
+      'files:reconfigure:false',
+      'github:updatePolicy:deny',
+      'github:reconfigure:false',
+    ])
+  })
+
+  it('passes the reloaded revalidation section through to reconfigure', () => {
+    const log: string[] = []
+    const stacks = [stubStack('files', log)]
+    const { policy } = compilePolicies({
+      default: 'allow',
+      dry_run: false,
+      rules: [],
+      tool_revalidation: { enabled: true, interval: '5m' },
+    })
+
+    applyReloadedPolicy(stacks, policy)
+
+    expect(log).toEqual(['files:updatePolicy:allow', 'files:reconfigure:true'])
+  })
+})

--- a/packages/proxy/src/reload-fanout.ts
+++ b/packages/proxy/src/reload-fanout.ts
@@ -1,0 +1,32 @@
+import type { CompiledPolicy } from './policy/index.js'
+import type { CompiledToolRevalidation } from './policy/types.js'
+
+// ---------------------------------------------------------------------------
+// Hot-reload policy fan-out across governed upstream stacks. Kept out of
+// cli.ts so it stays unit-testable (cli.ts parses argv at import time).
+// Structural types keep the module import-light, like shutdown.ts.
+// ---------------------------------------------------------------------------
+
+/** One governed upstream stack the reload fan-out applies a new policy to. */
+export interface ReloadableStack {
+  readonly governedForwarder: { updatePolicy(policy: CompiledPolicy): void }
+  readonly annotationPrime: {
+    reconfigure(revalidation: CompiledToolRevalidation | undefined): void
+  }
+}
+
+/**
+ * Apply a reloaded policy across every governed stack, in config order.
+ * Update and reconfigure are PAIRED per stack (matching the singular
+ * sequence) rather than swept per operation, so a future partial failure
+ * surfaces adjacent to its door.
+ */
+export function applyReloadedPolicy(
+  stacks: ReadonlyArray<ReloadableStack>,
+  newPolicy: CompiledPolicy,
+): void {
+  for (const stack of stacks) {
+    stack.governedForwarder.updatePolicy(newPolicy)
+    stack.annotationPrime.reconfigure(newPolicy.toolRevalidation)
+  }
+}

--- a/packages/proxy/src/server.test.ts
+++ b/packages/proxy/src/server.test.ts
@@ -119,7 +119,7 @@ describe('createApp', () => {
 
     expect(() => createApp(named, forwarder)).toThrow(
       'createApp serves a single-upstream (upstream:) config only. Named multi-upstream ' +
-        'configs are composed by createMultiApp, which lands with issue #294.',
+        'configs are composed by createMultiApp.',
     )
   })
 

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -6,7 +6,8 @@ import { createStreamableHttpRoute } from './transport/streamable-http.js'
 import { createSseRoute } from './transport/sse.js'
 import { compileSessionIdentity } from './mcp/session-resolver.js'
 import { isNamedConfig } from './config/index.js'
-import type { HelioConfig } from './config/index.js'
+import type { HelioConfig, NamedHelioConfig } from './config/index.js'
+import { INVALID_REQUEST, makeJsonRpcErrorWithoutId } from './mcp/types.js'
 import type { HeaderMismatchRejection, McpForwarder } from './mcp/types.js'
 
 /** Handle returned by `startServer` for lifecycle management. */
@@ -152,7 +153,7 @@ export function createApp(
     // named config would drop every other declared upstream.
     throw new Error(
       'createApp serves a single-upstream (upstream:) config only. Named multi-upstream ' +
-        'configs are composed by createMultiApp, which lands with issue #294.',
+        'configs are composed by createMultiApp.',
     )
   }
   const app = new Hono()
@@ -183,6 +184,132 @@ export function createApp(
   if (options?.slackActionApp) {
     app.route('/slack/actions', options.slackActionApp)
   }
+
+  return app
+}
+
+/**
+ * Optional sub-apps and callbacks for the multi-upstream composition.
+ * The main-port posture is `createApp`'s (see CreateAppOptions): only the
+ * Slack webhook callback belongs beside the MCP doors.
+ */
+export interface CreateMultiAppOptions {
+  /** Slack interactive action handler (mounted at /slack/actions, global). */
+  slackActionApp?: Hono
+  /**
+   * Recorder for inbound header/body agreement rejections (issue #226),
+   * called with the name of the door that rejected so the audit record can
+   * attribute it. Enforcement does not depend on it.
+   */
+  onHeaderMismatch?: (rejection: HeaderMismatchRejection, upstreamName: string) => void
+}
+
+/**
+ * Create a Hono app serving every named upstream at its own pair of mounts,
+ * `/mcp/<name>` and `/sse/<name>`, each a fresh route stack wrapping that
+ * entry's forwarder. `/healthz` and `/slack/actions` stay global. There is
+ * NO bare-path default: bare `/mcp`, `/sse`, and unknown names get an
+ * explicit 404 catch-all whose JSON-RPC envelope states the path shape and
+ * never enumerates configured names.
+ *
+ * @param config - The validated named-mode Helio configuration.
+ * @param forwarders - One forwarder per configured entry, keyed by name.
+ *   Must cover the configured names exactly; missing or extra keys throw
+ *   (a missing key would silently mount a dead door, an extra one means the
+ *   record drifted from the config — fail at composition, not per request).
+ * @param options - Optional sub-apps and callbacks.
+ */
+export function createMultiApp(
+  config: HelioConfig,
+  forwarders: Record<string, McpForwarder>,
+  options?: CreateMultiAppOptions,
+): Hono {
+  if (!isNamedConfig(config)) {
+    throw new Error(
+      'createMultiApp composes a named multi-upstream (upstreams:) config only. ' +
+        'Singular configs are served by createApp.',
+    )
+  }
+
+  const doors: Array<{
+    entry: NamedHelioConfig['upstreams'][number]
+    forwarder: McpForwarder
+  }> = []
+  const missing: string[] = []
+  for (const entry of config.upstreams) {
+    const forwarder = forwarders[entry.name]
+    if (forwarder === undefined) missing.push(entry.name)
+    else doors.push({ entry, forwarder })
+  }
+  const configured = new Set(config.upstreams.map((entry) => entry.name))
+  const unexpected = Object.keys(forwarders).filter((name) => !configured.has(name))
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new Error(
+      'createMultiApp forwarders must match the configured upstream names exactly — ' +
+        `missing: [${missing.join(', ')}], unexpected: [${unexpected.join(', ')}].`,
+    )
+  }
+
+  const app = new Hono()
+  const allowedOrigins = config.listen.allowed_origins
+  // Compiled ONCE and shared by every door — the session section is global
+  // (one listener, one identity posture) and restart-required at the reload
+  // boundary (issue #218).
+  const session = compileSessionIdentity(config.session)
+
+  app.get('/healthz', (c) => c.json({ status: 'ok' }))
+
+  for (const { entry, forwarder } of doors) {
+    const name = entry.name
+    app.route(
+      `/mcp/${name}`,
+      createStreamableHttpRoute(forwarder, {
+        forwardHeadersAllowlist: entry.forward_headers,
+        allowedOrigins,
+        session,
+        onHeaderMismatch: options?.onHeaderMismatch
+          ? (rejection) => options.onHeaderMismatch?.(rejection, name)
+          : undefined,
+      }),
+    )
+    app.route(
+      `/sse/${name}`,
+      createSseRoute(forwarder, {
+        forwardHeadersAllowlist: entry.forward_headers,
+        allowedOrigins,
+        session,
+        routeLabel: `/sse/${name}`,
+      }),
+    )
+  }
+
+  if (options?.slackActionApp) {
+    app.route('/slack/actions', options.slackActionApp)
+  }
+
+  // Registered AFTER every mount — a catch-all registered first would shadow
+  // every door. The `*` pattern also matches the bare prefix, so bare /mcp
+  // and /sse need no separate registration. The bodies use the id-omitting
+  // helper only (no body parsing — this must not become another id-echo
+  // site) and never enumerate configured names.
+  app.all('/mcp/*', (c) =>
+    c.json(
+      makeJsonRpcErrorWithoutId(
+        INVALID_REQUEST,
+        'No MCP endpoint answers this request: this Helio serves named upstreams at /mcp/<name>.',
+      ),
+      404,
+    ),
+  )
+  app.all('/sse/*', (c) =>
+    c.json(
+      makeJsonRpcErrorWithoutId(
+        INVALID_REQUEST,
+        'No MCP endpoint answers this request: this Helio serves named upstreams at /sse/<name>.',
+      ),
+      404,
+    ),
+  )
 
   return app
 }

--- a/packages/proxy/src/shutdown.test.ts
+++ b/packages/proxy/src/shutdown.test.ts
@@ -25,11 +25,13 @@ describe('closeResources', () => {
 
     await closeResources({
       handle: asyncClose('handle'),
-      annotationPrime: { stop: () => order.push('annotationPrime') },
-      closeForwarder: async () => {
-        await Promise.resolve()
-        order.push('forwarder')
-      },
+      annotationPrimes: [{ stop: () => order.push('annotationPrime') }],
+      closeForwarders: [
+        async () => {
+          await Promise.resolve()
+          order.push('forwarder')
+        },
+      ],
       auditWriter: sync('auditWriter'),
       configWatcher: sync('configWatcher'),
       sidebandHandle: asyncClose('sidebandHandle'),
@@ -76,5 +78,35 @@ describe('closeResources', () => {
     const { order, asyncClose } = orderedHarness()
     await expect(closeResources({ handle: asyncClose('handle') })).resolves.toBeUndefined()
     expect(order).toEqual(['handle'])
+  })
+
+  it('stops every prime loop first and closes every forwarder last, in stack order (issue #294)', async () => {
+    const { order, sync, asyncClose } = orderedHarness()
+    await closeResources({
+      handle: asyncClose('handle'),
+      annotationPrimes: [
+        { stop: () => order.push('prime-a') },
+        { stop: () => order.push('prime-b') },
+      ],
+      closeForwarders: [
+        async () => {
+          await Promise.resolve()
+          order.push('forwarder-a')
+        },
+        async () => {
+          await Promise.resolve()
+          order.push('forwarder-b')
+        },
+      ],
+      auditWriter: sync('auditWriter'),
+    })
+    expect(order).toEqual([
+      'prime-a',
+      'prime-b',
+      'handle',
+      'auditWriter',
+      'forwarder-a',
+      'forwarder-b',
+    ])
   })
 })

--- a/packages/proxy/src/shutdown.ts
+++ b/packages/proxy/src/shutdown.ts
@@ -10,8 +10,8 @@
 export interface CloseableResources {
   /** The MCP server — the primary traffic door. Drained with `await`. */
   handle: { close(): Promise<void> }
-  annotationPrime?: { stop(): void }
-  closeForwarder?: () => Promise<void>
+  annotationPrimes?: ReadonlyArray<{ stop(): void }>
+  closeForwarders?: ReadonlyArray<() => Promise<void>>
   auditWriter?: { close(): void }
   configWatcher?: { close(): void }
   sidebandHandle?: { close(): Promise<void> }
@@ -30,7 +30,7 @@ export interface CloseableResources {
 /** Close everything the proxy holds, in traffic-safe order. */
 export async function closeResources(resources: CloseableResources): Promise<void> {
   // Background loops first: nothing may schedule new work mid-shutdown.
-  resources.annotationPrime?.stop()
+  for (const prime of resources.annotationPrimes ?? []) prime.stop()
   resources.configWatcher?.close()
 
   // Resolve pending approvals BEFORE draining the doors: requests parked on
@@ -59,5 +59,7 @@ export async function closeResources(resources: CloseableResources): Promise<voi
   // Storage last: drained requests above may still have flushed audit rows.
   resources.evidenceStore?.close()
   resources.auditWriter?.close()
-  if (resources.closeForwarder) await resources.closeForwarder()
+  // Forwarders close LAST, sequentially in stack order — deterministic, and
+  // bounded by the CLI's force-exit timer.
+  for (const close of resources.closeForwarders ?? []) await close()
 }

--- a/packages/proxy/src/startup-error.ts
+++ b/packages/proxy/src/startup-error.ts
@@ -1,0 +1,17 @@
+/**
+ * Marker for startup failures that are already diagnosed for the operator.
+ *
+ * The CLI start action prints the message VERBATIM and exits 1 — no stack,
+ * no `Error:` prefix, no unhandled-rejection wrapper — so a boot refused for
+ * a stated reason reads as a diagnosis, not a crash dump. Anything else
+ * thrown during startup keeps the crash path (stack plus crash drain).
+ *
+ * Deliberately not exported from the package root: the clean-exit contract
+ * is the CLI's, not library surface.
+ */
+export class StartupError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'StartupError'
+  }
+}

--- a/packages/proxy/src/transport/stdio-wrapper.test.ts
+++ b/packages/proxy/src/transport/stdio-wrapper.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { StdioForwarder } from './stdio-wrapper.js'
 import type { McpRequest } from '../mcp/types.js'
 
@@ -184,6 +184,50 @@ describe('StdioForwarder', () => {
     await new Promise((resolve) => setTimeout(resolve, 100))
 
     await expect(forwarder.forward(makeRequest(1, 'ping'))).rejects.toThrow('dead')
+  }, 5000)
+
+  it('tags the max-retries death line with the upstream name when one is set (issue #294)', async () => {
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logged.push(String(args[0]))
+    })
+    try {
+      forwarder = new StdioForwarder({
+        command: 'node',
+        args: ['-e', CRASH_SCRIPT],
+        maxRetries: 0,
+        retryDelayMs: 10,
+        upstreamName: 'files',
+      })
+      await forwarder.start()
+
+      // Wait for the crash to mark the forwarder dead and log the death line.
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      expect(logged).toContain('[helio][files] Stdio forwarder: max retries (0) exceeded')
+    } finally {
+      spy.mockRestore()
+    }
+  }, 5000)
+
+  it('keeps the max-retries death line bare when no upstream name is set', async () => {
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logged.push(String(args[0]))
+    })
+    try {
+      forwarder = new StdioForwarder({
+        command: 'node',
+        args: ['-e', CRASH_SCRIPT],
+        maxRetries: 0,
+        retryDelayMs: 10,
+      })
+      await forwarder.start()
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      expect(logged).toContain('[helio] Stdio forwarder: max retries (0) exceeded')
+    } finally {
+      spy.mockRestore()
+    }
   }, 5000)
 
   it('auto-restarts on crash up to maxRetries', async () => {

--- a/packages/proxy/src/transport/stdio-wrapper.ts
+++ b/packages/proxy/src/transport/stdio-wrapper.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
 import { PendingRequests } from '../mcp/pending-requests.js'
+import { helioLogTag } from '../util/log-label.js'
 import type {
   McpForwarder,
   McpRequest,
@@ -26,6 +27,11 @@ export interface StdioForwarderOptions {
   retryDelayMs?: number
   /** Timeout in milliseconds for individual requests. */
   requestTimeoutMs?: number
+  /**
+   * The operator-chosen upstream entry name (multi-upstream mode). Unset in
+   * singular mode — the death line then keeps its bare `[helio]` tag.
+   */
+  upstreamName?: string
 }
 
 /**
@@ -40,6 +46,7 @@ export class StdioForwarder implements McpForwarder {
   private readonly maxRetries: number
   private readonly retryDelayMs: number
   private readonly pending: PendingRequests
+  private readonly logTag: string
 
   private child: ChildProcess | null = null
   private buffer = ''
@@ -53,6 +60,7 @@ export class StdioForwarder implements McpForwarder {
     this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
     this.retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
     this.pending = new PendingRequests(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS)
+    this.logTag = helioLogTag(options.upstreamName)
   }
 
   /** Spawn the child process and set up event handlers. */
@@ -211,7 +219,9 @@ export class StdioForwarder implements McpForwarder {
     } else {
       this.dead = true
       // eslint-disable-next-line no-console -- operational error logging
-      console.error(`[helio] Stdio forwarder: max retries (${String(this.maxRetries)}) exceeded`)
+      console.error(
+        `${this.logTag} Stdio forwarder: max retries (${String(this.maxRetries)}) exceeded`,
+      )
       this.pending.rejectAll(new Error('stdio forwarder is dead (max retries exceeded)'))
     }
   }


### PR DESCRIPTION
## Description

Multi-upstream composition and routing: the light-up. `helio start` now serves named `upstreams:` configs, giving every entry its own `/mcp/<name>` and `/sse/<name>` mounts wrapping that entry's governed forwarder with a fresh route stack (own annotation cache, era cache, prime loop, header/body agreement door, per-door `/sse` session cap). `/healthz` and `/slack/actions` stay global. There is no bare-path default: bare `/mcp`, `/sse`, and unknown names get an explicit HTTP 404 with an id-less JSON-RPC `-32600` envelope that states the path shape and never enumerates configured names. Startup is all-or-nothing in config order (a connect failure aborts boot naming the entry after best-effort closing whatever already connected), hot reload fans out across every stack, shutdown stops every prime loop first and closes every forwarder last, and `createMultiApp(config, forwarders)` joins `createApp` on the package root with an exact-match forwarder record. The Limits page renders upstream-prefixed tool keys as the tool with a door qualifier.

The acceptance bar, all proven at the CLI layer against the built `dist/cli.js`: a two-upstream config serves end to end (each door answers with its own child's entry-named tool, asserted by name over real HTTP, and a deny rule answers through the door with the policy envelope), singular mode is byte-identical (untouched integration suites, the #293 schema pins, unchanged startup log and tags), the catch-all bodies match the pinned texts, and the mandatory extract-then-loop split shows in the commit history (`7d525bc` then `6c87715`).

Two ride-alongs land in full. #257: `reconfigure()` no-ops when a reload delivers an unchanged `tool_revalidation` section, so saves stop pushing the next check a full interval out, and all three prime chains (revalidation, retry, initial) survive an outright rejection with a logged line and their cadence intact instead of crashing the process or dying silently. #233: a `StartupError` marker gives diagnosed boot failures (audit schema mismatch, upstream connect failure) a clean one-line exit with no stack and no unhandled-rejection wrapper; genuine crashes keep the full crash path. Singular connect failures print the underlying message alone; no name is ever minted for them.

Boundaries: the two-real-server isolation and sharing net (era split, bucket isolation, budget pooling, cross-upstream `requires`) is #296. The Limits/Analytics/Budgets grouping UX is #297; only the minimal key-parsing tolerance rides here. The docs overhaul is #298, which also picks up two stale lines found in review: `docs/audit.md` ("until the multi-upstream config surface lands") and the `docs/configuration.md` v0.1 callout. Degraded start is out of scope, and #313 (stdio `url` requiredness) does not ride.

Notes from the work: externally reviewed over three rounds (READY; three minor findings folded, all documentation truthfulness: stale dark-until-composition copy on a published JSDoc and two changelog entries, a cap-refusal log line mislabeled as tag-carrying, and a changelog wrap plus pointer direction). A raw-vs-governed forwarder wiring slip during implementation was caught by the existing singular approval e2e and is now pinned by a deny-probe assertion through a named door. A workspace flake during verification was triaged against a clean-main worktree and commented on #271 (eleventh occurrence, with a new note on equalizing the comparison's load profile).

Closes #294
Closes #257
Closes #233

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [x] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `pnpm build && pnpm test` (the proxy suite includes the named-mode e2e set in `cli.test.ts`: two-door serve with entry-named tools, the deny probe, catch-all envelopes over real HTTP, all-or-nothing boot naming the failing entry, the 17-upstream warning ordering, and clean SIGTERM shutdown).
2. Write a two-entry named config and `helio start -c` it: one `Upstream[<name>]:` line per entry, `[helio][<name>]`-tagged prime lines, and each door serving at `/mcp/<name>`.
3. POST bare `/mcp` or an unknown `/mcp/<ghost>`: HTTP 404 with the id-less `-32600` envelope naming the path shape only.
4. Run a singular config: startup log, tags, and behavior are unchanged; a connect failure now exits with the underlying message alone instead of an unhandled-rejection dump.

## Additional Context

Boot waits each entry's annotation-prime window sequentially, so a slow upstream can add up to 1.5 seconds per entry; parallelizing is deliberately deferred alongside degraded start. Module-scope once-warnings fire once per process rather than once per door, as ruled in planning. The best-effort close of already-connected forwarders on a partial boot failure is stated behavior pinned only where cheaply observable; the real multi-server harness belongs to #296.
