### PR TITLE
docs(changelog): roll unreleased entries into 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Maintainer notes:
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-08-31
+
 ### Breaking changes
 
 - **BREAKING: `upstream.headers` may no longer set `Accept` (#304).**
@@ -1231,7 +1233,8 @@ Helio's first public release.
 - Secret scanning is now part of the default quality gate (pre-commit + CI),
   designed to prevent accidental credential commits before merge.
 
-[Unreleased]: https://github.com/gethelio/helio/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/gethelio/helio/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/gethelio/helio/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/gethelio/helio/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/gethelio/helio/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/gethelio/helio/compare/v0.10.0...v0.11.0


### PR DESCRIPTION
## Description

Rolls the Unreleased CHANGELOG into `## [0.13.0] - 2026-08-31` ahead of the
release tag. All 24 entries move byte-identical into the new section and
`Unreleased` resets to a bare heading. The compare-link footer gains the
`[0.13.0]` definition with `[Unreleased]` repointed at `v0.13.0...HEAD`;
both URLs 404 until the tag is pushed, per the established pattern.

Nothing rides along. The diff is `CHANGELOG.md` only, +4/-1.

This PR does not cut the release. The pre-flight gauntlet, the benchmark,
and the signed tag follow separately.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [ ] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. Prove the move is lossless: `diff <(git show 09e885e:CHANGELOG.md | awk 'NR>=22 && NR<=285') <(git show HEAD:CHANGELOG.md | awk 'NR>=24 && NR<=287')` is empty, and `grep -cE '^- '` over each slice returns 24.
2. Confirm the diff shape: `git diff 09e885e..HEAD -- CHANGELOG.md | grep -E '^[+-]' | grep -vE '^\+\+\+|^---'` yields exactly five lines, the new heading plus its blank separator plus the three footer lines, with zero entry lines.
3. `pnpm format:check && pnpm lint && pnpm typecheck && pnpm docs:check:samples` (the sample count must stay at 90 checked, 89 passed, 0 failed, 1 skipped).

## Additional Context

The `### Breaking changes` subsection already led the Unreleased block, so
this roll needed no restructuring. The section carries one breaking entry,
the #304 Accept-header reservation.
