### PR TITLE
fix(deps): override fast-uri to 3.1.6 for four high advisories

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -77,7 +77,7 @@ Action versions are pinned to major version tags (e.g., `@v4`). Dependabot propo
 
 The `pnpm-workspace.yaml` file includes overrides to patch known vulnerabilities in transitive dependencies when upstream packages haven't released fixes yet.
 
-Current security-patch overrides include `axios` pinned at `1.18.1` for its Node-adapter advisories inherited via `@slack/web-api`, `fast-uri` at `3.1.5` for `GHSA-7p8r-x3mc-p8w7` and its two predecessors, and `ip-address` at `10.3.1` for `GHSA-mwp4-54f8-5fhr` (needed because `express-rate-limit`, inherited via `@modelcontextprotocol/sdk`, depends on an exact `10.1.0`, so no range resolution reaches the fix).
+Current security-patch overrides include `axios` pinned at `1.18.1` for its Node-adapter advisories inherited via `@slack/web-api`, `fast-uri` lifted to `3.1.6` through a ranged override (`fast-uri@<3.1.6`) for four host-confusion and SSRF advisories patched in `3.1.6`, on top of the three the earlier `3.1.5` pin covered, and `ip-address` at `10.3.1` for `GHSA-mwp4-54f8-5fhr` (needed because `express-rate-limit`, inherited via `@modelcontextprotocol/sdk`, depends on an exact `10.1.0`, so no range resolution reaches the fix).
 
 `brace-expansion` is lifted to `1.1.18` and `5.0.9`, which clears both `GHSA-mh99-v99m-4gvg` and `GHSA-rgw5-rvv9-x895`, the latter being a bypass of the former's mitigation. The 1.x line gained a patched release (`1.1.17`, then `1.1.18`) after the original override was written, so `GHSA-mh99-v99m-4gvg` is no longer an audit ignore.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   path-to-regexp: 8.4.2
   axios: 1.18.1
-  fast-uri: 3.1.5
+  fast-uri@<3.1.6: 3.1.6
   follow-redirects: 1.16.0
   brace-expansion@<1.1.18: 1.1.18
   brace-expansion@>=3.0.0 <5.0.9: 5.0.9
@@ -1595,6 +1595,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -1670,8 +1671,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3712,7 +3713,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4225,7 +4226,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,17 @@ packages:
 overrides:
   path-to-regexp: 8.4.2
   axios: 1.18.1
-  fast-uri: 3.1.5 # GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx, GHSA-7p8r-x3mc-p8w7
+  # fast-uri host confusion and SSRF via IDN canonicalization, IPv6
+  # normalization, percent-decoding, and scheme handling
+  # (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf,
+  # GHSA-jqff-g426-hqxp, all patched 3.1.6), on top of the three the 3.1.5
+  # pin covered (GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx,
+  # GHSA-7p8r-x3mc-p8w7). Dev-only path through @modelcontextprotocol/sdk
+  # and ajv, whose ^3.0.1 already admits the fix; the ranged override
+  # carries it and self-retires once natural resolution reaches 3.1.6 or
+  # later. 3.1.7 closes two more (GHSA-qw65-cvwx-89v3, GHSA-58mr-gqgx-xq4g)
+  # and is the next lift once it clears the release-age guard.
+  'fast-uri@<3.1.6': 3.1.6
   follow-redirects: 1.16.0
   # Both brace-expansion advisories at once: GHSA-mh99-v99m-4gvg (patched 1.1.17
   # / 5.0.8) and GHSA-rgw5-rvv9-x895, which bypasses that mitigation (patched


### PR DESCRIPTION
## Description

Four high-severity advisories were published against `fast-uri` on
2026-09-02 between 15:41Z and 15:44Z, all patched in 3.1.6. The lockfile
carried 3.1.5, which is in range.

- GHSA-5jgf-p345-68v8 (host confusion via skipped IDN canonicalization)
- GHSA-f65p-4m7j-42xc (SSRF via malformed IPv6 normalization)
- GHSA-fph4-wmhf-6fwf (SSRF via repeated hostname percent-decoding)
- GHSA-jqff-g426-hqxp (host confusion via percent-encoded scheme normalization)

