### PR TITLE
test(proxy): add the two-upstream end-to-end isolation and sharing suite

### DIFF
--- a/packages/proxy/src/__tests__/helpers/test-utils.ts
+++ b/packages/proxy/src/__tests__/helpers/test-utils.ts
@@ -97,6 +97,63 @@ export function makeConfig(
 }
 
 /**
+ * Build a valid named-mode (upstreams:) HelioConfig for the given entry
+ * names. Pass per-entry URLs and section overrides to customize, the same
+ * way makeConfig does for singular configs; without a `urls` entry a name
+ * gets a placeholder URL (fine for routing tests that never dial out).
+ */
+export function makeNamedConfig(
+  names: string[],
+  overrides: {
+    /** Real per-entry URL by name — two-upstream suites point these at live fixtures. */
+    urls?: Record<string, string>
+    listen?: Partial<HelioConfig['listen']>
+    environment?: string
+    session?: Partial<HelioConfig['session']>
+    policies?: Partial<HelioConfig['policies']>
+    budgets?: HelioConfig['budgets']
+  } = {},
+): HelioConfig {
+  return {
+    version: '1',
+    upstreams: names.map((name) => ({
+      name,
+      url: overrides.urls?.[name] ?? `http://localhost:8081/${name}`,
+      transport: 'streamable-http',
+      protocol_version: 'auto',
+      connect_timeout: '10s',
+      request_timeout: '30s',
+      forward_headers: [],
+      headers: {},
+    })),
+    listen: { port: 3000, host: '127.0.0.1', allowed_origins: [], ...overrides.listen },
+    dashboard: {
+      enabled: false,
+      port: 3100,
+      host: '127.0.0.1',
+      allow_open_mode: false,
+      sse_heartbeat_interval: '30s',
+    },
+    environment: overrides.environment,
+    session: {
+      identity: [{ source: 'header', name: 'x-helio-session-id' }, { source: 'legacy_header' }],
+      on_unresolved: 'deny',
+      ...overrides.session,
+    },
+    policies: { default: 'allow', dry_run: false, rules: [], ...overrides.policies },
+    approval: { timeout: '300s', default_on_timeout: 'deny', channels: [] },
+    audit: {
+      storage: 'sqlite',
+      path: './helio-audit.db',
+      retention: '90d',
+      include_responses: true,
+    },
+    sdk: { enabled: false, port: 3200, host: '127.0.0.1', evaluation_ttl: '10m' },
+    budgets: overrides.budgets ?? [],
+  } as HelioConfig
+}
+
+/**
  * Send a JSON-RPC request to a proxy/server URL.
  * Returns the HTTP status and parsed JSON body.
  */

--- a/packages/proxy/src/__tests__/integration-multi.test.ts
+++ b/packages/proxy/src/__tests__/integration-multi.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { Hono } from 'hono'
 import { createMultiApp } from '../server.js'
-import { makeConfig } from './helpers/test-utils.js'
-import type { HelioConfig } from '../config/index.js'
+import { makeConfig, makeNamedConfig } from './helpers/test-utils.js'
 import type { McpForwarder, McpRequest } from '../mcp/types.js'
 
 // ---------------------------------------------------------------------------
@@ -34,45 +33,6 @@ function stubForwarder(toolName: string): McpForwarder & { calls: McpRequest[] }
       })
     },
   }
-}
-
-/** Build a validated-shape named config for the given entry names. */
-function makeNamedConfig(names: string[]): HelioConfig {
-  return {
-    version: '1',
-    upstreams: names.map((name) => ({
-      name,
-      url: `http://localhost:8081/${name}`,
-      transport: 'streamable-http',
-      protocol_version: 'auto',
-      connect_timeout: '10s',
-      request_timeout: '30s',
-      forward_headers: [],
-      headers: {},
-    })),
-    listen: { port: 3000, host: '127.0.0.1', allowed_origins: [] },
-    dashboard: {
-      enabled: false,
-      port: 3100,
-      host: '127.0.0.1',
-      allow_open_mode: false,
-      sse_heartbeat_interval: '30s',
-    },
-    session: {
-      identity: [{ source: 'header', name: 'x-helio-session-id' }, { source: 'legacy_header' }],
-      on_unresolved: 'deny',
-    },
-    policies: { default: 'allow', dry_run: false, rules: [] },
-    approval: { timeout: '300s', default_on_timeout: 'deny', channels: [] },
-    audit: {
-      storage: 'sqlite',
-      path: './helio-audit.db',
-      retention: '90d',
-      include_responses: true,
-    },
-    sdk: { enabled: false, port: 3200, host: '127.0.0.1', evaluation_ttl: '10m' },
-    budgets: [],
-  } as HelioConfig
 }
 
 const MCP_CATCH_ALL_MESSAGE =

--- a/packages/proxy/src/__tests__/integration-two-upstream.test.ts
+++ b/packages/proxy/src/__tests__/integration-two-upstream.test.ts
@@ -95,6 +95,8 @@ async function composeTwoDoors(options: {
   environment?: string
   /** Await a direct annotation-cache prime per door (no prime-loop windows). */
   prime?: boolean
+  /** Per-door /sse concurrent-session cap (the issue #296 I4 seam). */
+  sse?: { maxConcurrentSessions?: number }
 }): Promise<TwoDoorComposition> {
   const config = makeNamedConfig(['alpha', 'beta'], {
     urls: {
@@ -175,6 +177,7 @@ async function composeTwoDoors(options: {
         buildHeaderMismatchAuditRecord(rejection, config.environment, upstreamName),
       )
     },
+    sse: options.sse,
   })
   const proxy = startOnDynamicPort(app)
   const base = `http://127.0.0.1:${String(proxy.port)}`
@@ -661,6 +664,84 @@ describe('isolation: tool limit buckets count per door (I3)', () => {
       { helioSessionId: 'i3-s1' },
     )
     expect(betaCall.body['error']).toBeUndefined()
+  })
+})
+
+describe('isolation: per-door /sse session caps (I4)', () => {
+  let comp: TwoDoorComposition
+  let errorSpy: MockInstance
+  const streams: AbortController[] = []
+
+  beforeAll(async () => {
+    errorSpy = vi.spyOn(console, 'error')
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [{ name: 'denied-probe', match: { tool: 'denied_probe' }, action: 'deny' }],
+      } as PoliciesConfig,
+      sse: { maxConcurrentSessions: 1 },
+    })
+  })
+
+  afterAll(async () => {
+    errorSpy.mockRestore()
+    // Abort held streams FIRST or the proxy close hangs on live connections.
+    for (const ac of streams) ac.abort()
+    await comp.close()
+  })
+
+  /**
+   * Open an /sse stream and HOLD it: cap occupancy is live map size (a
+   * disconnect deletes the entry), so the occupant must stay connected.
+   * Reads exactly the first chunk (the endpoint event) to guarantee the
+   * session registered server-side before the caller proceeds.
+   */
+  async function openHeldSseStream(url: string): Promise<Response> {
+    const ac = new AbortController()
+    streams.push(ac)
+    const res = await fetch(url, { signal: ac.signal })
+    if (res.status === 200 && res.body) {
+      const reader = res.body.getReader()
+      await reader.read()
+      reader.releaseLock()
+    }
+    return res
+  }
+
+  it('door A at cap refuses its second stream; door B still admits', async () => {
+    const first = await openHeldSseStream(comp.sseUrl('alpha'))
+    expect(first.status).toBe(200)
+    expect(first.headers.get('content-type')).toBe('text/event-stream')
+
+    const second = await openHeldSseStream(comp.sseUrl('alpha'))
+    expect(second.status).toBe(503)
+    expect(await second.json()).toEqual({ error: 'session capacity reached' })
+
+    // The refusal line names the door that refused.
+    const lines = errorSpy.mock.calls.map((args: unknown[]) => args.join(' '))
+    expect(lines).toContain(
+      '[helio] /sse/alpha at session cap (1); refusing new streams (1 refusals so far).',
+    )
+
+    // Door B's map is its own: its first stream admits while door A is full.
+    const betaStream = await openHeldSseStream(comp.sseUrl('beta'))
+    expect(betaStream.status).toBe(200)
+    expect(betaStream.headers.get('content-type')).toBe('text/event-stream')
+  })
+
+  it('the composition is governed: the deny probe blocks through the mcp mount', async () => {
+    const res = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'denied_probe', arguments: {} },
+      'i4-deny',
+      { helioSessionId: 'i4-s1' },
+    )
+    const error = res.body['error'] as { code: number; data: Record<string, unknown> }
+    expect(error.code).toBe(-32001)
+    expect(error.data['rule']).toBe('denied-probe')
   })
 })
 

