### PR TITLE
feat(config): make upstream.url optional for stdio transports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,7 @@ CI runs the same checks, plus a full repository secret scan (`pnpm secrets:scan`
 ```yaml
 version: '1'
 upstream:
-  url: 'http://localhost:8080/mcp' # required
+  url: 'http://localhost:8080/mcp' # required when transport is streamable-http or sse
   transport: 'streamable-http' # streamable-http | sse | stdio
   command: 'node' # required when transport is stdio
   args: ['server.js'] # stdio only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,16 @@ Maintainer notes:
 
 ### Changed
 
+- `upstream.url` is now optional when `transport` is `stdio` (#313):
+  the stdio forwarder spawns `command` and never reads a URL, so a
+  stdio upstream (singular or any named `upstreams:` entry) no longer
+  needs a placeholder. A present value is still accepted and ignored,
+  so existing placeholder-carrying configs validate unchanged. The
+  HTTP transports still require the field, and a missing `url` now
+  fails with a message naming the transport
+  (`"url" is required when transport is "streamable-http"`). For
+  library embedders, the inferred `HelioConfig` upstream shape marks
+  `url` optional.
 - First use of the ratified additive-migration path (#292): a v0.12.0
   audit database missing only the new `upstream` column is migrated in
   place on first open with a single `ALTER TABLE` and one stderr

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,7 +131,7 @@ merged across upstreams — each named upstream is served at its own
 
 | Field              | Type     | Required    | Default           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | ------------------ | -------- | ----------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `url`              | string   | Yes         | —                 | URL of the upstream MCP server (e.g. `http://localhost:8080/mcp`).                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `url`              | string   | Conditional | —                 | URL of the upstream MCP server (e.g. `http://localhost:8080/mcp`). **Required** when `transport` is `streamable-http` or `sse` (the default is `streamable-http`); optional and ignored for `stdio`.                                                                                                                                                                                                                                                                                        |
 | `transport`        | string   | No          | `streamable-http` | Transport protocol: `streamable-http`, `sse`, or `stdio`.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `protocol_version` | string   | No          | `auto`            | MCP revision spoken to the upstream: `auto` (probe and detect, see [era detection](#upstream-mcp-era-detection)), `2025-06-18` (pin legacy), or `2026-07-28` (pin modern; requires `transport: streamable-http`). A dated pin trusts the operator and skips era probing entirely — it exists for upstreams the probe cannot classify, such as a modern-only server gated behind per-client `Authorization` pass-through, where the probe is refused forever while relayed requests succeed. |
 | `command`          | string   | Conditional | —                 | Command to spawn the MCP server. **Required** when `transport` is `stdio`.                                                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -155,10 +155,9 @@ upstream:
   transport: stdio
   command: npx
   args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp']
-  url: 'stdio://'
 ```
 
-> **Note:** The `url` field is required by the schema but ignored when `transport` is `stdio`. Any value (e.g. `stdio://`) works as a placeholder.
+> **Note:** The `url` field may be omitted when `transport` is `stdio`; a present value (e.g. a legacy `stdio://` placeholder) is accepted and ignored.
 
 #### Static request headers
 
@@ -260,23 +259,20 @@ Each entry accepts every field of the [`upstream`](#upstream) section with
 identical semantics, defaults, and validation — the entry schema reuses the
 singular schema and its refinements verbatim — plus `name`:
 
-| Field              | Type     | Required    | Default           | Description                                                                                                                                                                                               |
-| ------------------ | -------- | ----------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`             | string   | Yes         | —                 | Unique entry name; becomes the door path (`/mcp/<name>`, `/sse/<name>`) and the limiter/audit attribution key. Letters, digits, `_` and `-` only; 1–64 characters.                                        |
-| `url`              | string   | Yes         | —                 | URL of this entry's upstream MCP server (e.g. `http://localhost:8080/mcp`).                                                                                                                               |
-| `transport`        | string   | No          | `streamable-http` | Transport protocol: `streamable-http`, `sse`, or `stdio` — identical to [`upstream.transport`](#upstream).                                                                                                |
-| `protocol_version` | string   | No          | `auto`            | MCP revision spoken to this entry's upstream — identical to [`upstream.protocol_version`](#upstream). Each entry probes, pins, and caches its own era (see [era detection](#upstream-mcp-era-detection)). |
-| `command`          | string   | Conditional | —                 | Command to spawn the MCP server. **Required** when `transport` is `stdio`.                                                                                                                                |
-| `args`             | string[] | No          | —                 | Arguments passed to the `command` (stdio only).                                                                                                                                                           |
-| `connect_timeout`  | duration | No          | `10s`             | Timeout for establishing SSE upstream connections.                                                                                                                                                        |
-| `request_timeout`  | duration | No          | `30s`             | Timeout for upstream HTTP/SSE POST requests.                                                                                                                                                              |
-| `forward_headers`  | string[] | No          | `[]`              | Explicit allowlist of caller `x-*` headers to forward to this entry's upstream.                                                                                                                           |
-| `headers`          | object   | No          | `{}`              | Static headers sent on every request to this entry's upstream — same `${VAR}` interpolation and reserved-header rejections as [`upstream.headers`](#static-request-headers).                              |
+| Field              | Type     | Required    | Default           | Description                                                                                                                                                                                                   |
+| ------------------ | -------- | ----------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`             | string   | Yes         | —                 | Unique entry name; becomes the door path (`/mcp/<name>`, `/sse/<name>`) and the limiter/audit attribution key. Letters, digits, `_` and `-` only; 1–64 characters.                                            |
+| `url`              | string   | Conditional | —                 | URL of this entry's upstream MCP server (e.g. `http://localhost:8080/mcp`). **Required** when `transport` is `streamable-http` or `sse` (the default is `streamable-http`); optional and ignored for `stdio`. |
+| `transport`        | string   | No          | `streamable-http` | Transport protocol: `streamable-http`, `sse`, or `stdio` — identical to [`upstream.transport`](#upstream).                                                                                                    |
+| `protocol_version` | string   | No          | `auto`            | MCP revision spoken to this entry's upstream — identical to [`upstream.protocol_version`](#upstream). Each entry probes, pins, and caches its own era (see [era detection](#upstream-mcp-era-detection)).     |
+| `command`          | string   | Conditional | —                 | Command to spawn the MCP server. **Required** when `transport` is `stdio`.                                                                                                                                    |
+| `args`             | string[] | No          | —                 | Arguments passed to the `command` (stdio only).                                                                                                                                                               |
+| `connect_timeout`  | duration | No          | `10s`             | Timeout for establishing SSE upstream connections.                                                                                                                                                            |
+| `request_timeout`  | duration | No          | `30s`             | Timeout for upstream HTTP/SSE POST requests.                                                                                                                                                                  |
+| `forward_headers`  | string[] | No          | `[]`              | Explicit allowlist of caller `x-*` headers to forward to this entry's upstream.                                                                                                                               |
+| `headers`          | object   | No          | `{}`              | Static headers sent on every request to this entry's upstream — same `${VAR}` interpolation and reserved-header rejections as [`upstream.headers`](#static-request-headers).                                  |
 
-> **Note:** As in the singular form, an entry's `url` is required by the
-> schema but ignored when `transport` is `stdio`. Any value (e.g. `stdio://`)
-> works as a placeholder. Issue #313 tracks lifting the requirement for
-> stdio entries.
+> **Note:** As in the singular form, a stdio entry may omit `url`.
 
 Names may only contain letters, digits, `_` and `-` (1–64 characters), must
 be unique within the list, and the list itself must be non-empty. The
@@ -908,7 +904,7 @@ On failure, Helio reports the exact path and error:
 
 ```
 Invalid config: Invalid configuration (1 error)
-  upstream.url: Invalid input: expected string, received undefined
+  upstream.url: "url" is required when transport is "streamable-http"
 ```
 
 The whole file is strict, at every level: an unknown or misplaced key — a `rules:` block at the top level instead of nested under `policies:`, a singular `policy:` or `budget:` typo, a misspelled field inside a section like `upstream.request_timout` or `dashboard.api_secrett`, or an unknown key inside an approval channel entry — is a hard error naming the key and its path, not a silently ignored no-op. `helio start` refuses to boot on such a config, and a hot reload that introduces one is rejected while the proxy keeps its current configuration (see [Hot Reload](#hot-reload)).

--- a/packages/proxy/scripts/benchmark.ts
+++ b/packages/proxy/scripts/benchmark.ts
@@ -328,7 +328,7 @@ async function main(): Promise<void> {
   const config1 = makeConfig({
     upstream: { url: upstreamUrl, transport: 'streamable-http' },
   })
-  const forwarder1 = new UpstreamForwarder({ url: config1.upstream.url })
+  const forwarder1 = new UpstreamForwarder({ url: config1.upstream.url as string })
   const app1 = createApp(config1, forwarder1)
   const proxy1 = startOnDynamicPort(app1)
   const proxyUrl1 = `http://127.0.0.1:${String(proxy1.port)}/mcp`
@@ -363,7 +363,7 @@ async function main(): Promise<void> {
       ],
     },
   })
-  const forwarder2 = new UpstreamForwarder({ url: config2.upstream.url })
+  const forwarder2 = new UpstreamForwarder({ url: config2.upstream.url as string })
   const { policy } = compilePolicies(config2.policies)
   const auditStore = new AuditStore({
     path: ':memory:',

--- a/packages/proxy/src/__tests__/e2e-python-sdk-sideband.test.ts
+++ b/packages/proxy/src/__tests__/e2e-python-sdk-sideband.test.ts
@@ -91,7 +91,7 @@ e2eDescribe('E2E: Python SDK → sideband → proxy → evidence grounding', () 
       },
     })
 
-    const forwarder = new StreamableHttpForwarder({ url: config.upstream.url })
+    const forwarder = new StreamableHttpForwarder({ url: config.upstream.url as string })
     const { policy } = compilePolicies(config.policies)
     const governed = new GovernedForwarder(forwarder, policy, { evidenceStore })
     const app = createApp(config, governed)

--- a/packages/proxy/src/__tests__/integration-governance.test.ts
+++ b/packages/proxy/src/__tests__/integration-governance.test.ts
@@ -53,7 +53,7 @@ function createGovernedProxyWithAudit(
     environment: options?.environment,
   })
 
-  const rawForwarder = new StreamableHttpForwarder({ url: config.upstream.url })
+  const rawForwarder = new StreamableHttpForwarder({ url: config.upstream.url as string })
   const { policy } = compilePolicies(config.policies)
 
   const auditStore = new AuditStore({
@@ -365,7 +365,7 @@ policies:
       upstream: { url: upstreamUrl, transport: 'streamable-http' },
       policies: { default: 'allow', rules: [] },
     })
-    const rawForwarder = new StreamableHttpForwarder({ url: config.upstream.url })
+    const rawForwarder = new StreamableHttpForwarder({ url: config.upstream.url as string })
     const { policy } = compilePolicies(config.policies)
 
     auditStore = new AuditStore({

--- a/packages/proxy/src/__tests__/integration-http.test.ts
+++ b/packages/proxy/src/__tests__/integration-http.test.ts
@@ -27,7 +27,7 @@ describe('Streamable HTTP integration', () => {
     })
 
     const forwarder = new StreamableHttpForwarder({
-      url: config.upstream.url,
+      url: config.upstream.url as string,
       headers: {},
     })
 
@@ -191,7 +191,7 @@ describe('Streamable HTTP integration', () => {
       },
     })
 
-    const forwarder = new StreamableHttpForwarder({ url: config.upstream.url })
+    const forwarder = new StreamableHttpForwarder({ url: config.upstream.url as string })
     const app = createApp(config, forwarder)
     const badProxy = startOnDynamicPort(app)
 
@@ -227,7 +227,7 @@ describe('Streamable HTTP integration', () => {
         transport: 'streamable-http',
       },
     })
-    const forwarder = new StreamableHttpForwarder({ url: config.upstream.url })
+    const forwarder = new StreamableHttpForwarder({ url: config.upstream.url as string })
     const app = createApp(config, forwarder)
     const proxy = startOnDynamicPort(app)
 
@@ -281,7 +281,7 @@ describe('Policy evaluation (Streamable HTTP)', () => {
       },
       policies: policiesConfig as ReturnType<typeof makeConfig>['policies'],
     })
-    const rawForwarder = new StreamableHttpForwarder({ url: config.upstream.url })
+    const rawForwarder = new StreamableHttpForwarder({ url: config.upstream.url as string })
     const { policy } = compilePolicies(config.policies)
     const governed = new GovernedForwarder(rawForwarder, policy, {
       environment: config.environment,
@@ -445,7 +445,7 @@ describe('Audit response capture (Streamable HTTP)', () => {
       },
       policies: policiesConfig as ReturnType<typeof makeConfig>['policies'],
     })
-    const rawForwarder = new StreamableHttpForwarder({ url: config.upstream.url })
+    const rawForwarder = new StreamableHttpForwarder({ url: config.upstream.url as string })
     const { policy } = compilePolicies(config.policies)
 
     const auditStore = new AuditStore({

--- a/packages/proxy/src/cli-forwarder.ts
+++ b/packages/proxy/src/cli-forwarder.ts
@@ -27,7 +27,7 @@ export async function createForwarderFromConfig(
       // upstream.connect_timeout does not apply to this transport — the
       // initialize handshake is bounded by request_timeout instead.
       const http = new StreamableHttpForwarder({
-        url: config.upstream.url,
+        url: config.upstream.url as string,
         headers: config.upstream.headers,
         requestTimeoutMs: parseDuration(config.upstream.request_timeout),
         protocolVersion: config.upstream.protocol_version,
@@ -47,7 +47,7 @@ export async function createForwarderFromConfig(
     }
     case 'sse': {
       const sse = new SseUpstreamForwarder({
-        url: config.upstream.url,
+        url: config.upstream.url as string,
         headers: config.upstream.headers,
         connectTimeoutMs: parseDuration(config.upstream.connect_timeout),
         requestTimeoutMs: parseDuration(config.upstream.request_timeout),

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -169,7 +169,6 @@ function writeStdioStartConfig(requestTimeout: string): {
     `
 version: "1"
 upstream:
-  url: "http://127.0.0.1:1/mcp"
   transport: stdio
   command: "node"
   args:
@@ -596,6 +595,11 @@ dashboard:
           ['upstreams.0.command: "command" is required when transport is "stdio"'],
         ],
         [
+          'entry missing url on the default transport',
+          `version: "1"\nupstreams:\n  - name: files\n${FOOTER}`,
+          ['upstreams.0.url: "url" is required when transport is "streamable-http"'],
+        ],
+        [
           'rule naming an unknown upstream',
           `${NAMED_HEADER}\npolicies:\n  rules:\n    - match:\n        tool: "*"\n        upstreams: [ghost]\n      action: deny\n${FOOTER}`,
           ['policies.rules.0.match.upstreams.0: Rule names upstream "ghost"'],
@@ -777,9 +781,8 @@ dashboard:
       const configPath = join(dir, 'helio.yaml')
 
       // upstream present but upstream.url omitted → exactly one error, on the
-      // scalar. Pins the rendered CLI output so a future Zod message change (as
-      // happened on the v3→v4 upgrade) fails here instead of silently drifting
-      // from docs/configuration.md.
+      // scalar. Pins the rendered CLI output so a future message change fails
+      // here instead of silently drifting from docs/configuration.md.
       writeFileSync(
         configPath,
         'version: "1"\nupstream:\n  transport: streamable-http\ndashboard:\n  enabled: false\n',
@@ -789,7 +792,9 @@ dashboard:
         const { code, stderr } = await runCli(['validate', '-c', configPath])
         expect(code).toBe(1)
         expect(stderr).toContain('Invalid config: Invalid configuration (1 error)')
-        expect(stderr).toContain('upstream.url: Invalid input: expected string, received undefined')
+        expect(stderr).toContain(
+          'upstream.url: "url" is required when transport is "streamable-http"',
+        )
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }
@@ -2234,6 +2239,11 @@ audit:
         // If stdio ignored request_timeout, this would hang near the default
         // 30s and trip the 5s client timeout above.
         expect(elapsedMs).toBeLessThan(4_000)
+
+        // The url-less singular summary line (issue #313). It prints after the
+        // listen banner, so it can race the ready marker — asserted here, after
+        // the health wait, where stderr has kept accumulating.
+        expect(stderr).toContain('Upstream: node (stdio)')
       } finally {
         if (child.exitCode === null && child.signalCode === null) {
           child.kill('SIGTERM')

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -627,13 +627,13 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
       if (entry.transport === 'stdio') {
         console.error(`Upstream[${entry.name}]: ${entry.command ?? ''} (stdio)`)
       } else {
-        console.error(`Upstream[${entry.name}]: ${entry.url} (${entry.transport})`)
+        console.error(`Upstream[${entry.name}]: ${entry.url ?? ''} (${entry.transport})`)
       }
     }
   } else if (config.upstream.transport === 'stdio') {
     console.error(`Upstream: ${config.upstream.command ?? ''} (stdio)`)
   } else {
-    console.error(`Upstream: ${config.upstream.url} (${config.upstream.transport})`)
+    console.error(`Upstream: ${config.upstream.url ?? ''} (${config.upstream.transport})`)
   }
   console.error(`Audit: ${config.audit.path} (retention: ${config.audit.retention})`)
   if (sidebandHandle) {

--- a/packages/proxy/src/config/schema.test.ts
+++ b/packages/proxy/src/config/schema.test.ts
@@ -314,6 +314,51 @@ describe('helioConfigSchema', () => {
         },
       ])
     })
+
+    it('emits every co-firable issue family, url first, for a url-less sse upstream (issue #313)', () => {
+      // The HTTP-side sibling of the pin above: url and protocol_version can
+      // co-fire only on sse (the modern pin never fires on streamable-http),
+      // so this is the one fixture that observes the url arm's position among
+      // every family it can co-fire with.
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          upstream: {
+            transport: 'sse',
+            protocol_version: '2026-07-28',
+            forward_headers: ['nope'],
+            headers: { 'content-type': 'y' },
+          },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(
+        result.error.issues.map((i) => ({ code: i.code, path: i.path, message: i.message })),
+      ).toStrictEqual([
+        {
+          code: 'custom',
+          path: ['upstream', 'url'],
+          message: '"url" is required when transport is "sse"',
+        },
+        {
+          code: 'custom',
+          path: ['upstream', 'protocol_version'],
+          message:
+            'protocol_version "2026-07-28" requires transport "streamable-http" — ' +
+            'the SSE upstream transport is the deprecated legacy transport.',
+        },
+        {
+          code: 'custom',
+          path: ['upstream', 'forward_headers', 0],
+          message: 'Forwarded caller headers must start with "x-"',
+        },
+        {
+          code: 'custom',
+          path: ['upstream', 'headers', 'content-type'],
+          message: 'upstream.headers must not set reserved header "content-type"',
+        },
+      ])
+    })
   })
 
   describe('upstreamNameSchema (issue #293)', () => {
@@ -652,15 +697,39 @@ describe('helioConfigSchema', () => {
     })
 
     it('forwards singular-arm issues verbatim through the dispatch', () => {
-      // The singular arm's error shape is the pre-#293 one — pinned so the
-      // dispatch encoding cannot bury or reword singular errors.
+      // Pinned so the dispatch encoding cannot bury or reword singular errors.
       const result = helioConfigSchema.safeParse(minimalConfig({ upstream: {} }))
       expect(result.success).toBe(false)
       if (result.success) return
       expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
         {
           path: ['upstream', 'url'],
-          message: 'Invalid input: expected string, received undefined',
+          message: '"url" is required when transport is "streamable-http"',
+        },
+      ])
+    })
+
+    it('accepts a stdio entry with command and no url (issue #313)', () => {
+      const result = helioConfigSchema.safeParse(
+        namedMinimal({
+          upstreams: [{ name: 'files', transport: 'stdio', command: 'node' }],
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('forwards the named sse missing-url issue with its full path (issue #313)', () => {
+      const result = helioConfigSchema.safeParse(
+        namedMinimal({
+          upstreams: [{ name: 'files', transport: 'sse' }],
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['upstreams', 0, 'url'],
+          message: '"url" is required when transport is "sse"',
         },
       ])
     })
@@ -1285,9 +1354,36 @@ describe('helioConfigSchema', () => {
   // -------------------------------------------------------------------------
 
   describe('upstream', () => {
-    it('rejects missing url', () => {
+    it('rejects missing url for sse transport with the transport-naming message (issue #313)', () => {
       const result = helioConfigSchema.safeParse(minimalConfig({ upstream: { transport: 'sse' } }))
       expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['upstream', 'url'],
+          message: '"url" is required when transport is "sse"',
+        },
+      ])
+    })
+
+    it('reports both the missing url and sibling violations in one parse (issue #313)', () => {
+      // Pre-#313 the missing-url failure happened at base object parse, which
+      // masked every superRefine family until the url was supplied.
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ upstream: { forward_headers: ['nope'] } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      const issues = result.error.issues.map((i) => ({ path: i.path, message: i.message }))
+      expect(issues).toHaveLength(2)
+      expect(issues).toContainEqual({
+        path: ['upstream', 'url'],
+        message: '"url" is required when transport is "streamable-http"',
+      })
+      expect(issues).toContainEqual({
+        path: ['upstream', 'forward_headers', 0],
+        message: 'Forwarded caller headers must start with "x-"',
+      })
     })
 
     it('rejects stdio transport without command', () => {
@@ -1311,6 +1407,55 @@ describe('helioConfigSchema', () => {
         }),
       )
       expect(result.success).toBe(true)
+    })
+
+    it('accepts stdio transport with command and no url (issue #313)', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          upstream: {
+            transport: 'stdio',
+            command: 'node',
+            args: ['server.js'],
+          },
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('reports the missing command, not url, for a stdio upstream with neither (issue #313)', () => {
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({ upstream: { transport: 'stdio' } }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['upstream', 'command'],
+          message: '"command" is required when transport is "stdio"',
+        },
+      ])
+    })
+
+    it('reports sibling violations for a url-less stdio upstream (issue #313)', () => {
+      // The operator is told about the real problem, never about a field the
+      // stdio transport does not use.
+      const result = helioConfigSchema.safeParse(
+        minimalConfig({
+          upstream: {
+            transport: 'stdio',
+            command: 'node',
+            forward_headers: ['nope'],
+          },
+        }),
+      )
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues.map((i) => ({ path: i.path, message: i.message }))).toStrictEqual([
+        {
+          path: ['upstream', 'forward_headers', 0],
+          message: 'Forwarded caller headers must start with "x-"',
+        },
+      ])
     })
 
     it('accepts allowlisted forwarded caller headers that start with x-', () => {

--- a/packages/proxy/src/config/schema.ts
+++ b/packages/proxy/src/config/schema.ts
@@ -74,7 +74,7 @@ const protocolVersionSchema = z.enum(['auto', '2025-06-18', '2026-07-28'])
 
 const upstreamObjectSchema = z
   .object({
-    url: z.string(),
+    url: z.string().optional(),
     transport: transportSchema.default('streamable-http'),
     protocol_version: protocolVersionSchema.default('auto'),
     command: z.string().optional(),
@@ -98,6 +98,14 @@ function upstreamEntryChecks(
       code: 'custom',
       path: ['command'],
       message: '"command" is required when transport is "stdio"',
+    })
+  }
+
+  if (data.transport !== 'stdio' && data.url === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['url'],
+      message: `"url" is required when transport is "${data.transport}"`,
     })
   }
 
@@ -1433,7 +1441,7 @@ export type NamedHelioConfig = z.output<typeof namedConfigSchema>
 /**
  * Route a raw config document to exactly one mode arm (issue #293). A plain
  * z.union cannot do this job: zod's arm selection is heuristic, and a common
- * mistake like a named entry missing `url` surfaces as a buried
+ * mistake like a named entry missing `name` surfaces as a buried
  * "(top level): Invalid input" instead of its real issue. The dispatch owns
  * the exactly-one-of contract and forwards the chosen arm's issues verbatim,
  * so every error keeps its real path and message.


### PR DESCRIPTION
## Description

`upstream.url` was required even when `transport: stdio`, where the
forwarder spawns `command` and never reads a URL, so every stdio config
carried a placeholder (`url: "unused"`) that read like dead config. The
shared per-entry checks now mirror the existing stdio rule in the
opposite direction: `url` is required only when the transport is
`streamable-http` or `sse`, with a message naming the operator's actual
transport, and it may be omitted for stdio. Because the checks are
shared, the fix lands identically in the singular `upstream:` form and
in every named `upstreams:` entry. A present value on stdio is still
accepted and ignored, so existing placeholder-carrying configs keep
validating unchanged.

The missing-url failure moves from base object parse to the shared
checks, which makes error output strictly more accurate for invalid
configs: a url-less config now surfaces sibling violations the base
failure used to mask, and a stdio config missing both fields reports
the missing `command` instead of a field stdio never used. The new
message, its rendered singular and named paths, the check's position
among the co-firable issue families, and the placeholder tolerance are
all pinned by tests in both directions. The configuration reference
flips both `url` rows to Conditional, the stdio example drops its
placeholder line, and the validation quote was captured live from the
built CLI. For library embedders, the inferred `HelioConfig` upstream
shape now marks `url` optional.

Out of scope and not ridden here, per the issue's own suggestion:
warning when a stdio entry sets a `url` that will be ignored. To be
considered as a separate filing.

Closes #313

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification (the `as string` casts follow the existing `command as string` posture at proven-transport sites)
- [x] I have added or updated tests for my changes (eleven behavior pins added or upgraded in both directions: absence accepted, requirement kept with the exact message, tolerance unchanged; `pnpm docs:check:samples` 90 checked / 0 failed)
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)