The only path is a dev-only transitive: `@modelcontextprotocol/sdk` is a
devDependency of the proxy, and it reaches `fast-uri` through `ajv` and
`ajv-formats`. Nothing in a published artifact depends on it
(`pnpm --filter @gethelio/proxy why fast-uri --prod` is empty).

The tree was held inside the vulnerable range by this repo's own
override. The exact `fast-uri: 3.1.5` pin, added for three earlier
advisories, kept the resolver from reaching the fix even though `ajv`
declares `^3.0.1`, a range that admits it. This replaces the pin with a
ranged override (`fast-uri@<3.1.6`) that self-retires once natural
resolution reaches 3.1.6 or later, matching the `nanoid` and
`browserslist` entries, and names every advisory it covers in the
comment. `DEPENDENCIES.md` is updated to match.

**Why 3.1.6 and not 3.1.7.** Both are patched. 3.1.7 additionally closes
GHSA-qw65-cvwx-89v3 (authority injection via an unvalidated port in
`serialize()`) and GHSA-58mr-gqgx-xq4g (host confusion via unbalanced
IP-literal brackets), which are published on the upstream repository but
not yet in the GitHub Advisory Database, so the audit gate does not flag
them today. 3.1.7 was published 2026-09-02 at 11:06Z, nine hours before
this change and inside pnpm 11's default 24-hour `minimumReleaseAge`
guard; installing it would have committed a `minimumReleaseAgeExclude`
entry. 3.1.6 was published 2026-08-23, ten days before the advisories,
so it carries soak time. A follow-up lifts the override to 3.1.7 once it
clears the guard, ahead of those two advisories reaching the database.

**Vetted before installing.** The publisher is the same account on
3.1.4, 3.1.5, 3.1.6, and 3.1.7. 3.1.6 declares no `preinstall`,
`install`, or `postinstall` script and no dependency. The package has no
provenance attestation, so every non-test file in the tarball was
compared byte for byte against the `v3.1.6` git tag (all 21 identical),
and the source diff from 3.1.5 (`index.js`, `lib/schemes.js`,
`lib/utils.js`) was read in full: scheme validation, percent-encoding
normalization, an IPv6 parser rewrite, and path, query, fragment, and
userinfo encoding, plus ten new test files. No network, process, or
environment access is introduced. The lockfile diff moves `fast-uri`
alone; its only other change is a `deprecated` annotation pnpm now
writes on the unchanged `eslint@9.39.4` entry (see below).

**Why this is a separate PR.** The docs-only #343 merge pushed main and
ran the full audit that pull requests otherwise skip, which is what
exposed the advisories. The dependency fix belongs on its own so it can
be reviewed, vetted, and reverted independently.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [ ] TypeScript strict mode — no `any` types or `@ts-ignore` without justification (not applicable: no TypeScript touched)
- [ ] I have added or updated tests for my changes (not applicable: dependency override only)
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `pnpm install --frozen-lockfile && pnpm audit --audit-level=high` exits 0 (three pre-existing moderate findings remain, none high).
2. `git diff main...HEAD -- pnpm-lock.yaml` moves only `fast-uri` (3.1.5 to 3.1.6).
3. `pnpm --filter @gethelio/proxy why fast-uri --prod` prints nothing, confirming the dev-only path.
4. Optional tarball check: `npm pack fast-uri@3.1.6`, extract, and compare `index.js`, `lib/schemes.js`, and `lib/utils.js` against `https://github.com/fastify/fast-uri/tree/v3.1.6`.

## Additional Context

Run locally on the commit: `pnpm audit --audit-level=high` exit 0, `pnpm build`, the full proxy test suite, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, and the pre-commit hook. The PR run is green, and because this PR changes a dependency manifest, its audit step ran the full-tree audit rather than skipping (run 33679552765).

**Surfaced, not in scope.** While resolving, pnpm annotated the
lockfile's unchanged `eslint@9.39.4` entry as deprecated ("This version
is no longer supported"), meaning the pinned ESLint is past its support
window. That is a separate upgrade with its own vetting and belongs in
its own PR.
