### PR TITLE
feat(cli): scaffold the sidecar layout with helio init --sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Added
+
+- **`helio init --sandbox [dir]` writes the sidecar layout.** Three
+  files (`compose.yaml`, `helio/helio.yaml`, `helio/README.md`) in a
+  new directory (`helio-sandbox` by default) that the agent container
+  never mounts: four services on three networks, the agent on `edge`
+  only, Helio attached to no network the agent is on, the config
+  mounted read-only into Helio alone, the dashboard published to the
+  host's loopback (unreachable from the agent by service name or
+  address; a host-published port stays reachable through Docker
+  Desktop's host gateway, with the control-plane routes behind the
+  secret), and a README with the hard constraints, the four checks, and
+  a `devcontainer.json` snippet. Refuses to overwrite
+  without `--force`.
+
 ### Changed
 
 - **The sidecar recipe keeps the config out of the agent's reach and

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ npx @gethelio/proxy init
 
 This single package includes the built-in dashboard UI bundle.
 
+Running your agent in a container? `npx @gethelio/proxy init --sandbox` writes the sidecar layout instead; see [Running Helio as a Sidecar](./docs/deployment-sidecar.md).
+
 ### 2. Configure
 
 `npx @gethelio/proxy init` already created a `helio.yaml` in your project root. Open it (e.g. `nano helio.yaml`, or in your editor) and point `upstream.url` at your existing MCP server. The singular `upstream:` form stays fully supported; to govern more than one MCP server, declare a named `upstreams:` list in its place (set exactly one of the two). Tool sets are never merged: each named upstream is served at its own `/mcp/<name>` door. See the [Configuration Reference](./docs/configuration.md#upstreams).

--- a/docs/deployment-sidecar.md
+++ b/docs/deployment-sidecar.md
@@ -9,6 +9,7 @@ route to Helio by service name or address, and no copy of the upstream
 credential; the one residual, a dashboard port published to the host that
 Docker Desktop's host gateway still reaches, is stated in the verification
 section), with a copy-paste Docker Compose setup that implements it.
+`helio init --sandbox` writes the same files.
 
 **Who it's for:** you already know roughly what Helio does — if not, start with
 the [README](../README.md) or [Getting Started](./getting-started.md) — and you
@@ -84,7 +85,8 @@ what Helio allows is from the host.
 helio-sandbox/          the Compose project directory; never mounted into agent
 ├── compose.yaml
 ├── helio/