--- a/packages/proxy/src/__tests__/integration-two-upstream.test.ts
+++ b/packages/proxy/src/__tests__/integration-two-upstream.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Two-upstream end-to-end isolation and sharing suite (issue #296).
+ *
+ * Two REAL MCP servers — one legacy stateful (sessions + SSE framing), one
+ * modern 2026-07-28-only — composed behind one `createMultiApp` on a real
+ * socket, governed per door exactly the way `cli.ts` governs: production
+ * `createForwarderFromConfig` per entry, one `GovernedForwarder` per door,
+ * and ONE shared governance object (audit, evidence, approval, limiters,
+ * budgets, session) mirroring the cli's field set. The suite proves the
+ * multi-upstream contract's isolation claims (what must never cross doors),
+ * its deliberate-sharing claims (what must pool), and its identity claims.
+ *
+ * Every composition's policy carries a deny rule and at least one assertion
+ * that only passes THROUGH governance — a raw transport forwarder mounted by
+ * mistake fails those loudly instead of silently bypassing policy.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { createMultiApp } from '../server.js'
+import { createForwarderFromConfig } from '../cli-forwarder.js'
+import { GovernedForwarder } from '../policy/governed-forwarder.js'
+import type { GovernedForwarderOptions } from '../policy/governed-forwarder.js'
+import { compilePolicies, RateLimiter, SpendLimiter } from '../policy/index.js'
+import { compileSessionIdentity } from '../mcp/session-resolver.js'
+import { AuditStore, AuditWriter, buildHeaderMismatchAuditRecord } from '../audit/index.js'
+import { EvidenceStore } from '../evidence/index.js'
+import { ApprovalQueue, ApprovalRouter, createChannels } from '../approval/index.js'
+import { BudgetEngine, compileBudgets } from '../budget/index.js'
+import { parseDuration } from '../config/schema.js'
+import { isNamedConfig } from '../config/index.js'
+import type { HelioConfig, PoliciesConfig } from '../config/index.js'
+import type { McpForwarder } from '../mcp/types.js'
+import {
+  startSessionEnforcingHttpMcpServer,
+  startModernOnlyHttpMcpServer,
+} from './helpers/mcp-test-server.js'
+import type { ModernOnlyMcpServer } from './helpers/mcp-test-server.js'
+import { startOnDynamicPort, makeNamedConfig, sendMcpRequest } from './helpers/test-utils.js'
+import type { ManagedServer } from './helpers/test-utils.js'
+
+// ---------------------------------------------------------------------------
+// File-scope fixtures — one legacy door, one modern door, shared by every
+// composition. Anything that mutates fixture state (setTools) must restore
+// it: owning a composition does not own these servers.
+// ---------------------------------------------------------------------------
+
+let alphaFixture: { port: number; close: () => Promise<void> }
+let betaFixture: ModernOnlyMcpServer
+
+beforeAll(async () => {
+  alphaFixture = await startSessionEnforcingHttpMcpServer()
+  betaFixture = await startModernOnlyHttpMcpServer()
+})
+
+afterAll(async () => {
+  await alphaFixture.close()
+  await betaFixture.close()
+})
+
+// ---------------------------------------------------------------------------
+// Composition harness
+// ---------------------------------------------------------------------------
+
+type DoorName = 'alpha' | 'beta'
+
+interface TwoDoorComposition {
+  proxy: ManagedServer
+  config: HelioConfig
+  governed: Record<DoorName, GovernedForwarder>
+  auditStore: AuditStore
+  auditWriter: AuditWriter
+  evidenceStore: EvidenceStore
+  rateLimiter: RateLimiter
+  spendLimiter: SpendLimiter
+  budgetEngine: BudgetEngine
+  mcpUrl: (door: DoorName) => string
+  sseUrl: (door: DoorName) => string
+  close: () => Promise<void>
+}
+
+/**
+ * Compose the two file-scope fixtures behind one createMultiApp on a real
+ * socket, governed the way cli.ts governs a named config: phase 1 connects
+ * every upstream (production createForwarderFromConfig per entry, with the
+ * entry name), then the shared services are built once and every door's
+ * GovernedForwarder composes them via ONE governance object carrying the
+ * cli.ts field set: environment, auditWriter, evidenceStore, approvalRouter,
+ * rateLimiter, spendLimiter, budgetEngine, session.
+ */
+async function composeTwoDoors(options: {
+  policies: PoliciesConfig
+  session?: Partial<HelioConfig['session']>
+  budgets?: HelioConfig['budgets']
+  environment?: string
+  /** Await a direct annotation-cache prime per door (no prime-loop windows). */
+  prime?: boolean
+}): Promise<TwoDoorComposition> {
+  const config = makeNamedConfig(['alpha', 'beta'], {
+    urls: {
+      alpha: `http://127.0.0.1:${String(alphaFixture.port)}/mcp`,
+      beta: `http://127.0.0.1:${String(betaFixture.port)}/mcp`,
+    },
+    policies: options.policies,
+    session: options.session,
+    budgets: options.budgets,
+    environment: options.environment,
+  })
+  if (!isNamedConfig(config)) throw new Error('unreachable: makeNamedConfig builds named configs')
+
+  // Phase 1 (cli.ts order): connect every upstream before any shared service.
+  const doors: Array<{ name: string; forwarder: McpForwarder; close?: () => Promise<void> }> = []
+  for (const entry of config.upstreams) {
+    const built = await createForwarderFromConfig({ upstream: entry }, entry.name)
+    doors.push({ name: entry.name, forwarder: built.forwarder, close: built.close })
+  }
+
+  const auditStore = new AuditStore({
+    path: ':memory:',
+    retention: '90d',
+    includeResponses: true,
+    cleanupIntervalMs: 0,
+  })
+  const auditWriter = new AuditWriter({ store: auditStore, flushIntervalMs: 0 })
+  const evidenceStore = new EvidenceStore({ cleanupIntervalMs: 0 })
+  const approvalQueue = new ApprovalQueue({ cleanupIntervalMs: 0 })
+  const approvalRouter = new ApprovalRouter({
+    defaultTimeoutMs: parseDuration(config.approval.timeout),
+    defaultOnTimeout: config.approval.default_on_timeout,
+    channels: createChannels(config.approval.channels),
+    queue: approvalQueue,
+  })
+  const rateLimiter = new RateLimiter({ cleanupIntervalMs: 0 })
+  const spendLimiter = new SpendLimiter({ cleanupIntervalMs: 0 })
+  const budgetEngine = new BudgetEngine({
+    budgets: compileBudgets(config.budgets),
+    cleanupIntervalMs: 0,
+  })
+  const session = compileSessionIdentity(config.session)
+  const { policy } = compilePolicies(config.policies)
+
+  // The one governance object every door shares — cli.ts field for field.
+  const governance: GovernedForwarderOptions = {
+    environment: config.environment,
+    auditWriter,
+    evidenceStore,
+    approvalRouter,
+    rateLimiter,
+    spendLimiter,
+    budgetEngine,
+    session,
+  }
+
+  const governed = {} as Record<DoorName, GovernedForwarder>
+  const forwarders: Record<string, GovernedForwarder> = {}
+  for (const door of doors) {
+    const governedForwarder = new GovernedForwarder(door.forwarder, policy, {
+      ...governance,
+      upstreamName: door.name,
+    })
+    governed[door.name as DoorName] = governedForwarder
+    forwarders[door.name] = governedForwarder
+  }
+
+  if (options.prime) {
+    for (const door of ['alpha', 'beta'] as const) {
+      const primed = await governed[door].primeAnnotationCache()
+      if (!primed.success) throw new Error(`annotation prime failed for ${door}`)
+    }
+  }
+
+  const app = createMultiApp(config, forwarders, {
+    onHeaderMismatch: (rejection, upstreamName) => {
+      auditWriter.pushImmediate(
+        buildHeaderMismatchAuditRecord(rejection, config.environment, upstreamName),
+      )
+    },
+  })
+  const proxy = startOnDynamicPort(app)
+  const base = `http://127.0.0.1:${String(proxy.port)}`
+
+  return {
+    proxy,
+    config,
+    governed,
+    auditStore,
+    auditWriter,
+    evidenceStore,
+    rateLimiter,
+    spendLimiter,
+    budgetEngine,
+    mcpUrl: (door) => `${base}/mcp/${door}`,
+    sseUrl: (door) => `${base}/sse/${door}`,
+    close: async () => {
+      await proxy.close()
+      for (const door of doors) {
+        await door.close?.()
+      }
+      approvalRouter.close()
+      approvalQueue.close()
+      rateLimiter.close()
+      spendLimiter.close()
+      budgetEngine.close()
+      evidenceStore.close()
+      auditWriter.close() // also closes auditStore
+    },
+  }
+}
+
+/**
+ * Run the legacy door's downstream handshake through the proxy: initialize,
+ * capture the fixture-minted wire session, send notifications/initialized.
+ * Returns the wire session id for subsequent session'd calls.
+ */
+async function initializeLegacyDoor(
+  url: string,
+  options?: { helioSessionId?: string },
+): Promise<string> {
+  const init = await sendMcpRequest(
+    url,
+    'initialize',
+    {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'two-upstream-suite', version: '1' },
+    },
+    'init-1',
+    options,
+  )
+  expect(init.status).toBe(200)
+  const wireSession = init.headers.get('mcp-session-id')
+  if (!wireSession) throw new Error('legacy door minted no wire session')
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'mcp-session-id': wireSession },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+  })
+  return wireSession
+}
+
+// ---------------------------------------------------------------------------
+// Composition skeleton — the two doors work end-to-end, and each mount
+// serves its GOVERNED forwarder (the deny probe never reaches an upstream).
+// ---------------------------------------------------------------------------
+
+describe('two-door composition', () => {
+  let comp: TwoDoorComposition
+
+  beforeAll(async () => {
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [{ name: 'denied-probe', match: { tool: 'denied_probe' }, action: 'deny' }],
+      } as PoliciesConfig,
+    })
+  })
+
+  afterAll(async () => {
+    await comp.close()
+  })
+
+  it('serves the legacy door end-to-end: handshake relayed, minted session honored', async () => {
+    const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
+    const call = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      2,
+      { sessionId: wireSession },
+    )
+    expect(call.status).toBe(200)
+    expect(call.body['error']).toBeUndefined()
+    const result = call.body['result'] as { content: { type: string; text: string }[] }
+    expect(result.content[0]?.text).toBe('Sunny, 22°C in Berlin')
+  })
+
+  it('serves the modern door end-to-end: sessionless governed call succeeds', async () => {
+    const call = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {} },
+      3,
+      { helioSessionId: 'skeleton-s1' },
+    )
+    expect(call.status).toBe(200)
+    expect(call.body['error']).toBeUndefined()
+    const result = call.body['result'] as { content: { type: string; text: string }[] }
+    expect(result.content[0]?.text).toContain('get_status executed')
+  })
+
+  it('each mount serves its GOVERNED forwarder: the deny probe blocks and never reaches an upstream', async () => {
+    const betaSeenBefore = betaFixture.receivedRequests.length
+    for (const door of ['alpha', 'beta'] as const) {
+      const res = await sendMcpRequest(
+        comp.mcpUrl(door),
+        'tools/call',
+        { name: 'denied_probe', arguments: {} },
+        `deny-${door}`,
+        { helioSessionId: 'skeleton-deny' },
+      )
+      const error = res.body['error'] as { code: number; data: Record<string, unknown> }
+      expect(error).toBeDefined()
+      expect(error.code).toBe(-32001)
+      expect(error.data['blocked']).toBe(true)
+      expect(error.data['reason']).toBe('policy_denied')
+      expect(error.data['rule']).toBe('denied-probe')
+    }
+    // Neither denied call was forwarded: the modern fixture saw no new
+    // tools/call (the legacy fixture has no capture affordance; its deny
+    // envelope above already proves the governed path).
+    const newBetaCalls = betaFixture.receivedRequests
+      .slice(betaSeenBefore)
+      .filter((req) => req.method === 'tools/call')
+    expect(newBetaCalls).toHaveLength(0)
+  })
+})

