### PR TITLE
fix(deps): override browserslist to 4.28.8 for two high advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   form-data@>=4.0.0 <4.0.6: 4.0.6
   nanoid@<3.3.18: 3.3.18
   ip-address: 10.3.1
+  browserslist@<4.28.7: 4.28.8
 
 importers:
 
@@ -1248,8 +1249,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.13:
-    resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1277,8 +1278,8 @@ packages:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1311,8 +1312,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001784:
-    resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1508,8 +1509,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.331:
-    resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
+  electron-to-chromium@1.5.418:
+    resolution: {integrity: sha512-UzS26r3AEbG5wSoGVpJKqwHIU9zwQN7LHdVIThDrJpS0I5KdlXFMEb8543fhc9dVnIIAST6ar8rhwa00AL5MlA==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -2126,8 +2127,9 @@ packages:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
-  node-releases@2.0.37:
-    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2642,11 +2644,11 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.8
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -2868,7 +2870,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -3750,7 +3752,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.13: {}
+  baseline-browser-mapping@2.11.20: {}
 
   better-sqlite3@12.8.0:
     dependencies:
@@ -3794,13 +3796,13 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  browserslist@4.28.2:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.13
-      caniuse-lite: 1.0.30001784
-      electron-to-chromium: 1.5.331
-      node-releases: 2.0.37
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.418
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   buffer@5.7.1:
     dependencies:
@@ -3828,7 +3830,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001784: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -3980,7 +3982,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.331: {}
+  electron-to-chromium@1.5.418: {}
 
   encodeurl@2.0.0: {}
 
@@ -4606,7 +4608,7 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  node-releases@2.0.37: {}
+  node-releases@2.0.54: {}
 
   object-assign@4.1.1: {}
 
@@ -5143,9 +5145,9 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,15 @@ overrides:
   # express-rate-limit (via @modelcontextprotocol/sdk) depends on an EXACT
   # ip-address 10.1.0, so no range resolution can reach the fix.
   ip-address: 10.3.1 # GHSA-mwp4-54f8-5fhr
+  # browserslist prototype write and uncaught crash via untrusted
+  # browserslist-stats.json (GHSA-c83g-rgw3-j3cx, GHSA-73wf-gq98-2v4g,
+  # both patched 4.28.7). Every path is a dev-only transitive through
+  # @babel/core, whose @babel/helper-compilation-targets declares
+  # ^4.24.0, a range that already admits the fix. The lockfile was
+  # simply pinned at 4.28.2, and pnpm has no scoped transitive refresh,
+  # so the ranged override carries it; the range self-retires once
+  # natural resolution reaches 4.28.7 or later.
+  'browserslist@<4.28.7': 4.28.8
 
 # pnpm 11 reads settings from this file only; the package.json "pnpm" field
 # is ignored. The GHSA below is triaged and tracked (esbuild dev-server: #64).


### PR DESCRIPTION
## Description

Two high-severity advisories were published against `browserslist` on
2026-09-01 at 16:41Z: a prototype write and an uncaught crash, both
reachable through untrusted `browserslist-stats.json` custom stats, and
both patched in 4.28.7. The lockfile carried 4.28.2, which is in range.

- GHSA-c83g-rgw3-j3cx
- GHSA-73wf-gq98-2v4g

Every path is a dev-only transitive through `@babel/core`, reached from
`eslint-plugin-react-hooks` and `@vitejs/plugin-react`. Nothing in a
published artifact depends on it, and nothing in this repo feeds it a
custom stats file.

`@babel/helper-compilation-targets` already declares `^4.24.0`, a range
that admits the fix, so no manifest is wrong. The lockfile was simply
pinned at 4.28.2 from March, and pnpm has no scoped transitive refresh
(`update` is direct-only, `dedupe` cannot fetch), so a ranged override
carries it. The range self-retires once natural resolution reaches
4.28.7 or later, matching the `nanoid` precedent already in the file.

This takes 4.28.8, the current patch, rather than the 4.28.7 minimum:
4.28.8 was published 2026-08-08, three weeks before the advisory, so it
carries soak time rather than being a rushed post-disclosure publish.

**Why this is a separate PR.** #338 is unrelated (benchmark gate and CI)
and touches no dependency. It surfaced this only because it edits a
`package.json` script line, which fires `ci.yml`'s manifest trigger and
runs the full audit that PRs otherwise skip. The security fix belongs on
its own so it can be reviewed, vetted, and reverted independently.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

No test is added: this is a lockfile resolution change with no behavior
of its own. `pnpm audit --audit-level=high` is the check that fails
before and passes after, and it already runs in CI.

## How to Test

1. `git checkout main && pnpm install && pnpm audit --audit-level=high`
   fails with the two high advisories above.
2. On this branch, `pnpm install && pnpm audit --audit-level=high` exits
   0, reporting only the one low advisory that is explicitly ignored via
   `auditConfig.ignoreGhsas` (esbuild dev-server, triaged on #64).
3. `grep -n "browserslist@" pnpm-lock.yaml` resolves to 4.28.8.
4. `pnpm build` succeeds — browserslist feeds the dashboard's babel
   browser targets, so the dashboard build is the surface this touches.

## Additional Context

**Vetted before installing**, per the repo's supply-chain practice:

- Sole maintainer unchanged: `ai <andrey@sitnik.es>`, the long-standing
  browserslist author.
- 4.28.8 is published through a GitHub Actions OIDC trusted publisher
  and carries a SLSA provenance attestation plus a registry signature.
  4.28.2 was published with a personal token, so this is a hardening.
- No install hooks on browserslist 4.28.8 or on the new transitive
  `update-browserslist-db` 1.3.2.
- Dependency delta is a within-major data refresh (`caniuse-lite`,
  `node-releases`, `electron-to-chromium`, `baseline-browser-mapping`,
  `update-browserslist-db`) with nothing added or removed.

**Lockfile change is tightly scoped**: only `browserslist` and its own
five data dependencies move. Nothing else in the tree shifts.

**No CHANGELOG entry.** Dev-only transitive that never reaches a
published artifact; the file's bar is user-visible and
operator-relevant changes.

**Timing worth noting.** The last green Security Audit ran 2026-09-01 at
12:33Z, four hours before these advisories published. Main has been
latently red since, and the next daily audit or push to main would have
failed identically. Whether that detection window should be narrower is
a separate question from this fix.
