### PR TITLE
fix(proxy): name both config forms in the unreachable-upstream hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,11 @@ Maintainer notes:
   the wire. This covers the constructor and caller vectors reachable
   through direct library use; yaml config is rejected at validation
   per the breaking entry above.
+- The unreachable-upstream hint now names both config forms (#320):
+  the remedy reads `set upstream.url (or upstreams[].url) in helio.yaml`
+  instead of naming only `upstream.url`, a field named-mode configs
+  cannot contain. The message head is unchanged; the new tail appears
+  in both singular and named modes.
 
 ## [0.12.0] - 2026-08-17
 

--- a/packages/proxy/src/budget/engine.ts
+++ b/packages/proxy/src/budget/engine.ts
@@ -383,8 +383,10 @@ export class BudgetEngine {
 
     // One context for every contributor predicate of this call. Only
     // toolName/toolArguments exist here — the charge context has no
-    // annotations, environment, or metadata, which is why the contributor
-    // match schema admits only tool + input.
+    // annotations, environment, or metadata, so tool and input are the
+    // only contributor matchers evaluated through it. The match schema's
+    // third field, upstreams (issue #293), is tested against ctx.upstream
+    // directly in the find() below, never through this context.
     const matchCtx = {
       toolName: ctx.toolName,
       ...(ctx.toolArguments !== undefined && { toolArguments: ctx.toolArguments }),

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -1367,6 +1367,7 @@ audit:
         expect(result.code).toBe(1)
         expect(result.stderr).toContain('upstream "backend": ')
         expect(result.stderr).toContain('is unreachable (ECONNREFUSED)')
+        expect(result.stderr).toContain('(or upstreams[].url)')
         expect(result.stderr).not.toContain('Unhandled promise rejection')
       } finally {
         rmSync(dir, { recursive: true, force: true })
@@ -1471,6 +1472,7 @@ audit:
         const result = await runCli(['start', '-c', configPath])
         expect(result.code).toBe(1)
         expect(result.stderr).toContain('is unreachable (ECONNREFUSED)')
+        expect(result.stderr).toContain('(or upstreams[].url)')
         // Singular mode: the underlying message alone — no minted upstream
         // name, no crash dump.
         expect(result.stderr).not.toContain('upstream "')

--- a/packages/proxy/src/upstream/connection-error.test.ts
+++ b/packages/proxy/src/upstream/connection-error.test.ts
@@ -20,6 +20,16 @@ describe('describeUnreachableUpstream', () => {
     expect(result?.message).toContain('upstream.url')
   })
 
+  it('pins the full ECONNREFUSED message, naming both config forms (issue #320)', () => {
+    const result = describeUnreachableUpstream(fetchFailed('ECONNREFUSED'), URL)
+    expect(result?.message).toBe(
+      `Upstream MCP server at ${URL} is unreachable (ECONNREFUSED) — is it running? ` +
+        'Helio proxies an existing MCP server: set upstream.url (or upstreams[].url) in ' +
+        'helio.yaml to a reachable server, or start the server it points at. ' +
+        'See https://github.com/gethelio/helio/blob/main/docs/getting-started.md',
+    )
+  })
+
   it.each(['ENOTFOUND', 'EAI_AGAIN', 'ECONNRESET', 'EHOSTUNREACH', 'ETIMEDOUT'])(
     'recognizes %s as unreachable',
     (code) => {

--- a/packages/proxy/src/upstream/connection-error.ts
+++ b/packages/proxy/src/upstream/connection-error.ts
@@ -5,8 +5,9 @@
  * terse `TypeError: fetch failed`, hiding the URL and the real cause behind a
  * nested `.cause`. When Helio surfaces that verbatim — for example while
  * priming the annotation cache at startup — operators see "fetch failed" with
- * no hint that the actual problem is "nothing is listening at upstream.url".
- * This helper translates those failures into a clear, URL-aware message.
+ * no hint that the actual problem is "nothing is listening at the configured
+ * upstream url". This helper translates those failures into a clear, URL-aware
+ * message.
  */
 
 /** Docs link surfaced when the upstream MCP server cannot be reached. */
@@ -67,7 +68,8 @@ export function describeUnreachableUpstream(error: unknown, url: string): Error 
   const codeSuffix = code ? ` (${code})` : ''
   return new Error(
     `Upstream MCP server at ${url} is unreachable${codeSuffix} — is it running? ` +
-      `Helio proxies an existing MCP server: set upstream.url in helio.yaml to a ` +
-      `reachable server, or start the server it points at. See ${UPSTREAM_DOCS_URL}`,
+      `Helio proxies an existing MCP server: set upstream.url (or upstreams[].url) ` +
+      `in helio.yaml to a reachable server, or start the server it points at. ` +
+      `See ${UPSTREAM_DOCS_URL}`,
   )
 }


### PR DESCRIPTION
## Description

The unreachable-upstream hint told every operator to `set upstream.url in helio.yaml`, a field named-mode configs cannot contain. The remedy now reads `set upstream.url (or upstreams[].url) in helio.yaml` in both singular and named modes; the message head is byte-identical, so the sidecar guide's troubleshooting quote stays truthful and no docs move. The file header's singular phrasing goes mode-neutral in the same edit. The full message is now pinned byte-for-byte at the unit level, and the new tail is pinned through the built CLI in both boot modes (assertions on already-captured stderr; no new spawns).

A comment-only rider corrects the budget engine's stale contributor-match comment: it said the match schema "admits only tool + input", but the schema has also admitted the `upstreams` scope since the named-upstreams layer (#293). The reworded comment names all three fields and the nuance that the upstreams conjunct tests `ctx.upstream` directly, never the match context the comment describes. No behavior change.

Boundaries: unreachable detection, error codes, and the docs-link destination are untouched; the sidecar quote's pre-existing code-suffix generalization stays as is; #324 (warn on ignored stdio `url`) remains backlog.

Notes from the work: planned and implemented under external adversarial review (plan settled in one round, 3 MINOR + 2 NIT folded; implementation round 1 READY with zero findings and one commit-body grammar NIT, folded before push). Workspace flakes during verification were the documented #271 faces, green on isolated re-run and commented there (fifteenth occurrence plus two addenda).

Closes #320
Closes #321

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [ ] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `pnpm build && pnpm test` (proxy 3066, dashboard 397; the new coverage is the full-message unit pin in `connection-error.test.ts` and the two built-CLI tail pins in `cli.test.ts`).
2. Point a config at a dead port in either form (`upstream:` or a named `upstreams:` entry) and run `helio start`: the unreachable error's remedy now names both fields.