--- a/packages/proxy/src/__tests__/integration-two-upstream.test.ts
+++ b/packages/proxy/src/__tests__/integration-two-upstream.test.ts
@@ -15,7 +15,8 @@
  * mistake fails those loudly instead of silently bypassing policy.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
 import { createMultiApp } from '../server.js'
 import { createForwarderFromConfig } from '../cli-forwarder.js'
 import { GovernedForwarder } from '../policy/governed-forwarder.js'
@@ -313,5 +314,460 @@ describe('two-door composition', () => {
       .slice(betaSeenBefore)
       .filter((req) => req.method === 'tools/call')
     expect(newBetaCalls).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Isolation family (issue #296 bullets I1, I2, I3, I5; I4 has its own
+// describe below once the cap seam exists). Each assertion owns its
+// composition: annotation caches, drift baselines, era caches, and limit
+// counters all live per composition, so a fresh one is the cheapest way to
+// guarantee no cross-test contamination.
+// ---------------------------------------------------------------------------
+
+describe('isolation: era caches classify independently (I1)', () => {
+  let comp: TwoDoorComposition
+  let errorSpy: MockInstance
+
+  beforeAll(async () => {
+    // Installed before the composition so both era-detected lines land in it.
+    errorSpy = vi.spyOn(console, 'error')
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [{ name: 'denied-probe', match: { tool: 'denied_probe' }, action: 'deny' }],
+      } as PoliciesConfig,
+    })
+  })
+
+  afterAll(async () => {
+    errorSpy.mockRestore()
+    await comp.close()
+  })
+
+  it('classifies one legacy and one modern door in the same process, beta first', async () => {
+    const betaSeenBefore = betaFixture.receivedRequests.length
+
+    // The order is the counterfactual's: beta's first relay (its era probe)
+    // runs BEFORE alpha's handshake. A shared era cache would classify alpha
+    // modern, strip its session, and the session-enforcing fixture would
+    // answer the relayed call with HTTP 400 -32000 instead of 200.
+    const betaCall = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {} },
+      'era-beta-1',
+      { helioSessionId: 'era-s1' },
+    )
+    expect(betaCall.status).toBe(200)
+    expect(betaCall.body['error']).toBeUndefined()
+
+    const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
+    const alphaCall = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'era-alpha-1',
+      { sessionId: wireSession },
+    )
+    expect(alphaCall.status).toBe(200)
+    expect(alphaCall.body['error']).toBeUndefined()
+
+    // Every send to the modern door was sessionless and modern-versioned —
+    // the behavioral half of beta's classification.
+    const betaSeen = betaFixture.receivedRequests.slice(betaSeenBefore)
+    expect(betaSeen.length).toBeGreaterThan(0)
+    for (const received of betaSeen) {
+      expect(received.headers['mcp-session-id']).toBeUndefined()
+      expect(received.headers['mcp-protocol-version']).toBe('2026-07-28')
+    }
+
+    // Both door-tagged era lines appeared, in ONE process, simultaneously.
+    const eraLines = errorSpy.mock.calls.map((args: unknown[]) => args.join(' '))
+    expect(eraLines).toContain(
+      '[helio][beta] Upstream MCP era detected: modern (2026-07-28, via server/discover)',
+    )
+    expect(eraLines).toContain(
+      '[helio][alpha] Upstream MCP era detected: legacy (initialize handshake)',
+    )
+  })
+
+  it('the composition is governed: the deny probe blocks on the alpha door', async () => {
+    const res = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'denied_probe', arguments: {} },
+      'era-deny',
+      { helioSessionId: 'era-s1' },
+    )
+    const error = res.body['error'] as { code: number; data: Record<string, unknown> }
+    expect(error.code).toBe(-32001)
+    expect(error.data['rule']).toBe('denied-probe')
+  })
+})
+
+// The modern fixture's startup tool set, verbatim (mcp-test-server.ts) — any
+// test that calls setTools on the SHARED file-scope fixture restores this
+// afterward, or a later family loses get_status.
+const ORIGINAL_BETA_TOOLS: Record<string, unknown>[] = [
+  {
+    name: 'get_status',
+    description: 'Report the current server status',
+    annotations: { readOnlyHint: true, destructiveHint: false },
+  },
+  {
+    name: 'Hello, 世界',
+    description: 'Report status with a non-ASCII display name',
+    annotations: { readOnlyHint: true, destructiveHint: false },
+  },
+]
+
+/** A same-named twin of alpha's get_weather, advertised by beta via setTools. */
+function betaWeatherTwin(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    name: 'get_weather',
+    description: 'Get the current weather for a city (beta twin)',
+    annotations: { readOnlyHint: true, destructiveHint: false },
+    ...overrides,
+  }
+}
+
+describe('isolation: annotation caches match per door (I2, annotation half)', () => {
+  let comp: TwoDoorComposition
+
+  beforeAll(async () => {
+    // Beta's twin is genuinely destructive by ITS OWN advertised annotations;
+    // alpha's get_weather is annotated {readOnlyHint: true, destructiveHint:
+    // false} by the SDK fixture. Set before compose so the primed caches see
+    // each door's real definitions. This composition never drifts.
+    betaFixture.setTools([
+      ...ORIGINAL_BETA_TOOLS,
+      betaWeatherTwin({ annotations: { readOnlyHint: false, destructiveHint: true } }),
+    ])
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [
+          {
+            name: 'block-destructive',
+            match: { annotations: { destructiveHint: true } },
+            action: 'deny',
+          },
+        ],
+      } as PoliciesConfig,
+      prime: true,
+    })
+  })
+
+  afterAll(async () => {
+    betaFixture.setTools(ORIGINAL_BETA_TOOLS)
+    await comp.close()
+  })
+
+  it("denies beta's destructive twin while alpha's read-only twin passes", async () => {
+    const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
+    const alphaCall = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'i2a-alpha',
+      { sessionId: wireSession },
+    )
+    expect(alphaCall.body['error']).toBeUndefined()
+    const alphaResult = alphaCall.body['result'] as { content: { text: string }[] }
+    expect(alphaResult.content[0]?.text).toBe('Sunny, 22°C in Berlin')
+
+    // The SAME tool name on beta is denied — by beta's own primed cache, not
+    // alpha's. A shared cache would give both doors one verdict.
+    const betaCall = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'i2a-beta',
+      { helioSessionId: 'i2a-s1' },
+    )
+    const error = betaCall.body['error'] as { code: number; data: Record<string, unknown> }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.data['reason']).toBe('policy_denied')
+    expect(error.data['rule']).toBe('block-destructive')
+  })
+})
+
+describe('isolation: drift baselines gate per door (I2, drift half)', () => {
+  let comp: TwoDoorComposition
+
+  beforeAll(async () => {
+    // A benign twin first — the pre-drift baseline. NO annotation rule in
+    // this policy (the drift override discards matchedRule, so an annotation
+    // assertion could never be read off a drifted cache); this half owns
+    // revalidation deliberately and leaves tool_revalidation at its default.
+    betaFixture.setTools([...ORIGINAL_BETA_TOOLS, betaWeatherTwin()])
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        on_tool_drift: 'block',
+        rules: [{ name: 'denied-probe', match: { tool: 'denied_probe' }, action: 'deny' }],
+      } as PoliciesConfig,
+      prime: true,
+    })
+  })
+
+  afterAll(async () => {
+    betaFixture.setTools(ORIGINAL_BETA_TOOLS)
+    await comp.close()
+  })
+
+  it('a drifted tool on beta gates beta only; alpha keeps serving', async () => {
+    const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
+
+    // Pre-drift baseline: BOTH doors serve get_weather (the red step this
+    // drift lever flips — valid because this policy has no annotation rule).
+    const alphaPre = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'i2b-alpha-pre',
+      { sessionId: wireSession },
+    )
+    expect(alphaPre.body['error']).toBeUndefined()
+    const betaPre = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'i2b-beta-pre',
+      { helioSessionId: 'i2b-s1' },
+    )
+    expect(betaPre.body['error']).toBeUndefined()
+
+    // Drift beta's twin out from under its baseline and re-prime BETA only
+    // (stand-in for the scheduled revalidation tick).
+    betaFixture.setTools([
+      ...ORIGINAL_BETA_TOOLS,
+      betaWeatherTwin({ description: 'Get the current weather for a city (beta twin, v2)' }),
+    ])
+    const reprimed = await comp.governed.beta.primeAnnotationCache()
+    expect(reprimed.success).toBe(true)
+
+    // Beta gates on ITS drift...
+    const betaPost = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'i2b-beta-post',
+      { helioSessionId: 'i2b-s1' },
+    )
+    const error = betaPost.body['error'] as {
+      code: number
+      message: string
+      data: Record<string, unknown>
+    }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.message).toBe('Tool definition drift: "get_weather" changed after baseline')
+    expect(error.data['reason']).toBe('tool_definition_drift')
+
+    // ...while alpha's same-named tool keeps serving from ITS baseline.
+    const alphaPost = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'i2b-alpha-post',
+      { sessionId: wireSession },
+    )
+    expect(alphaPost.body['error']).toBeUndefined()
+
+    // The drift event and the drift deny are both attributed to beta.
+    comp.auditWriter.flush()
+    const betaRecords = comp.auditStore.list({ upstream: 'beta' }).records
+    expect(betaRecords.some((r) => r.record_kind === 'drift_event')).toBe(true)
+    expect(
+      betaRecords.some(
+        (r) => r.record_kind === 'tool_call' && r.block_reason === 'tool_definition_drift',
+      ),
+    ).toBe(true)
+    const alphaRecords = comp.auditStore.list({ upstream: 'alpha' }).records
+    expect(alphaRecords.some((r) => r.record_kind === 'drift_event')).toBe(false)
+    expect(alphaRecords.some((r) => r.block_reason === 'tool_definition_drift')).toBe(false)
+  })
+})
+
+describe('isolation: tool limit buckets count per door (I3)', () => {
+  let comp: TwoDoorComposition
+
+  beforeAll(async () => {
+    // An undrifted composition: same-named get_weather on both doors, one
+    // rate_limit rule keyed on the tool.
+    betaFixture.setTools([...ORIGINAL_BETA_TOOLS, betaWeatherTwin()])
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [
+          {
+            name: 'limit-weather',
+            match: { tool: 'get_weather' },
+            action: 'rate_limit',
+            limits: { max_calls: 1, window: '60s' },
+          },
+        ],
+      } as PoliciesConfig,
+    })
+  })
+
+  afterAll(async () => {
+    betaFixture.setTools(ORIGINAL_BETA_TOOLS)
+    await comp.close()
+  })
+
+  it("exhausting alpha's get_weather bucket leaves beta's untouched", async () => {
+    const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
+
+    const first = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'i3-alpha-1',
+      { sessionId: wireSession },
+    )
+    expect(first.body['error']).toBeUndefined()
+
+    // The second alpha call trips ALPHA's bucket — the deny message embeds
+    // the full partitioned key, the cheapest wire-visible observable.
+    const second = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'i3-alpha-2',
+      { sessionId: wireSession },
+    )
+    const error = second.body['error'] as { code: number; message: string }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.message).toBe('Rate limit exceeded for upstream:alpha:tool:get_weather:rule:0')
+
+    // Beta's same-named bucket has its own count: its first call passes.
+    const betaCall = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'i3-beta-1',
+      { helioSessionId: 'i3-s1' },
+    )
+    expect(betaCall.body['error']).toBeUndefined()
+  })
+})
+
+describe('isolation: audit attribution follows routing (I5)', () => {
+  let comp: TwoDoorComposition
+
+  beforeAll(async () => {
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [{ name: 'denied-probe', match: { tool: 'denied_probe' }, action: 'deny' }],
+      } as PoliciesConfig,
+    })
+  })
+
+  afterAll(async () => {
+    await comp.close()
+  })
+
+  it('attributes every record to the door driven, under adversarial identity inputs', async () => {
+    const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
+    // Adversarial drive: every call carries a crafted identity header and
+    // client-authored _meta; beta also gets a LYING legacy wire session.
+    // None of it may influence the upstream column — only routing does.
+    const adversarialMeta = {
+      'io.modelcontextprotocol/clientInfo': { name: 'liar', version: '9' },
+    }
+
+    const alphaCall = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' }, _meta: adversarialMeta },
+      'i5-alpha-1',
+      { sessionId: wireSession, helioSessionId: 'i5-liar' },
+    )
+    expect(alphaCall.body['error']).toBeUndefined()
+
+    const alphaDeny = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'denied_probe', arguments: {}, _meta: adversarialMeta },
+      'i5-alpha-2',
+      { helioSessionId: 'i5-liar' },
+    )
+    const denyError = alphaDeny.body['error'] as { code: number }
+    expect(denyError.code).toBe(-32001)
+
+    for (const id of ['i5-beta-1', 'i5-beta-2']) {
+      const betaCall = await sendMcpRequest(
+        comp.mcpUrl('beta'),
+        'tools/call',
+        { name: 'get_status', arguments: {}, _meta: adversarialMeta },
+        id,
+        { sessionId: 'fake-wire-session-lie', helioSessionId: 'i5-liar' },
+      )
+      expect(betaCall.body['error']).toBeUndefined()
+    }
+
+    comp.auditWriter.flush()
+    const alphaRecords = comp.auditStore.list({ upstream: 'alpha' }).records
+    const betaRecords = comp.auditStore.list({ upstream: 'beta' }).records
+    expect(alphaRecords.map((r) => r.tool_name).sort()).toEqual(['denied_probe', 'get_weather'])
+    expect(betaRecords.map((r) => r.tool_name)).toEqual(['get_status', 'get_status'])
+  })
+
+  it('a null-upstream record matches neither door filter (exclusion arm)', () => {
+    // A synthetic upstream: null record makes the exclusion assertion
+    // non-vacuous — without one in the store it would assert nothing.
+    comp.auditWriter.push({
+      timestamp: new Date().toISOString(),
+      session_id: null,
+      session_source: null,
+      agent_id: null,
+      environment: null,
+      tool_name: 'synthetic_null_probe',
+      tool_input: {},
+      policy_decision: 'allow',
+      block_reason: null,
+      matched_rule: null,
+      matched_rule_index: null,
+      evidence_chain: null,
+      approval_status: null,
+      approved_by: null,
+      upstream_response: null,
+      upstream_error: null,
+      upstream_http_status: null,
+      upstream_latency_ms: null,
+      total_duration_ms: 0,
+      approval_wait_ms: 0,
+      proxy_compute_ms: 0,
+      flagged_destructive: false,
+      dry_run: false,
+      record_kind: 'tool_call',
+      origin: 'mcp',
+      metadata: null,
+      protocol_version: null,
+      upstream: null,
+    })
+    comp.auditWriter.flush()
+
+    const all = comp.auditStore.list({}).records
+    expect(all.some((r) => r.tool_name === 'synthetic_null_probe')).toBe(true)
+    for (const door of ['alpha', 'beta'] as const) {
+      const filtered = comp.auditStore.list({ upstream: door }).records
+      expect(filtered.some((r) => r.tool_name === 'synthetic_null_probe')).toBe(false)
+    }
   })
 })

