### PR TITLE
docs(readme): state the enforcement claims by tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,13 @@ Maintainer notes:
   `[helio] Audit DB migrated: added column "config_sha256"`; a v0.12.0
   database gets `upstream` and `config_sha256`, one notice each.
   Databases older than v0.12.0 still hit the clean break.
+- **The README states the enforcement claims by tier.** "Why Helio?"
+  now carries the two claims that hold at every tier (a rule in the
+  proxy cannot be forgotten, and enforcement is in the path rather than
+  in the prompt) and "cannot be weakened silently" with the mechanism
+  behind it; the enforcement-grades section states that claim's one
+  condition in the same-user install and names the deployments where
+  it falls away. The proxy package README mirrors it.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Model providers are building governance for their own platforms but your agents 
 
 Helio governs what agents **do to the rest of the world** across any MCP-compatible agent, any tool, any platform.
 
+A rule in Helio cannot be forgotten and cannot be weakened silently. It is not in the model's context, so a long session cannot evict it and an injection cannot argue it away, and enforcement is in the path rather than in the prompt: a tool call routed through Helio is decided before it is forwarded, whatever the model has been told. Every attempt to reload the policy file, including one that removes a rule, is an audit record, and every record carries the hash of the config in force when it was written, so a change shows against the decisions made under it. The "cannot be weakened silently" claim has one condition, stated under [Enforcement grades](#enforcement-grades).
+
 ## How It Works
 
 <p align="center">
@@ -50,7 +52,7 @@ Helio governs at the strongest grade each path physically allows, and records it
 - **Network** (HTTP MCP) — structural given you control the upstream's egress.
 - **Host-enforced** (hook adapters via the [adapter API](docs/adapter-api.md), e.g. OpenClaw) — for frameworks that run tools in-process and expose hooks rather than an MCP transport. The framework's hook gate enforces; Helio decides. This is a cooperative, lower grade than the proxy path, and Helio labels it as such rather than overclaiming. Helio's decisions still cannot be evicted from the agent's context or prompt-injected, and any attempt to route around them is visible in the audit trail.
 