-│   └── helio.yaml      mounted read-only into the helio service only
+│   ├── helio.yaml      mounted read-only into the helio service only
+│   └── README.md       the constraints and the checks; optional by hand
 └── workspace/          your project; the only thing agent mounts
 ```
 
@@ -93,8 +95,8 @@ agent and the forwarder. `plane` is an ordinary bridge for the forwarder and
 Helio, and Helio's route out for upstreams on the internet. `internal` is
 marked `internal: true`, for Helio and the upstream, with no route anywhere
 else. `helio-edge` is the only service on both `edge` and `plane`; Helio is on
-`plane` and `internal` and never on `edge`. Create these files. First
-`compose.yaml`:
+`plane` and `internal` and never on `edge`. `helio init --sandbox` creates this
+layout; by hand, the files are the two below. First `compose.yaml`:
 
 <!-- helio-config-guard: skip -->
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -266,7 +266,7 @@ The local steps above (`helio start`) run the proxy as the same user as your age
 ## Next Steps
 
 - [Configuration Reference](./configuration.md) — Every `helio.yaml` field with defaults and types
-- [Running Helio as a Sidecar](./deployment-sidecar.md) — Deploy next to a coding agent or dev container with the upstream out of its reach
+- [Running Helio as a Sidecar](./deployment-sidecar.md) — Deploy next to a coding agent or dev container with the upstream and the config out of its reach and Helio off its network; `helio init --sandbox` writes the layout
 - [Running Helio as its own user](./deployment-separate-user.md) — The separate-user tier on Ubuntu 24.04, run end to end
 - [Policy Guide](./policies.md) — Rule syntax, matchers, actions, rate limits, spend limits, and common patterns
 - [Approval Workflows](./approvals.md) — Route sensitive actions to humans via Slack, webhook, or dashboard

--- a/packages/proxy/AGENTS.md
+++ b/packages/proxy/AGENTS.md
@@ -248,13 +248,13 @@ pnpm --filter @gethelio/proxy benchmark   # Run performance benchmark (tsx scrip
 
 ## CLI Commands
 
-| Command                                                                                                                 | Description                                                                                        |
-| ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `helio start [-c path] [--no-hot-reload]`                                                                               | Load config, compile policies, start proxy server (`--no-hot-reload` disables config-watch reload) |
-| `helio init [-o path] [-f]`                                                                                             | Scaffold helio.yaml with commented defaults                                                        |
-| `helio validate [-c path]`                                                                                              | Validate config + compile policies, report errors/warnings                                         |
-| `helio secret`                                                                                                          | Generate a dashboard secret and the digest to store as `dashboard.api_secret`, on stdout           |
-| `helio export [-c path] [-f format] [--budgets] [--tool] [--decision] [--reason] [--session] [--from] [--to] [--limit]` | Export audit records — or one budget's spend ledger via `--budgets <name>` — as JSON or CSV        |
+| Command                                                                                                                 | Description                                                                                                                                                            |
+| ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `helio start [-c path] [--no-hot-reload]`                                                                               | Load config, compile policies, start proxy server (`--no-hot-reload` disables config-watch reload)                                                                     |
+| `helio init [-o path] [-f] [--sandbox [dir]]`                                                                           | Scaffold helio.yaml with commented defaults, or with --sandbox the sidecar layout (compose.yaml, helio/helio.yaml, helio/README.md) into <dir> (default helio-sandbox) |
+| `helio validate [-c path]`                                                                                              | Validate config + compile policies, report errors/warnings                                                                                                             |
+| `helio secret`                                                                                                          | Generate a dashboard secret and the digest to store as `dashboard.api_secret`, on stdout                                                                               |
+| `helio export [-c path] [-f format] [--budgets] [--tool] [--decision] [--reason] [--session] [--from] [--to] [--limit]` | Export audit records — or one budget's spend ledger via `--budgets <name>` — as JSON or CSV                                                                            |
 
 ## Performance Constraints
 

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -62,6 +62,8 @@ npx @gethelio/proxy init
 
 This single package includes the built-in dashboard UI bundle.
 
+Running your agent in a container? `npx @gethelio/proxy init --sandbox` writes the sidecar layout instead; see [Running Helio as a Sidecar](https://github.com/gethelio/helio/blob/main/docs/deployment-sidecar.md).
+
 ### 2. Configure
 
 `npx @gethelio/proxy init` already created a `helio.yaml` in your project root. Open it (e.g. `nano helio.yaml`, or in your editor) and point `upstream.url` at your existing MCP server. The singular `upstream:` form stays fully supported; to govern more than one MCP server, declare a named `upstreams:` list in its place (set exactly one of the two). Tool sets are never merged: each named upstream is served at its own `/mcp/<name>` door. See the [Configuration Reference](https://github.com/gethelio/helio/blob/main/docs/configuration.md#upstreams).

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -22,15 +22,21 @@ const CLI_PATH = join(import.meta.dirname, '../dist/cli.js')
 function runCli(
   args: string[],
   env?: NodeJS.ProcessEnv,
+  cwd?: string,
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
-    execFile('node', [CLI_PATH, ...args], env ? { env } : {}, (error, stdout, stderr) => {
-      resolve({
-        code: typeof error?.code === 'number' ? error.code : error ? 1 : 0,
-        stdout,
-        stderr,
-      })
-    })
+    execFile(
+      'node',
+      [CLI_PATH, ...args],
+      { ...(env ? { env } : {}), ...(cwd ? { cwd } : {}) },
+      (error, stdout, stderr) => {
+        resolve({
+          code: typeof error?.code === 'number' ? error.code : error ? 1 : 0,
+          stdout,
+          stderr,
+        })
+      },
+    )
   })
 }
 
@@ -517,6 +523,92 @@ describe('CLI', () => {
           expect(index, `\`${key}:\` is out of canonical order`).toBeGreaterThan(cursor)
           cursor = index
         }
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('--sandbox writes the three-file layout and prints the next steps', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-sandbox-'))
+      const target = join(dir, 'sandbox')
+      try {
+        const { code, stderr } = await runCli(['init', '--sandbox', target])
+        expect(code).toBe(0)
+        for (const rel of ['compose.yaml', 'helio/helio.yaml', 'helio/README.md']) {
+          expect(existsSync(join(target, rel)), rel).toBe(true)
+          expect(stderr).toContain(`Created ${join(target, rel)}`)
+        }
+        expect(stderr).toContain('Next steps')
+        expect(stderr).toContain('helio secret')
+        expect(stderr).not.toMatch(/[a-f0-9]{64}/)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('--sandbox defaults to ./helio-sandbox under the current directory', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-sandbox-'))
+      try {
+        const { code } = await runCli(['init', '--sandbox'], undefined, dir)
+        expect(code).toBe(0)
+        expect(existsSync(join(dir, 'helio-sandbox', 'compose.yaml'))).toBe(true)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('--sandbox refuses to overwrite an existing layout without --force', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-sandbox-'))
+      const target = join(dir, 'sandbox')
+      try {
+        expect((await runCli(['init', '--sandbox', target])).code).toBe(0)
+        const second = await runCli(['init', '--sandbox', target])
+        expect(second.code).toBe(1)
+        expect(second.stderr).toContain('already exists')
+        const forced = await runCli(['init', '--sandbox', target, '--force'])
+        expect(forced.code).toBe(0)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('--sandbox rejects an explicit --output', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-sandbox-'))
+      try {
+        const { code, stderr } = await runCli([
+          'init',
+          '--sandbox',
+          join(dir, 's'),
+          '-o',
+          join(dir, 'x.yaml'),
+        ])
+        expect(code).toBe(1)
+        expect(stderr).toContain('--output does not apply to --sandbox')
+        // An explicit -o equal to the default must be caught too (option source, not value).
+        const sameAsDefault = await runCli(
+          ['init', '--sandbox', join(dir, 's2'), '-o', 'helio.yaml'],
+          undefined,
+          dir,
+        )
+        expect(sameAsDefault.code).toBe(1)
+        expect(existsSync(join(dir, 's2'))).toBe(false)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('--sandbox writes a config that passes validate', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-sandbox-'))
+      const target = join(dir, 'sandbox')
+      try {
+        expect((await runCli(['init', '--sandbox', target])).code).toBe(0)
+        const validate = await runCli(['validate', '-c', join(target, 'helio', 'helio.yaml')], {
+          ...process.env,
+          HELIO_DASHBOARD_SECRET: 'sandbox-test',
+        })
+        expect(validate.code).toBe(0)
+        expect(validate.stderr).toContain('Config is valid')
+        expect(validate.stderr).toContain('(2 policy rules, 0 budgets)')
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-console -- CLI entry point, console is the intended output */
 import { Command } from 'commander'
-import { writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { randomBytes } from 'node:crypto'
-import { dirname, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { VERSION } from './version.js'
 import {
@@ -16,6 +16,14 @@ import {
 import type { SingularHelioConfig } from './config/index.js'
 import { findUnroutableApprovalReferences } from './config/reload-boundary.js'
 import { secretDigest } from './auth/bearer.js'
+import {
+  SANDBOX_DEFAULT_DIR,
+  SANDBOX_FILES,
+  renderSandboxCompose,
+  renderSandboxConfig,
+  renderSandboxReadme,
+  sandboxImageTag,
+} from './sandbox-scaffold.js'
 import type { Hono } from 'hono'
 import { createApp, createMultiApp, startServer, startSidebandServer } from './server.js'
 import { applyReloadedPolicy } from './reload-fanout.js'
@@ -813,6 +821,37 @@ async function initCommand(outputPath: string, force: boolean): Promise<void> {
   console.error('dashboard.api_secret, and restart the proxy.')
 }
 
+async function sandboxCommand(dir: string, force: boolean): Promise<void> {
+  const root = resolve(dir)
+  const targets = SANDBOX_FILES.map((rel) => join(root, rel))
+  const existing = targets.find((path) => existsSync(path))
+  if (existing !== undefined && !force) {
+    console.error(`Error: ${existing} already exists. Use --force to overwrite.`)
+    process.exit(1)
+  }
+
+  await mkdir(join(root, 'helio'), { recursive: true })
+  const contents: Record<(typeof SANDBOX_FILES)[number], string> = {
+    'compose.yaml': renderSandboxCompose({ imageTag: sandboxImageTag(VERSION) }),
+    'helio/helio.yaml': renderSandboxConfig(),
+    'helio/README.md': renderSandboxReadme(),
+  }
+  for (const rel of SANDBOX_FILES) await writeFile(join(root, rel), contents[rel], 'utf-8')
+
+  for (const path of targets) console.error(`Created ${path}`)
+  console.error('')
+  console.error('Next steps:')
+  console.error('  1. In compose.yaml, set the agent image (or build:) and the mcp-server image.')
+  console.error(
+    '  2. Run `helio secret` and put HELIO_DASHBOARD_SECRET=<digest> in ./.env next to compose.yaml.',
+  )
+  console.error(`  3. cd ${dir} && docker compose up -d`)
+  console.error('  4. docker compose exec agent sh, then run the checks in helio/README.md.')
+  console.error(
+    'Never mount this directory, ./helio, .env, or the Docker socket into the agent service.',
+  )
+}
+
 function secretCommand(): void {
   const secret = randomBytes(32).toString('hex')
   console.log(`secret: ${secret}`)
@@ -1097,7 +1136,20 @@ program
   .description('Scaffold a helio.yaml config file with commented defaults')
   .option('-o, --output <path>', 'Output file path', DEFAULT_CONFIG_PATH)
   .option('-f, --force', 'Overwrite existing file', false)
-  .action((opts: { output: string; force: boolean }) => initCommand(opts.output, opts.force))
+  .option(
+    '--sandbox [dir]',
+    `Write the sidecar layout (compose.yaml, helio/helio.yaml, helio/README.md) into <dir> (default: ${SANDBOX_DEFAULT_DIR}) instead of a helio.yaml`,
+  )
+  .action((opts: { output: string; force: boolean; sandbox?: string | true }, command: Command) => {
+    if (opts.sandbox === undefined) return initCommand(opts.output, opts.force)
+    if (command.getOptionValueSource('output') === 'cli') {
+      console.error(
+        'Error: --output does not apply to --sandbox; pass the directory as --sandbox <dir>.',
+      )
+      process.exit(1)
+    }
+    return sandboxCommand(opts.sandbox === true ? SANDBOX_DEFAULT_DIR : opts.sandbox, opts.force)
+  })
 
 program
   .command('validate')

--- a/packages/proxy/src/sandbox-scaffold.test.ts
+++ b/packages/proxy/src/sandbox-scaffold.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import yaml from 'js-yaml'
+import { loadConfig } from './config/index.js'
+import {
+  renderSandboxCompose,
+  renderSandboxConfig,
+  renderSandboxReadme,
+  sandboxImageTag,
+  SANDBOX_FILES,
+} from './sandbox-scaffold.js'
+
+const CANONICAL_ORDER = [
+  'version',
+  'upstream',
+  'upstreams',
+  'listen',
+  'environment',
+  'session',
+  'policies',
+  'budgets',
+  'approval',
+  'audit',
+  'dashboard',
+  'sdk',
+]
+
+interface ComposeService {
+  image?: string
+  networks?: string[]
+  volumes?: string[]
+  environment?: Record<string, string>
+  ports?: string[]
+  configs?: { source: string; target: string }[]
+}
+interface ComposeFile {
+  services: {
+    agent: ComposeService
+    'helio-edge': ComposeService
+    helio: ComposeService
+    'mcp-server': ComposeService
+  }
+  networks: Record<string, { internal?: boolean } | null>
+  configs?: { helio_edge_conf: { content: string } }
+}
+
+/** The N12 guard: sources an agent volume must never have. */
+function isForbiddenAgentMountSource(source: string): boolean {
+  const s = source.trim()
+  if (['.', '..', './helio', './helio/', 'helio', 'helio/'].includes(s)) return true
+  if (/(^|\/)\.env(\.[^/]*)?$/.test(s)) return true
+  return s.includes('docker.sock')
+}
+
+describe('sandbox scaffold: helio/helio.yaml', () => {
+  it('loads through loadConfig with the secret in the environment', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'helio-sandbox-config-'))
+    const path = join(dir, 'helio.yaml')
+    try {
+      writeFileSync(path, renderSandboxConfig())
+      const config = await loadConfig(path, { HELIO_DASHBOARD_SECRET: 'sandbox-test' })
+      if (!('upstream' in config)) throw new Error('expected the singular upstream form')
+      expect(config.upstream.url).toBe('http://mcp-server:8080/mcp')
+      expect(config.listen.host).toBe('0.0.0.0')
+      expect(config.dashboard.host).toBe('0.0.0.0')
+      expect(config.audit.path).toBe('/data/helio-audit.db')
+      expect(config.policies.rules).toHaveLength(2)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the top-level keys in canonical order', () => {
+    const text = renderSandboxConfig()
+    let cursor = -1
+    for (const key of CANONICAL_ORDER) {
+      const match = new RegExp(`^${key}:`, 'm').exec(text)
+      if (!match) continue
+      expect(match.index, `\`${key}:\` is out of canonical order`).toBeGreaterThan(cursor)
+      cursor = match.index
+    }
+    expect(cursor).toBeGreaterThan(-1)
+  })
+})
+
+describe('sandbox scaffold: compose.yaml', () => {
+  const compose = yaml.load(renderSandboxCompose({ imageTag: '1.2.3' })) as ComposeFile
+  const { services, networks } = compose
+
+  it('has exactly the four services', () => {
+    expect(Object.keys(services).sort()).toEqual(['agent', 'helio', 'helio-edge', 'mcp-server'])
+  })
+
+  it('keeps agent on edge only, with no volumes key at all', () => {
+    expect(services.agent.networks).toEqual(['edge'])
+    expect(services.agent.volumes).toBeUndefined()
+    expect(services.agent.environment).toBeUndefined()
+    expect(services.agent.ports).toBeUndefined()
+  })
+
+  it('rejects the forbidden agent mount sources (guard for later edits)', () => {
+    for (const source of [
+      '.',
+      '..',
+      './helio',
+      'helio/',
+      '.env',
+      './.env',
+      '/var/run/docker.sock',
+    ]) {
+      expect(isForbiddenAgentMountSource(source), source).toBe(true)
+    }
+    expect(isForbiddenAgentMountSource('./workspace')).toBe(false)
+    for (const volume of services.agent.volumes ?? []) {
+      expect(isForbiddenAgentMountSource(volume.split(':')[0] ?? ''), volume).toBe(false)
+    }
+  })
+
+  it('never attaches helio to edge', () => {
+    expect(services.helio.networks).toEqual(['plane', 'internal'])
+    expect(services['helio-edge'].networks).toEqual(['edge', 'plane'])
+    expect(services['mcp-server'].networks).toEqual(['internal'])
+  })
+
+  it('gives only helio an environment and a host-loopback port', () => {
+    for (const [name, service] of Object.entries(services)) {
+      if (name === 'helio') continue
+      expect(service.environment, name).toBeUndefined()
+      expect(service.ports, name).toBeUndefined()
+    }
+    expect(Object.keys(services.helio.environment ?? {})).toEqual(['HELIO_DASHBOARD_SECRET'])
+    expect(services.helio.ports).toEqual(['127.0.0.1:3100:3100'])
+  })
+
+  it('mounts ./helio read-only into helio only', () => {
+    expect(services.helio.volumes).toContain('./helio:/config:ro')
+    for (const [name, service] of Object.entries(services)) {
+      if (name === 'helio') continue
+      for (const volume of service.volumes ?? [])
+        expect(volume, name).not.toMatch(/^\.\/helio(\/|:)/)
+    }
+  })
+
+  it('marks internal as internal and the other two networks not', () => {
+    expect(Object.keys(networks).sort()).toEqual(['edge', 'internal', 'plane'])
+    expect(networks.internal?.internal).toBe(true)
+    expect(networks.edge?.internal).toBeUndefined()
+    expect(networks.plane?.internal).toBeUndefined()
+  })
+
+  it('forwards port 3000 to helio through the Docker resolver', () => {
+    const content = compose.configs?.helio_edge_conf.content ?? ''
+    expect(content).toContain('listen 3000;')
+    expect(content).toContain('resolver 127.0.0.11')
+    expect(content).toContain('proxy_timeout 1h;')
+    expect(content).toContain('set $$helio helio:3000;')
+    expect(content).toContain('proxy_pass $$helio;')
+    expect(services['helio-edge'].configs?.[0]).toEqual({
+      source: 'helio_edge_conf',
+      target: '/etc/nginx/nginx.conf',
+    })
+  })
+
+  it('pins the helio image to the given tag and maps a source build to latest', () => {
+    expect(services.helio.image).toBe('ghcr.io/gethelio/helio:1.2.3')
+    expect(sandboxImageTag('0.0.0')).toBe('latest')
+    expect(sandboxImageTag('0.14.0')).toBe('0.14.0')
+    expect(SANDBOX_FILES).toEqual(['compose.yaml', 'helio/helio.yaml', 'helio/README.md'])
+  })
+})
+
+describe('sandbox scaffold: helio/README.md', () => {
+  const readme = renderSandboxReadme()
+
+  it('carries the five hard constraints verbatim', () => {
+    for (const line of [
+      'Never mount `.` or `.env` into the `agent` service.',
+      'Never mount `docker.sock` into it; an agent with the socket is the host.',
+      'Secrets only on the `helio` service.',
+      '`./helio/` is never mounted into `agent`.',
+      '`edge` has internet egress',
+    ]) {
+      expect(readme).toContain(line)
+    }
+  })
+
+  it('carries the four checks verbatim', () => {
+    for (const command of [
+      'curl -s -m 3 http://mcp-server:8080/mcp; echo "exit: $?"',
+      'ls /config /workspace/helio 2>&1; echo "exit: $?"',
+      'curl -s -m 3 http://helio:3100/api/health; echo "exit: $?"',
+      'env | grep -iE \'helio|upstream|secret\'; echo "exit: $?"',
+      'http://helio-edge:3000/mcp',
+    ]) {
+      expect(readme).toContain(command)
+    }
+  })
+
+  it('carries the dev-container snippet and the Desktop residual', () => {
+    expect(readme).toContain('"dockerComposeFile": "../../compose.yaml"')
+    expect(readme).toContain('"service": "agent"')
+    expect(readme).toContain('host.docker.internal:3100')
+    expect(readme).toContain('`/api/health` answers without it')
+  })
+})
+
+describe('sandbox scaffold: the sidecar page shows what the command writes', () => {
+  const page = readFileSync(
+    join(import.meta.dirname, '../../../docs/deployment-sidecar.md'),
+    'utf-8',
+  )
+  it('contains the generated compose.yaml and helio/helio.yaml verbatim', () => {
+    expect(page).toContain(renderSandboxCompose({ imageTag: 'latest' }).trimEnd())
+    expect(page).toContain(renderSandboxConfig().trimEnd())
+  })
+})

--- a/packages/proxy/src/sandbox-scaffold.ts
+++ b/packages/proxy/src/sandbox-scaffold.ts
@@ -1,0 +1,250 @@
+// ---------------------------------------------------------------------------
+// Sidecar layout for `helio init --sandbox`: the three files it writes.
+// The sidecar guide (docs/deployment-sidecar.md) shows compose.yaml and
+// helio/helio.yaml verbatim; a test pins the page to these renderers.
+// ---------------------------------------------------------------------------
+
+export const SANDBOX_DEFAULT_DIR = 'helio-sandbox'
+export const SANDBOX_FILES = ['compose.yaml', 'helio/helio.yaml', 'helio/README.md'] as const
+export const SANDBOX_FORWARDER_IMAGE = 'nginx:1.30-alpine'
+export const SANDBOX_AGENT_PLACEHOLDER_IMAGE = 'curlimages/curl:8.22.0'
+
+/** `0.0.0` is a source build with no published image; everything else is a release tag. */
+export function sandboxImageTag(version: string): string {
+  return version === '0.0.0' ? 'latest' : version
+}
+
+export function renderSandboxCompose(options: { imageTag: string }): string {
+  const { imageTag } = options
+  return `# Helio sidecar layout: four services on three networks. The sidecar
+# guide (docs/deployment-sidecar.md) explains every line and carries the
+# checks that prove the layout from inside the agent container.
+#
+#   agent        edge              your coding agent (placeholder below)
+#   helio-edge   edge + plane      forwards :3000 to Helio; the only thing the agent can reach
+#   helio        plane + internal  the proxy; attached to no network the agent is on
+#   mcp-server   internal          your MCP server (placeholder below)
+services:
+  agent:
+    # Placeholder: a shell with curl, so the verification checks run
+    # before you wire your own dev container in. Replace \`image:\` with
+    # your agent image or a \`build:\`; keep \`networks: [edge]\`; mount your
+    # project from a sibling directory (./workspace:/workspace). Never
+    # mount this directory, ./helio, a .env file, or the Docker socket
+    # into it.
+    image: ${SANDBOX_AGENT_PLACEHOLDER_IMAGE}
+    command: ['sleep', 'infinity']
+    networks: [edge]
+
+  helio-edge:
+    # TCP forwarder for the MCP edge. Point the agent's MCP client at
+    # http://helio-edge:3000/mcp. It relays port 3000 and nothing else.
+    image: ${SANDBOX_FORWARDER_IMAGE}
+    configs:
+      - source: helio_edge_conf
+        target: /etc/nginx/nginx.conf
+    networks: [edge, plane]
+    depends_on: [helio]
+    restart: unless-stopped
+
+  helio:
+    image: ghcr.io/gethelio/helio:${imageTag}
+    networks: [plane, internal]
+    environment:
+      # Put HELIO_DASHBOARD_SECRET=<secret or sha256:digest> in ./.env
+      # (this directory is never mounted into agent) or export it.
+      # \`helio secret\` prints a fresh pair.
+      HELIO_DASHBOARD_SECRET: '\${HELIO_DASHBOARD_SECRET:?put it in ./.env or export it; generate with: helio secret}'
+    volumes:
+      - ./helio:/config:ro
+      - helio-data:/data
+    ports:
+      # The dashboard, the operator control plane: host loopback only.
+      - '127.0.0.1:3100:3100'
+    depends_on: [mcp-server]
+    restart: unless-stopped
+
+  mcp-server:
+    # Your MCP server. Set the image first: \`docker compose up\` fails at
+    # the image pull until you do. Keep it on \`internal\` only. To try the
+    # layout without one, save
+    # https://raw.githubusercontent.com/gethelio/helio/main/docker/mcp-echo-server.mjs
+    # as ./mcp-server/server.mjs and use the three commented lines
+    # instead of the image line.
+    image: your-org/your-mcp-server:latest
+    # image: node:24-slim
+    # command: ['node', '/srv/server.mjs']
+    # volumes: ['./mcp-server/server.mjs:/srv/server.mjs:ro']
+    networks: [internal]
+    restart: unless-stopped
+
+configs:
+  helio_edge_conf:
+    content: |
+      events {}
+      stream {
+        resolver 127.0.0.11 valid=1s;
+        server {
+          listen 3000;
+          proxy_timeout 1h;
+          set $$helio helio:3000;
+          proxy_pass $$helio;
+        }
+      }
+
+networks:
+  edge: {} # agent + helio-edge; an ordinary bridge with internet egress
+  plane: {} # helio-edge + helio; Helio's route out for internet upstreams
+  internal:
+    internal: true # helio + mcp-server; no route anywhere else
+
+volumes:
+  helio-data: {}
+`
+}
+
+export function renderSandboxConfig(): string {
+  return `# Helio sidecar config. This directory is mounted read-only into the
+# helio service and never into the agent. Edit it on the host; policy
+# changes reload live.
+version: '1'
+
+upstream:
+  url: 'http://mcp-server:8080/mcp' # compose service name on the internal network
+  transport: streamable-http
+  # For an upstream that needs a credential, keep the only copy in this
+  # service's environment; the agent never holds it:
+  # headers:
+  #   Authorization: 'Bearer \${UPSTREAM_TOKEN}'
+
+listen:
+  port: 3000
+  host: '0.0.0.0' # inside the container; reached only through helio-edge
+
+policies:
+  default: allow
+  rules:
+    # Deny anything the tool marks as destructive.
+    - name: block-destructive
+      match:
+        annotations:
+          destructiveHint: true
+      action: deny
+      feedback:
+        message: 'Destructive actions are blocked by policy.'
+        suggestion: 'Use a non-destructive alternative or request approval.'
+    # Allow read-only tools.
+    - name: allow-reads
+      match:
+        annotations:
+          readOnlyHint: true
+      action: allow
+
+audit:
+  storage: sqlite
+  path: /data/helio-audit.db
+  retention: 90d
+  include_responses: true
+
+dashboard:
+  enabled: true
+  port: 3100
+  host: '0.0.0.0' # inside the container; the agent is on no network this container is on
+  # The variable may hold the secret or the sha256: digest \`helio secret\` prints.
+  api_secret: '\${HELIO_DASHBOARD_SECRET}'
+`
+}
+
+export function renderSandboxReadme(): string {
+  return `# Helio sidecar layout
+
+Written by \`helio init --sandbox\`. This directory is the Compose
+project directory. The agent container never mounts it.
+
+## What this layout guarantees
+
+From inside the \`agent\` container there is no route to the upstream
+except through Helio, no mount holding Helio's config, no route to
+Helio's dashboard by service name or address, and no copy of an
+upstream credential. Helio is attached to no network the agent is on;
+\`helio-edge\` forwards TCP port 3000 to it and nothing else.
+
+## Make it yours
+
+1. \`compose.yaml\`: set the \`agent\` image (or \`build:\`) and the
+   \`mcp-server\` image. \`docker compose up\` fails at the image pull until
+   the \`mcp-server\` image is set. Keep \`agent\` on \`edge\` only and
+   \`mcp-server\` on \`internal\` only.
+2. Run \`helio secret\`. Put \`HELIO_DASHBOARD_SECRET=sha256:<digest>\` in
+   \`./.env\` next to \`compose.yaml\` (or export it). The variable may hold
+   the secret itself or its \`sha256:\` digest; the dashboard login and the
+   Bearer header always take the secret.
+3. \`docker compose up -d\`, then run the checks below from inside the
+   agent container (\`docker compose exec agent sh\`).
+4. Point the agent's MCP client at \`http://helio-edge:3000/mcp\`. The
+   dashboard is on the host at \`http://127.0.0.1:3100\`.
+
+## Hard constraints
+
+- Never mount \`.\` or \`.env\` into the \`agent\` service.
+- Never mount \`docker.sock\` into it; an agent with the socket is the host.
+- Secrets only on the \`helio\` service.
+- \`./helio/\` is never mounted into \`agent\`.
+- \`edge\` has internet egress, so an upstream the agent could reach on
+  its own is protected only by Helio holding the sole copy of its
+  credential (\`upstream.headers\` with \`\${VAR}\` in \`helio/helio.yaml\`).
+
+## Verify from inside the agent container
+
+\`\`\`sh
+# 1. No route to the upstream: must fail (exit 6 or 7).
+curl -s -m 3 http://mcp-server:8080/mcp; echo "exit: $?"
+# 2. No mount holding the config: both paths must be missing.
+ls /config /workspace/helio 2>&1; echo "exit: $?"
+# 3. No route to the dashboard: must fail (exit 6; helio-edge:3100 gives 7).
+curl -s -m 3 http://helio:3100/api/health; echo "exit: $?"
+# 4. No credential in the environment: must print nothing.
+env | grep -iE 'helio|upstream|secret'; echo "exit: $?"
+# Through Helio it works and is audited:
+curl -s -m 5 -X POST http://helio-edge:3000/mcp \\
+  -H 'Content-Type: application/json' \\
+  -H 'Accept: application/json, text/event-stream' \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+\`\`\`
+
+On Docker Desktop (macOS and Windows) every port published to the host
+is reachable from every container through the Desktop host gateway:
+\`curl -s -m 3 http://host.docker.internal:3100/api/health\` answers from
+the agent there. Run the same probe on your own host and believe its
+answer. The dashboard's control-plane routes stay behind its secret,
+which the agent does not hold; \`/api/health\` answers without it. If that
+is not acceptable, front the dashboard with an
+authenticating reverse proxy or do not publish it while an untrusted
+agent runs.
+
+## Editing the config
+
+\`./helio/\` is mounted read-only into the \`helio\` service, so edit
+\`helio/helio.yaml\` on the host; policy changes reload live. Change it
+from the host only. The agent container has no path to it, and that is
+the point.
+
+## Dev container
+
+\`workspace/.devcontainer/devcontainer.json\`:
+
+\`\`\`jsonc
+{
+  "name": "agent-workspace",
+  "dockerComposeFile": "../../compose.yaml",
+  "service": "agent",
+  "workspaceFolder": "/workspace"
+}
+\`\`\`
+
+and in \`compose.yaml\` give \`agent\` the mount \`./workspace:/workspace:cached\`
+(a sibling of \`helio/\`, never this directory itself). Do not add a
+\`forwardPorts\` entry for the dashboard: it is published to the host by
+the \`helio\` service, and the agent has no route to \`helio\` by design.
+`
+}


### PR DESCRIPTION
## Description

Phase E, second PR: `helio init --sandbox [dir]` writes the sidecar layout that `docs/deployment-sidecar.md` describes. One commit, `feat(cli): scaffold the sidecar layout with helio init --sandbox`.

The command writes three files into a new directory (`helio-sandbox` by default) that the agent container never mounts: `compose.yaml`, `helio/helio.yaml`, and `helio/README.md`. The compose file runs four services on three networks: the agent on `edge` only (a curl image with `sleep infinity` as the placeholder, so the checks run before a real agent is wired in), an nginx stream forwarder on `edge` and `plane` relaying port 3000 through Docker's resolver with a one-hour idle timeout, Helio on `plane` and `internal` with `./helio` mounted read-only into it alone and the dashboard published to the host loopback, and the upstream placeholder on `internal`. The config points at the upstream by its compose service name, carries the two starter rules, and takes the dashboard secret from `HELIO_DASHBOARD_SECRET`, so the command generates no secret; the next-steps block says to run `helio secret` and put the digest in `.env` next to `compose.yaml`. The README carries the hard constraints, the four checks to run from inside the agent container, the Docker Desktop residual, and a `devcontainer.json` snippet. The command refuses to overwrite an existing layout without `--force`, rejects an explicit `--output` by its option source so that `-o helio.yaml` is caught too, and pins the `helio` image to the CLI's own version, or `latest` for a source build.

The generated `compose.yaml` and `helio/helio.yaml` are byte-identical to the two fences on the sidecar page, and a test reads the page and pins that. The other tests pin the invariants the layout depends on. The config loads with the secret in the environment and keeps its keys in canonical order. The compose file has exactly the four services, the agent on `edge` with no `volumes` key, Helio never on `edge`, only Helio with an environment and a port (`127.0.0.1:3100:3100`), `./helio:/config:ro` on Helio alone, `internal` marked internal, and the forwarder config with `listen 3000`, the resolver, `proxy_timeout 1h`, and the `$$helio` variable as Compose escapes it; a guard rejects the forbidden agent mount sources (`.`, `..`, `./helio`, `.env`, `docker.sock`) and is exercised against that list so it is not vacuous. The README carries the five constraints and the four checks verbatim. Five CLI tests exec the built binary: the three-file layout and the next steps, the default directory under the working directory, the overwrite refusal and `--force`, the `--output` rejection in both shapes, and `helio validate` passing on the generated config.

The layout was run before it shipped: `helio init --sandbox` from the built CLI, the `mcp-server` placeholder swapped for the demo echo server as the compose comment says, a digest from `helio secret` in `.env`, `docker compose up -d`, then the README's checks from inside the agent container (no route to the upstream, no config mount, no route to the dashboard by service name or address, no credential in the environment, the tool list through `helio-edge:3000`, a destructive call denied), `helio validate` with and without the secret, and `nginx -T` inside the forwarder showing `set $helio helio:3000;`, `proxy_pass $helio;`, and `proxy_timeout 1h;`. The transcript and its rerun script are kept outside the repo in the maintainer's evidence directory for this phase.

One residual, stated in the generated README and the changelog next to the publish: on Docker Desktop every port published to the host is reachable from every container through the host gateway, so the dashboard at `127.0.0.1:3100` answers `/api/health` from the agent container while its control-plane routes stay behind the secret, which the agent does not hold.

The docs fold, in the same commit because `cli.ts` is drift-listed: the sidecar page says the command writes the same files and lists `helio/README.md` in its tree, the getting-started next steps and both READMEs point at the command, the CLI reference row gains the option, and the changelog gains an `### Added` entry.

Refs #342

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

Root means `CHANGELOG.md` and `README.md`; `packages/proxy/README.md` and `packages/proxy/AGENTS.md` are also touched.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode: no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `pnpm --filter @gethelio/proxy build`, then `node packages/proxy/dist/cli.js init --sandbox /tmp/sandbox`: three `Created` lines and the next-steps block on stderr, no secret printed.
2. `diff` the generated `compose.yaml` and `helio/helio.yaml` against the two fences on `docs/deployment-sidecar.md`: no differences (the page shows `latest`, which a source build also writes).
3. `HELIO_DASHBOARD_SECRET=x node packages/proxy/dist/cli.js validate -c /tmp/sandbox/helio/helio.yaml` prints `Config is valid ... (2 policy rules, 0 budgets)`; without the variable it fails naming it.
4. Set the `mcp-server` image (or use the commented echo-server lines), put a digest from `helio secret` in `.env`, run `docker compose up -d`, and run the README's checks from `docker compose exec agent sh`: exits 6, 1, 6, and 1, then the tool list through `helio-edge:3000`. On Docker Desktop the `host.docker.internal:3100` probe answers health.
5. `cd packages/proxy && pnpm exec vitest run src/sandbox-scaffold.test.ts` (15 tests) and `pnpm exec vitest run src/cli.test.ts -t sandbox` (5 tests).

## Additional Context

The `mcp-server` placeholder image does not exist by design: `docker compose up` fails at the image pull until it is set, and the README's first step and the compose comment say so. The two generated files never name the command or the README in their comments, so the page's fences and the generator's output can stay identical; only the generated README says it was written by the command. Nothing new surfaced during the work; no issue was filed.