--- a/packages/proxy/src/__tests__/integration-two-upstream.test.ts
+++ b/packages/proxy/src/__tests__/integration-two-upstream.test.ts
@@ -852,3 +852,291 @@ describe('isolation: audit attribution follows routing (I5)', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// Sharing family (issue #296 bullets S1, S2, S3): what must POOL across
+// doors. Each claim runs beside its permanent negative control — the
+// deliberately scoped variant whose non-pooling is the config-lever red.
+// ---------------------------------------------------------------------------
+
+describe('sharing: un-scoped session limits pool across doors (S1)', () => {
+  let pooled: TwoDoorComposition
+  let scoped: TwoDoorComposition
+
+  const sessionLimitRule = (upstreams?: string[]): Record<string, unknown> => ({
+    name: 'pool-session-calls',
+    match: { tool: 'get_*', ...(upstreams ? { upstreams } : {}) },
+    action: 'rate_limit',
+    limits: { max_calls: 2, window: '60s', key: 'session' },
+  })
+
+  beforeAll(async () => {
+    pooled = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [sessionLimitRule()],
+      } as PoliciesConfig,
+    })
+    scoped = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [sessionLimitRule(['alpha'])],
+      } as PoliciesConfig,
+    })
+  })
+
+  afterAll(async () => {
+    await pooled.close()
+    await scoped.close()
+  })
+
+  it("one session's calls pool across both doors", async () => {
+    const wireSession = await initializeLegacyDoor(pooled.mcpUrl('alpha'))
+    const alpha1 = await sendMcpRequest(
+      pooled.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      's1-a1',
+      { sessionId: wireSession, helioSessionId: 's1-pool' },
+    )
+    expect(alpha1.body['error']).toBeUndefined()
+    const beta1 = await sendMcpRequest(
+      pooled.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {} },
+      's1-b1',
+      { helioSessionId: 's1-pool' },
+    )
+    expect(beta1.body['error']).toBeUndefined()
+
+    // The third call — back on ALPHA, which has only one call of its own —
+    // denies: beta's call fed the SAME session bucket. The un-prefixed key
+    // in the message is the design: session identity is proxy-owned.
+    const alpha2 = await sendMcpRequest(
+      pooled.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      's1-a2',
+      { sessionId: wireSession, helioSessionId: 's1-pool' },
+    )
+    const error = alpha2.body['error'] as { code: number; message: string }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.message).toBe('Rate limit exceeded for session:s1-pool:rule:0')
+  })
+
+  it('negative control: the alpha-scoped rule never pools beta calls', async () => {
+    const wireSession = await initializeLegacyDoor(scoped.mcpUrl('alpha'))
+    const drive = async (door: DoorName, id: string) =>
+      sendMcpRequest(
+        scoped.mcpUrl(door),
+        'tools/call',
+        door === 'alpha'
+          ? { name: 'get_weather', arguments: { city: 'Berlin' } }
+          : { name: 'get_status', arguments: {} },
+        id,
+        door === 'alpha'
+          ? { sessionId: wireSession, helioSessionId: 's1-scope' }
+          : { helioSessionId: 's1-scope' },
+      )
+
+    // The exact sequence the pooled variant denies on: alpha, beta, alpha.
+    expect((await drive('alpha', 's1s-a1')).body['error']).toBeUndefined()
+    expect((await drive('beta', 's1s-b1')).body['error']).toBeUndefined()
+    // Here the third call passes — beta's call never fed the scoped bucket.
+    expect((await drive('alpha', 's1s-a2')).body['error']).toBeUndefined()
+    // Beta keeps passing however often it calls...
+    expect((await drive('beta', 's1s-b2')).body['error']).toBeUndefined()
+    // ...and the scoped rule is no dead rule: alpha's own third call trips it.
+    const alpha3 = await drive('alpha', 's1s-a3')
+    const error = alpha3.body['error'] as { code: number; message: string }
+    expect(error).toBeDefined()
+    expect(error.message).toBe('Rate limit exceeded for session:s1-scope:rule:0')
+  })
+})
+
+describe('sharing: one budget pot spans both doors (S2)', () => {
+  let pooled: TwoDoorComposition
+  let scoped: TwoDoorComposition
+
+  const potBudget = (name: string, upstreams?: string[]): Record<string, unknown> => ({
+    name,
+    limit: 150,
+    currency: 'USD',
+    window: '24h',
+    key: 'global',
+    on_exceed: 'deny',
+    contributors: [
+      { match: { tool: 'create_payment', ...(upstreams ? { upstreams } : {}) }, field: '$.amount' },
+    ],
+  })
+
+  const allowAllPolicies = {
+    default: 'allow',
+    dry_run: false,
+    tool_revalidation: { enabled: false },
+    rules: [],
+  } as unknown as PoliciesConfig
+
+  beforeAll(async () => {
+    pooled = await composeTwoDoors({
+      policies: allowAllPolicies,
+      budgets: [potBudget('shared-pot')] as HelioConfig['budgets'],
+    })
+    scoped = await composeTwoDoors({
+      policies: allowAllPolicies,
+      budgets: [potBudget('scoped-pot', ['alpha'])] as HelioConfig['budgets'],
+    })
+  })
+
+  afterAll(async () => {
+    await pooled.close()
+    await scoped.close()
+  })
+
+  const payment = { amount: 60, currency: 'USD' }
+
+  it('charges from both doors drain one pot until it denies', async () => {
+    const wireSession = await initializeLegacyDoor(pooled.mcpUrl('alpha'))
+    const alpha1 = await sendMcpRequest(
+      pooled.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'create_payment', arguments: payment },
+      's2-a1',
+      { sessionId: wireSession, helioSessionId: 's2-1' },
+    )
+    expect(alpha1.body['error']).toBeUndefined()
+    const beta1 = await sendMcpRequest(
+      pooled.mcpUrl('beta'),
+      'tools/call',
+      { name: 'create_payment', arguments: payment },
+      's2-b1',
+      { helioSessionId: 's2-1' },
+    )
+    expect(beta1.body['error']).toBeUndefined()
+
+    // Third charge on ALPHA (alpha alone would sit at 120 of 150): the deny
+    // proves beta's 60 drained the same pot.
+    const alpha2 = await sendMcpRequest(
+      pooled.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'create_payment', arguments: payment },
+      's2-a2',
+      { sessionId: wireSession, helioSessionId: 's2-1' },
+    )
+    const error = alpha2.body['error'] as { code: number; message: string }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.message).toBe('Budget exceeded: "shared-pot"')
+  })
+
+  it("negative control: an alpha-scoped contributor never charges beta's calls", async () => {
+    const wireSession = await initializeLegacyDoor(scoped.mcpUrl('alpha'))
+    const drive = async (door: DoorName, id: string) =>
+      sendMcpRequest(
+        scoped.mcpUrl(door),
+        'tools/call',
+        { name: 'create_payment', arguments: payment },
+        id,
+        door === 'alpha'
+          ? { sessionId: wireSession, helioSessionId: 's2-2' }
+          : { helioSessionId: 's2-2' },
+      )
+    const potSpent = (): number => {
+      const state = scoped.budgetEngine.listStates().find((s) => s.name === 'scoped-pot')
+      return state?.buckets.find((b) => b.bucket_key === 'budget:scoped-pot:global')?.spent ?? 0
+    }
+
+    expect((await drive('alpha', 's2s-a1')).body['error']).toBeUndefined()
+    expect(potSpent()).toBe(60)
+    // Beta's charge leaves the pot untouched...
+    expect((await drive('beta', 's2s-b1')).body['error']).toBeUndefined()
+    expect(potSpent()).toBe(60)
+    // ...so the call the pooled pot denied passes here.
+    expect((await drive('alpha', 's2s-a2')).body['error']).toBeUndefined()
+    expect(potSpent()).toBe(120)
+  })
+})
+
+describe('sharing: a cross-door requires dependency satisfies (S3)', () => {
+  let comp: TwoDoorComposition
+
+  beforeAll(async () => {
+    // requires-gated rules make the identity chain header-only: the #293
+    // guard rejects legacy_header beside evidence-gated rules in named mode,
+    // and this suite's configs mirror what an operator could actually load.
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [
+          {
+            name: 'gate-status-on-weather',
+            match: { tool: 'get_status' },
+            action: 'allow',
+            requires: ['get_weather'],
+          },
+        ],
+      } as PoliciesConfig,
+      session: {
+        identity: [{ source: 'header', name: 'x-helio-session-id' }],
+        on_unresolved: 'deny',
+      },
+    })
+  })
+
+  afterAll(async () => {
+    await comp.close()
+  })
+
+  it('a dependency completed on door A satisfies the gate on door B', async () => {
+    const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
+    const dependency = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      's3-a1',
+      { sessionId: wireSession, helioSessionId: 's3-1' },
+    )
+    expect(dependency.body['error']).toBeUndefined()
+
+    const gated = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {} },
+      's3-b1',
+      { helioSessionId: 's3-1' },
+    )
+    expect(gated.body['error']).toBeUndefined()
+    const result = gated.body['result'] as { content: { text: string }[] }
+    expect(result.content[0]?.text).toContain('get_status executed')
+  })
+
+  it('negative control: a fresh identity is denied with the dependency-missing envelope', async () => {
+    const denied = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {} },
+      's3-b2',
+      { helioSessionId: 's3-2' },
+    )
+    const error = denied.body['error'] as {
+      code: number
+      message: string
+      data: Record<string, unknown>
+    }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.message).toBe(
+      'Evidence grounding failed: Required tool calls not completed: get_weather',
+    )
+    expect(error.data['reason']).toBe('dependency_missing')
+    expect(error.data['missing_dependencies']).toEqual(['get_weather'])
+    expect(error.data['rule']).toBe('gate-status-on-weather')
+  })
+})