-All three grades assume the proxy's config, secret, and audit store are outside the agent's reach. In the default local install they are not: the proxy runs as the same user as the agent. [SECURITY.md](SECURITY.md#process-and-filesystem-boundaries) states the boundary and the deployments that close it.
+All three grades assume the proxy's config, secret, and audit store are outside the agent's reach. In the default local install they are not: the proxy runs as the same user as the agent. [SECURITY.md](SECURITY.md#process-and-filesystem-boundaries) states the boundary and the deployments that close it. That install is also the condition on "cannot be weakened silently": a same-user agent can restart the proxy without the config pin and can edit or delete the audit file, so the reload record and the hash on every record are durable only while the agent cannot write the audit file, and the event stream and stderr are the channels that leave the box before that. Run the proxy as its own user or in its own container, as the recipes there do, and the condition falls away.
 
 ## Quick Start (5 minutes)
 

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -31,6 +31,8 @@ Model providers are building governance for their own platforms but your agents 
 
 Helio governs what agents **do to the rest of the world** across any MCP-compatible agent, any tool, any platform.
 
+A rule in Helio cannot be forgotten and cannot be weakened silently. It is not in the model's context, so a long session cannot evict it and an injection cannot argue it away, and enforcement is in the path rather than in the prompt: a tool call routed through Helio is decided before it is forwarded, whatever the model has been told. Every attempt to reload the policy file, including one that removes a rule, is an audit record, and every record carries the hash of the config in force when it was written, so a change shows against the decisions made under it. The "cannot be weakened silently" claim has one condition, stated under [Enforcement grades](#enforcement-grades).
+
 ## How It Works
 
 <p align="center">
@@ -50,7 +52,7 @@ Helio governs at the strongest grade each path physically allows, and records it
 - **Network** (HTTP MCP) — structural given you control the upstream's egress.
 - **Host-enforced** (hook adapters via the [adapter API](https://github.com/gethelio/helio/blob/main/docs/adapter-api.md), e.g. OpenClaw) — for frameworks that run tools in-process and expose hooks rather than an MCP transport. The framework's hook gate enforces; Helio decides. This is a cooperative, lower grade than the proxy path, and Helio labels it as such rather than overclaiming. Helio's decisions still cannot be evicted from the agent's context or prompt-injected, and any attempt to route around them is visible in the audit trail.
 
-All three grades assume the proxy's config, secret, and audit store are outside the agent's reach. In the default local install they are not: the proxy runs as the same user as the agent. [SECURITY.md](https://github.com/gethelio/helio/blob/main/SECURITY.md#process-and-filesystem-boundaries) states the boundary and the deployments that close it.
+All three grades assume the proxy's config, secret, and audit store are outside the agent's reach. In the default local install they are not: the proxy runs as the same user as the agent. [SECURITY.md](https://github.com/gethelio/helio/blob/main/SECURITY.md#process-and-filesystem-boundaries) states the boundary and the deployments that close it. That install is also the condition on "cannot be weakened silently": a same-user agent can restart the proxy without the config pin and can edit or delete the audit file, so the reload record and the hash on every record are durable only while the agent cannot write the audit file, and the event stream and stderr are the channels that leave the box before that. Run the proxy as its own user or in its own container, as the recipes there do, and the condition falls away.
 
 ## Quick Start (5 minutes)
 


### PR DESCRIPTION
## Description

Phase F, the in-repo copy: the README pair states the three enforcement claims by tier. One commit, `docs(readme): state the enforcement claims by tier`:

- "Why Helio?" gains a paragraph carrying the combined line, "cannot be forgotten, cannot be weakened silently", with the two claims that hold at every tier (a rule in Helio is not in the model's context, so a long session cannot evict it and an injection cannot argue it away; enforcement is in the path rather than in the prompt, so a tool call routed through Helio is decided before it is forwarded, whatever the model has been told) and the mechanism behind the third: every attempt to reload the policy file, including one that removes a rule, is an audit record, and every record carries the hash of the config in force when it was written.
- The condition on "cannot be weakened silently" is stated under Enforcement grades, on the paragraph that already names the same-user install: a same-user agent can restart the proxy without the config pin and can edit or delete the audit file, so the reload record and the hash on every record are durable only while the agent cannot write the audit file, and the event stream and stderr are the channels that leave the box before that. Running the proxy as its own user or in its own container, as the two deployment recipes do, removes the condition.
- `packages/proxy/README.md` mirrors both sentences with its absolute links. The two touched sections diff empty against the root README with the link prefix masked, and the whole-file masked diff stays at its 50-line baseline.
- One `### Changed` bullet under Unreleased, so the `v0.14.0` notes carry the wording change.

Every clause traces to a sentence of SECURITY.md's "Process and filesystem boundaries" section, which this PR does not touch. No new claim beyond the three and the tier framing; no "cannot be bypassed", "guarantee", "tamper-proof", or "cage" on any added line; the dashboard is not described. No `docs/` page, no source file, no changelog roll.

Not in this PR: `docs/adapter-api.md` still opens with "Helio's headline guarantee is structural enforcement" and its grade table still reads "Helio owns the only path to the tool", both without the co-located-process qualifier the README carries. That is filed as its own issue after this merges.

No issue is closed. Phase F has no issue of its own; it is tracked in the maintainer's enforcement-boundary remediation plan, outside the repo.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

Root means `README.md` and `CHANGELOG.md`; `packages/proxy` means `packages/proxy/README.md` only. No source file changes.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [ ] TypeScript strict mode: no `any` types or `@ts-ignore` without justification (no TypeScript in this PR)
- [ ] I have added or updated tests for my changes (documentation only; no config fence is added, so the samples guard has nothing new to check)
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. Read `README.md` line 34 (the new "Why Helio?" paragraph) and line 55 (the tier paragraph with its appended condition) against SECURITY.md, "Process and filesystem boundaries": the separate process and the trust domain (line 72), the reload record, the hash, the pin, and the two channels that leave the box (line 76), the two recipes (line 80), the same-user residuals (line 82). Every clause has a source sentence.
2. Mirror: `diff README.md <(sed -e 's#https://github.com/gethelio/helio/blob/main/##g' packages/proxy/README.md) | grep -c '^[<>]'` prints 50, the same as on main; the same diff restricted to lines 26-36 and 47-55 is empty.
3. Wording: `git diff -U0 main...HEAD | grep '^+' | grep -v '^+++' | grep -i "bypass\|tamper\|cage\|guarantee\|agent's reach"` returns only the two rewritten line-55 lines, whose "outside the agent's reach" is said of the config, secret, and audit store, as it was on main; the same pipeline with `grep -c $'\xe2\x80\x94'` prints 0.
4. `pnpm format:check`, `pnpm docs:check:ci`, and `pnpm lint` pass; the in-page link `#enforcement-grades` lands on the "Enforcement grades" heading in both READMEs.

## Additional Context

The sentences are the settled Phase F plan's, reviewed in four external rounds before implementation and one after, with every clause traced to its SECURITY.md line. The same sentences are the source for the site copy and the announcement post that follow the `v0.14.0` tag, so the repo carries the wording first. The description sentence at the top of the README is unchanged: it describes what the proxy does per call and makes no boundary claim. The in-page anchor follows the README's existing `#cross-tool-spend-budgets` link.
