### PR TITLE
docs(changelog): roll unreleased entries into 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Maintainer notes:
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-09-03
+
 ### Added
 
 - **The benchmark runs in CI and at the release gate (#333).** Every
@@ -1284,7 +1286,8 @@ Helio's first public release.
 - Secret scanning is now part of the default quality gate (pre-commit + CI),
   designed to prevent accidental credential commits before merge.
 
-[Unreleased]: https://github.com/gethelio/helio/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/gethelio/helio/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/gethelio/helio/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/gethelio/helio/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/gethelio/helio/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/gethelio/helio/compare/v0.11.0...v0.11.1


### PR DESCRIPTION
## Description

Roll the `Unreleased` entries into a new `## [0.13.1] - 2026-09-03` section ahead of the `v0.13.1` tag. The diff is a pure insertion: the new dated heading and its blank line under `## [Unreleased]`, plus the footer compare links (`[Unreleased]` repointed at `v0.13.1...HEAD`, a new `[0.13.1]` line above `[0.13.0]`). Every entry moves byte-identical; a range diff between `main` and this branch over the moved block is empty, and the bullet count is unchanged.

The section carries the dashboard-secret digest fix (#346, `### Security`, GHSA-5hpf-j7jh-7x44), the benchmark CI gate entries (#333), and the Phase A `SECURITY.md` boundary section (#343). Prettier was not run on this file: entries move unchanged and `format:check` passes as is.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [ ] TypeScript strict mode — no `any` types or `@ts-ignore` without justification (not applicable: changelog only)
- [ ] I have added or updated tests for my changes (not applicable: changelog only)
- [ ] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `git diff main...HEAD -- CHANGELOG.md` shows five changed lines: the new heading, its blank line, and the three footer lines.
2. `diff <(git show main:CHANGELOG.md | awk 'NR>=22 && NR<=72') <(awk 'NR>=24 && NR<=74' CHANGELOG.md)` prints nothing.
3. `pnpm docs:check:ci && pnpm format:check` pass.

## Additional Context

Release prep for `v0.13.1`, which also carries the fast-uri 3.1.7 override lift (#347, no changelog entry, as with #344). The tag follows once both are on `main` and the pre-flight gauntlet passes.