--- a/packages/proxy/src/__tests__/integration-two-upstream.test.ts
+++ b/packages/proxy/src/__tests__/integration-two-upstream.test.ts
@@ -766,8 +766,11 @@ describe('isolation: audit attribution follows routing (I5)', () => {
   it('attributes every record to the door driven, under adversarial identity inputs', async () => {
     const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
     // Adversarial drive: every call carries a crafted identity header and
-    // client-authored _meta; beta also gets a LYING legacy wire session.
-    // None of it may influence the upstream column — only routing does.
+    // client-authored _meta; the LYING legacy wire session rides both of
+    // beta's calls AND alpha's deny probe (blocked before forward, so the
+    // lie never reaches the session-enforcing fixture — alpha's forwarded
+    // call must keep its real wire session or the fixture 400s). None of it
+    // may influence the upstream column — only routing does.
     const adversarialMeta = {
       'io.modelcontextprotocol/clientInfo': { name: 'liar', version: '9' },
     }
@@ -786,7 +789,7 @@ describe('isolation: audit attribution follows routing (I5)', () => {
       'tools/call',
       { name: 'denied_probe', arguments: {}, _meta: adversarialMeta },
       'i5-alpha-2',
-      { helioSessionId: 'i5-liar' },
+      { sessionId: 'fake-wire-session-lie', helioSessionId: 'i5-liar' },
     )
     const denyError = alphaDeny.body['error'] as { code: number }
     expect(denyError.code).toBe(-32001)

--- a/packages/proxy/src/__tests__/integration-two-upstream.test.ts
+++ b/packages/proxy/src/__tests__/integration-two-upstream.test.ts
@@ -1140,3 +1140,331 @@ describe('sharing: a cross-door requires dependency satisfies (S3)', () => {
     expect(error.data['rule']).toBe('gate-status-on-weather')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Identity family (issue #296 bullets D2, D3; D1's validate matrix lives in
+// cli.test.ts beside its precedents). Assertions read bucket and store
+// BEHAVIOR, never the once-per-process warning lines.
+// ---------------------------------------------------------------------------
+
+describe('identity: on_unresolved anonymous pools limits and budgets (D2)', () => {
+  let pooled: TwoDoorComposition
+  let denyMode: TwoDoorComposition
+
+  const anonLimitRule = {
+    name: 'pool-anon-calls',
+    match: { tool: 'get_*' },
+    action: 'rate_limit',
+    limits: { max_calls: 2, window: '60s', key: 'session' },
+  }
+
+  beforeAll(async () => {
+    pooled = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [anonLimitRule],
+      } as PoliciesConfig,
+      session: {
+        identity: [{ source: 'header', name: 'x-helio-session-id' }],
+        on_unresolved: 'anonymous',
+      },
+      budgets: [
+        {
+          name: 'anon-pot',
+          limit: 150,
+          currency: 'USD',
+          window: '24h',
+          key: 'session',
+          on_exceed: 'deny',
+          contributors: [{ match: { tool: 'create_payment' }, field: '$.amount' }],
+        },
+        {
+          name: 'anon-scoped-pot',
+          limit: 150,
+          currency: 'USD',
+          window: '24h',
+          key: 'session',
+          on_exceed: 'deny',
+          contributors: [
+            { match: { tool: 'lookup_order', upstreams: ['alpha'] }, field: '$.amount' },
+          ],
+        },
+      ] as HelioConfig['budgets'],
+    })
+    denyMode = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [anonLimitRule],
+      } as PoliciesConfig,
+      session: {
+        identity: [{ source: 'header', name: 'x-helio-session-id' }],
+        on_unresolved: 'deny',
+      },
+    })
+  })
+
+  afterAll(async () => {
+    await pooled.close()
+    await denyMode.close()
+  })
+
+  it('identity-less calls on both doors pool the session:unknown limit bucket', async () => {
+    const wireSession = await initializeLegacyDoor(pooled.mcpUrl('alpha'))
+    // The wire session relays upstream but is NOT identity (header-only
+    // chain): these calls resolve nothing and pool as anonymous.
+    const alpha1 = await sendMcpRequest(
+      pooled.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'd2-a1',
+      { sessionId: wireSession },
+    )
+    expect(alpha1.body['error']).toBeUndefined()
+    const beta1 = await sendMcpRequest(pooled.mcpUrl('beta'), 'tools/call', {
+      name: 'get_status',
+      arguments: {},
+    })
+    expect(beta1.body['error']).toBeUndefined()
+
+    const beta2 = await sendMcpRequest(
+      pooled.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {} },
+      'd2-b2',
+    )
+    const error = beta2.body['error'] as { code: number; message: string }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.message).toBe('Rate limit exceeded for session:unknown:rule:0')
+  })
+
+  it('identity-less charges on both doors drain one session:unknown budget pot', async () => {
+    const payment = { amount: 60, currency: 'USD' }
+    const wireSession = await initializeLegacyDoor(pooled.mcpUrl('alpha'))
+    const alpha1 = await sendMcpRequest(
+      pooled.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'create_payment', arguments: payment },
+      'd2-p1',
+      { sessionId: wireSession },
+    )
+    expect(alpha1.body['error']).toBeUndefined()
+    const beta1 = await sendMcpRequest(pooled.mcpUrl('beta'), 'tools/call', {
+      name: 'create_payment',
+      arguments: payment,
+    })
+    expect(beta1.body['error']).toBeUndefined()
+
+    // Both doors drained ONE pot, keyed by the anonymous session.
+    const potState = pooled.budgetEngine.listStates().find((s) => s.name === 'anon-pot')
+    expect(potState?.buckets.map((b) => b.bucket_key)).toEqual(['budget:anon-pot:session:unknown'])
+    expect(potState?.buckets[0]?.spent).toBe(120)
+
+    const alpha2 = await sendMcpRequest(
+      pooled.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'create_payment', arguments: payment },
+      'd2-p3',
+      { sessionId: wireSession },
+    )
+    const error = alpha2.body['error'] as { code: number; message: string }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.message).toBe('Budget exceeded: "anon-pot"')
+  })
+
+  it("scoped-contributor control: beta's anonymous charge never enters the alpha-scoped pot", async () => {
+    const beta = await sendMcpRequest(pooled.mcpUrl('beta'), 'tools/call', {
+      name: 'lookup_order',
+      arguments: { order_id: 'o-1', amount: 60 },
+    })
+    expect(beta.body['error']).toBeUndefined()
+    expect(pooled.budgetEngine.hasBucket('budget:anon-scoped-pot:session:unknown')).toBe(false)
+    const potState = pooled.budgetEngine.listStates().find((s) => s.name === 'anon-scoped-pot')
+    expect(potState?.buckets).toEqual([])
+  })
+
+  it('deny-mode control: the same identity-less call is denied outright', async () => {
+    const denied = await sendMcpRequest(denyMode.mcpUrl('beta'), 'tools/call', {
+      name: 'get_status',
+      arguments: {},
+    })
+    const error = denied.body['error'] as {
+      code: number
+      message: string
+      data: Record<string, unknown>
+    }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.message).toBe(
+      'No session identity resolved (tried: header "x-helio-session-id") — a session-keyed ' +
+        'limit or budget requires one. See session.identity in helio.yaml.',
+    )
+    expect(error.data['reason']).toBe('session_unresolved')
+
+    // The rule itself is live: a resolved identity passes.
+    const resolved = await sendMcpRequest(
+      denyMode.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {} },
+      'd2-deny-ok',
+      { helioSessionId: 'd2-resolved' },
+    )
+    expect(resolved.body['error']).toBeUndefined()
+  })
+})
+
+describe('identity: anonymous can neither record nor satisfy evidence (D2)', () => {
+  let comp: TwoDoorComposition
+
+  beforeAll(async () => {
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [
+          {
+            name: 'gate-status-on-weather',
+            match: { tool: 'get_status' },
+            action: 'allow',
+            requires: ['get_weather'],
+          },
+        ],
+      } as PoliciesConfig,
+      session: {
+        identity: [{ source: 'header', name: 'x-helio-session-id' }],
+        on_unresolved: 'anonymous',
+      },
+    })
+  })
+
+  afterAll(async () => {
+    await comp.close()
+  })
+
+  it('an anonymous dependency call records nothing and satisfies nothing', async () => {
+    const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
+    const dependency = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' } },
+      'd2e-a1',
+      { sessionId: wireSession },
+    )
+    expect(dependency.body['error']).toBeUndefined()
+
+    // "Cannot record" proven as STORE ABSENCE, asserted BEFORE any
+    // resolved-session call could create a session and blur the count.
+    expect(comp.evidenceStore.getSessionState('unknown').completed_tools).toEqual([])
+    expect(comp.evidenceStore.sessionCount).toBe(0)
+
+    // The gated call denies for the anonymous caller — grounding denies
+    // unresolved identity in BOTH on_unresolved modes. The session-blocked
+    // path carries the grounding message RAW (no "Evidence grounding
+    // failed:" prefix — that belongs to the evidence/dependency reasons).
+    const anonymousGated = await sendMcpRequest(comp.mcpUrl('beta'), 'tools/call', {
+      name: 'get_status',
+      arguments: {},
+    })
+    const anonError = anonymousGated.body['error'] as { code: number; message: string }
+    expect(anonError).toBeDefined()
+    expect(anonError.code).toBe(-32001)
+    expect(anonError.message).toBe(
+      'No session identity resolved (tried: header "x-helio-session-id") — rules using ' +
+        'evidence.requires or requires need one. See session.identity in helio.yaml.',
+    )
+
+    // And a RESOLVED identity is still unsatisfied — the anonymous
+    // dependency call recorded for nobody.
+    const resolvedGated = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {} },
+      'd2e-b2',
+      { helioSessionId: 'd2-ev' },
+    )
+    const resolvedError = resolvedGated.body['error'] as { code: number; message: string }
+    expect(resolvedError).toBeDefined()
+    expect(resolvedError.message).toBe(
+      'Evidence grounding failed: Required tool calls not completed: get_weather',
+    )
+  })
+})
+
+describe('identity: the meta source behaves as caller-class input (D3)', () => {
+  let comp: TwoDoorComposition
+
+  const clientMeta = (name: string): Record<string, unknown> => ({
+    'io.modelcontextprotocol/clientInfo': { name, version: '1' },
+  })
+
+  beforeAll(async () => {
+    comp = await composeTwoDoors({
+      policies: {
+        default: 'allow',
+        dry_run: false,
+        tool_revalidation: { enabled: false },
+        rules: [
+          {
+            name: 'pool-meta-calls',
+            match: { tool: 'get_*' },
+            action: 'rate_limit',
+            limits: { max_calls: 2, window: '60s', key: 'session' },
+          },
+        ],
+      } as PoliciesConfig,
+      session: { identity: [{ source: 'meta' }], on_unresolved: 'deny' },
+    })
+  })
+
+  afterAll(async () => {
+    await comp.close()
+  })
+
+  it('the same _meta clientInfo pools across doors exactly like a caller header', async () => {
+    const wireSession = await initializeLegacyDoor(comp.mcpUrl('alpha'))
+    const alpha1 = await sendMcpRequest(
+      comp.mcpUrl('alpha'),
+      'tools/call',
+      { name: 'get_weather', arguments: { city: 'Berlin' }, _meta: clientMeta('agent-x') },
+      'd3-a1',
+      { sessionId: wireSession },
+    )
+    expect(alpha1.body['error']).toBeUndefined()
+    const beta1 = await sendMcpRequest(comp.mcpUrl('beta'), 'tools/call', {
+      name: 'get_status',
+      arguments: {},
+      _meta: clientMeta('agent-x'),
+    })
+    expect(beta1.body['error']).toBeUndefined()
+
+    const beta2 = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {}, _meta: clientMeta('agent-x') },
+      'd3-b2',
+    )
+    const error = beta2.body['error'] as { code: number; message: string }
+    expect(error).toBeDefined()
+    expect(error.code).toBe(-32001)
+    expect(error.message).toBe('Rate limit exceeded for session:clientinfo:agent-x@1:rule:0')
+  })
+
+  it('a different _meta identity partitions — caller-class, not upstream-derived', async () => {
+    // agent-x's bucket is exhausted; agent-y's is untouched. Nothing the
+    // UPSTREAM sends can enter resolveSession — its inputs are the caller's
+    // headers and _meta only (the born-green non-influence half).
+    const other = await sendMcpRequest(
+      comp.mcpUrl('beta'),
+      'tools/call',
+      { name: 'get_status', arguments: {}, _meta: clientMeta('agent-y') },
+      'd3-b3',
+    )
+    expect(other.body['error']).toBeUndefined()
+  })
+})

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -611,6 +611,11 @@ dashboard:
           `${NAMED_HEADER}\npolicies:\n  rules:\n    - match:\n        tool: "*"\n      action: allow\n      requires: [deploy_ticket]\n${FOOTER}`,
           ['session.identity.1: session.identity includes "legacy_header"'],
         ],
+        [
+          'evidence.requires rule under the default legacy_header chain',
+          `${NAMED_HEADER}\npolicies:\n  rules:\n    - match:\n        tool: "*"\n      action: allow\n      evidence:\n        requires: [deploy_ticket]\n${FOOTER}`,
+          ['session.identity.1: session.identity includes "legacy_header"'],
+        ],
       ]
 
       it.each(rejectionCases)('rejects %s', async (_name, yamlBody, fragments) => {
@@ -624,6 +629,62 @@ dashboard:
           for (const fragment of fragments) {
             expect(stderr).toContain(fragment)
           }
+        } finally {
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
+
+      it('accepts a singular config with an evidence-gated rule under the default chain', async () => {
+        // The guard is named-mode only: singular mode keeps legacy_header
+        // beside evidence-gated rules (wire sessions are proxy-relayed 1:1
+        // there, so the forgeability concern the guard exists for is moot).
+        const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+        const configPath = join(dir, 'helio.yaml')
+        writeFileSync(
+          configPath,
+          'version: "1"\n' +
+            'upstream:\n' +
+            '  url: "http://localhost:8080/mcp"\n' +
+            'policies:\n' +
+            '  rules:\n' +
+            '    - match:\n' +
+            '        tool: "*"\n' +
+            '      action: allow\n' +
+            '      requires: [deploy_ticket]\n' +
+            FOOTER,
+        )
+        try {
+          const { code, stderr } = await runCli(['validate', '-c', configPath])
+          expect(code).toBe(0)
+          expect(stderr).toContain(`Config is valid: ${configPath} (1 policy rule, 0 budgets)`)
+        } finally {
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
+
+      it('accepts a named config with an evidence.requires rule on a header-only chain', async () => {
+        const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
+        const configPath = join(dir, 'helio.yaml')
+        writeFileSync(
+          configPath,
+          `${NAMED_HEADER}\n` +
+            'session:\n' +
+            '  identity:\n' +
+            '    - source: header\n' +
+            '      name: x-helio-session-id\n' +
+            'policies:\n' +
+            '  rules:\n' +
+            '    - match:\n' +
+            '        tool: "*"\n' +
+            '      action: allow\n' +
+            '      evidence:\n' +
+            '        requires: [deploy_ticket]\n' +
+            FOOTER,
+        )
+        try {
+          const { code, stderr } = await runCli(['validate', '-c', configPath])
+          expect(code).toBe(0)
+          expect(stderr).toContain(`Config is valid: ${configPath} (1 policy rule, 0 budgets)`)
         } finally {
           rmSync(dir, { recursive: true, force: true })
         }

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -10,6 +10,10 @@ import { AuditStore } from './audit/store.js'
 import type { AuditRecord } from './audit/types.js'
 import { BudgetLedger } from './budget/ledger.js'
 import type { BudgetLedgerRow } from './budget/engine.js'
+import {
+  startSessionEnforcingHttpMcpServer,
+  startModernOnlyHttpMcpServer,
+} from './__tests__/helpers/mcp-test-server.js'
 
 const CLI_PATH = join(import.meta.dirname, '../dist/cli.js')
 
@@ -1144,6 +1148,184 @@ dashboard:
       } finally {
         if (child.exitCode === null) child.kill('SIGKILL')
         rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    it('boots a mixed-era two-HTTP-upstream config with per-door era detection (issue #296)', async () => {
+      // Two REAL HTTP fixtures — one legacy stateful, one 2026-07-28-only —
+      // served by the SHIPPED binary. The smoke covers what the in-process
+      // suite cannot: dist/cli.js composing two real HTTP upstreams, with
+      // both door-tagged era lines on real process stderr.
+      const legacy = await startSessionEnforcingHttpMcpServer()
+      const modern = await startModernOnlyHttpMcpServer()
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-mixed-era-'))
+      const configPath = join(dir, 'helio.yaml')
+      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      writeFileSync(
+        configPath,
+        `
+version: "1"
+upstreams:
+  - name: alpha
+    url: "http://127.0.0.1:${String(legacy.port)}/mcp"
+  - name: beta
+    url: "http://127.0.0.1:${String(modern.port)}/mcp"
+listen:
+  port: ${String(listenPort)}
+  host: 127.0.0.1
+dashboard:
+  enabled: false
+policies:
+  default: allow
+  rules:
+    - name: deny-probe
+      match:
+        tool: "denied_probe"
+      action: deny
+audit:
+  path: "${join(dir, 'audit.db')}"
+`,
+      )
+      const baseUrl = `http://127.0.0.1:${String(listenPort)}`
+      const child = spawn('node', [CLI_PATH, 'start', '-c', configPath], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+      })
+      let stderr = ''
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf-8')
+      })
+      try {
+        await Promise.race([
+          waitForProxyHealth(baseUrl, 8_000),
+          new Promise<never>((_, reject) => {
+            child.on('close', (code) => {
+              reject(
+                new Error(`helio start exited ${String(code)} before healthy. stderr:\n${stderr}`),
+              )
+            })
+          }),
+        ])
+
+        // One governed call per door. The legacy door needs its fixture's
+        // handshake: initialize, then the minted wire session on the call.
+        const initRes = await fetch(`${baseUrl}/mcp/alpha`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2025-06-18',
+              capabilities: {},
+              clientInfo: { name: 'cli-smoke', version: '1' },
+            },
+          }),
+        })
+        expect(initRes.status).toBe(200)
+        const wireSession = initRes.headers.get('mcp-session-id')
+        expect(wireSession).toBeTruthy()
+        await fetch(`${baseUrl}/mcp/alpha`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'mcp-session-id': wireSession as string,
+          },
+          body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+        })
+        const alphaCall = await fetch(`${baseUrl}/mcp/alpha`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'mcp-session-id': wireSession as string,
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/call',
+            params: { name: 'get_weather', arguments: { city: 'Berlin' } },
+          }),
+        })
+        expect(alphaCall.status).toBe(200)
+        const alphaBody = (await alphaCall.json()) as {
+          error?: unknown
+          result?: { content: Array<{ text: string }> }
+        }
+        expect(alphaBody.error).toBeUndefined()
+        expect(alphaBody.result?.content[0]?.text).toBe('Sunny, 22°C in Berlin')
+
+        const betaCall = await fetch(`${baseUrl}/mcp/beta`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-helio-session-id': 'cli-smoke-s1',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 3,
+            method: 'tools/call',
+            params: { name: 'get_status', arguments: {} },
+          }),
+        })
+        expect(betaCall.status).toBe(200)
+        const betaBody = (await betaCall.json()) as {
+          error?: unknown
+          result?: { content: Array<{ text: string }> }
+        }
+        expect(betaBody.error).toBeUndefined()
+        expect(betaBody.result?.content[0]?.text).toContain('get_status executed')
+
+        // One deny probe per door: the mounts serve the GOVERNED forwarders.
+        for (const [door, id] of [
+          ['alpha', 4],
+          ['beta', 5],
+        ] as const) {
+          const deniedRes = await fetch(`${baseUrl}/mcp/${door}`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-helio-session-id': 'cli-smoke-s1',
+            },
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id,
+              method: 'tools/call',
+              params: { name: 'denied_probe', arguments: {} },
+            }),
+          })
+          const deniedBody = (await deniedRes.json()) as {
+            error?: { code: number; data?: { blocked?: boolean; rule?: string } }
+          }
+          expect(deniedBody.error?.code).toBe(-32001)
+          expect(deniedBody.error?.data?.blocked).toBe(true)
+          expect(deniedBody.error?.data?.rule).toBe('deny-probe')
+        }
+
+        // Both door-tagged era lines on the shipped binary's real stderr.
+        expect(stderr).toContain(
+          '[helio][alpha] Upstream MCP era detected: legacy (initialize handshake)',
+        )
+        expect(stderr).toContain(
+          '[helio][beta] Upstream MCP era detected: modern (2026-07-28, via server/discover)',
+        )
+
+        // Clean shutdown.
+        const exitCode = await new Promise<number | null>((resolve) => {
+          if (child.exitCode !== null) {
+            resolve(child.exitCode)
+            return
+          }
+          child.on('close', (code) => {
+            resolve(code)
+          })
+          child.kill('SIGTERM')
+        })
+        expect(exitCode).toBe(0)
+      } finally {
+        if (child.exitCode === null) child.kill('SIGKILL')
+        rmSync(dir, { recursive: true, force: true })
+        await legacy.close()
+        await modern.close()
       }
     }, 15_000)
 

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -202,6 +202,14 @@ export interface CreateMultiAppOptions {
    * attribute it. Enforcement does not depend on it.
    */
   onHeaderMismatch?: (rejection: HeaderMismatchRejection, upstreamName: string) => void
+  /**
+   * @internal Test seam for the per-door concurrent-session cap on the
+   * `/sse/<name>` mounts (issue #232's cap, per-route by construction), so
+   * tests need not mint 1024 real streams per door. The same value goes to
+   * every door's route; the session maps stay per-route-instance. Not wired
+   * to config — absent means the hardcoded 1024.
+   */
+  sse?: { readonly maxConcurrentSessions?: number }
 }
 
 /**
@@ -279,6 +287,7 @@ export function createMultiApp(
         allowedOrigins,
         session,
         routeLabel: `/sse/${name}`,
+        maxConcurrentSessions: options?.sse?.maxConcurrentSessions,
       }),
     )
   }


### PR DESCRIPTION
## Description

Adds the two-upstream end-to-end suite for the multi-upstream milestone: two real MCP servers (one legacy stateful with sessions and SSE framing, one 2026-07-28-only) composed behind one `createMultiApp` on a real socket, governed per door the way `cli.ts` governs, driven through both mounts.

The suite proves the isolation claims (era caches classify per door simultaneously, annotation caches and drift baselines gate per door, upstream-qualified tool limit buckets keep separate counts for same-named tools, per-door `/sse` session caps, audit attribution assigned by routing under adversarial identity inputs), the deliberate-sharing claims (an un-scoped session-keyed limit pools one session's calls across doors, a budget pot spans both doors with contributor `upstreams` scoping filtering correctly, a cross-upstream `requires` dependency satisfies across doors), and the identity claims (the named-mode legacy_header/evidence guard matrix at the CLI, `on_unresolved: anonymous` pooling limits and budgets with no evidence channel, the `meta` identity source behaving as caller-class input). Pooled claims run beside permanent scoped negative controls driving identical call sequences with the opposite outcome. A CLI smoke boots the shipped binary against both fixtures and pins the door-tagged era lines on real process stderr.

The only product change is the per-door `/sse` cap seam: `CreateMultiAppOptions.sse.maxConcurrentSessions` (`@internal`, absent means the hardcoded 1024, `createMultiApp` only), threaded into each per-entry route so the cap is testable through the real mounts without minting 1024 streams per door.

Closes #296

## Type of Change

- [x] Tests (regression net; no runtime behavior change - the only product touch is a dark `@internal` test seam defaulting to today's constant)

## Packages Affected

- [x] `packages/proxy`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode - no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `pnpm build` (the CLI tests drive `dist/cli.js`)
2. `cd packages/proxy && pnpm exec vitest run src/__tests__/integration-two-upstream.test.ts` (the suite, 25 tests)
3. `pnpm exec vitest run src/cli.test.ts` (guard matrix rows + the mixed-era smoke)
4. Full gates: `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm docs:check:samples`

## Additional Context

- Full-workspace `pnpm test` on this branch hit only the two long-documented #271 faces (the benchmark p95 bound and the sse-forwarder ECONNRESET), both in files this branch does not touch and both green on isolated re-run; the twelfth occurrence is commented on #271 per the accepted isolated-re-run mitigation.
- The born-green isolation pins (shared era cache, un-partitioned tool bucket) were verified with uncommitted product mutations run locally to watch the tests fail, then reverted.
- No CHANGELOG entry: the suite is invisible to operators and the seam is dark; no touched file is drift-listed.