### PR TITLE
fix(test): wait for the stdio death line instead of a fixed sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@ Maintainer notes:
   keeps serving the running policy instead of exiting on an unhandled
   rejection. It does not re-arm the watch: no later edit reloads until
   a restart.
+- **The stdio forwarder's death-line tests no longer race a fixed
+  sleep.** Three tests in `stdio-wrapper.test.ts` waited 100 ms for a
+  crashing child to exhaust its retries before asserting; on a slow or
+  loaded runner the assertion ran first and `pnpm test` went red with
+  nothing wrong in the proxy. They now wait for the death line itself,
+  up to the test's own budget.
 
 ## [0.13.1] - 2026-09-03
 

--- a/packages/proxy/src/transport/stdio-wrapper.test.ts
+++ b/packages/proxy/src/transport/stdio-wrapper.test.ts
@@ -32,6 +32,16 @@ function makeRequest(id: number, method: string): McpRequest {
   return { jsonrpc: '2.0', id, method }
 }
 
+/** Wait for the forwarder's death line to reach the console spy. */
+async function waitForDeathLine(logged: string[], line: string): Promise<void> {
+  await vi.waitFor(
+    () => {
+      expect(logged).toContain(line)
+    },
+    { timeout: 4000, interval: 20 },
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -169,21 +179,30 @@ describe('StdioForwarder', () => {
   })
 
   it('rejects forward when dead after max retries', async () => {
-    forwarder = new StdioForwarder({
-      command: 'node',
-      args: ['-e', CRASH_SCRIPT],
-      maxRetries: 0,
-      retryDelayMs: 10,
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logged.push(String(args[0]))
     })
+    try {
+      forwarder = new StdioForwarder({
+        command: 'node',
+        args: ['-e', CRASH_SCRIPT],
+        maxRetries: 0,
+        retryDelayMs: 10,
+      })
 
-    // start() will succeed (process spawns), but it will exit immediately.
-    // After exit with maxRetries=0, the forwarder should be dead.
-    await forwarder.start()
+      // start() will succeed (process spawns), but it will exit immediately.
+      // After exit with maxRetries=0, the forwarder should be dead.
+      await forwarder.start()
 
-    // Wait for the process to crash and be marked dead
-    await new Promise((resolve) => setTimeout(resolve, 100))
+      // The death line is logged only after the forwarder is marked dead
+      // and its child is gone, so the forward() below never writes.
+      await waitForDeathLine(logged, '[helio] Stdio forwarder: max retries (0) exceeded')
 
-    await expect(forwarder.forward(makeRequest(1, 'ping'))).rejects.toThrow('dead')
+      await expect(forwarder.forward(makeRequest(1, 'ping'))).rejects.toThrow('dead')
+    } finally {
+      spy.mockRestore()
+    }
   }, 5000)
 
   it('tags the max-retries death line with the upstream name when one is set (issue #294)', async () => {
@@ -201,9 +220,7 @@ describe('StdioForwarder', () => {
       })
       await forwarder.start()
 
-      // Wait for the crash to mark the forwarder dead and log the death line.
-      await new Promise((resolve) => setTimeout(resolve, 100))
-      expect(logged).toContain('[helio][files] Stdio forwarder: max retries (0) exceeded')
+      await waitForDeathLine(logged, '[helio][files] Stdio forwarder: max retries (0) exceeded')
     } finally {
       spy.mockRestore()
     }
@@ -223,8 +240,7 @@ describe('StdioForwarder', () => {
       })
       await forwarder.start()
 
-      await new Promise((resolve) => setTimeout(resolve, 100))
-      expect(logged).toContain('[helio] Stdio forwarder: max retries (0) exceeded')
+      await waitForDeathLine(logged, '[helio] Stdio forwarder: max retries (0) exceeded')
     } finally {
       spy.mockRestore()
     }


### PR DESCRIPTION
## Description

Three tests in `packages/proxy/src/transport/stdio-wrapper.test.ts` slept a fixed 100 ms after spawning a crashing child and then asserted on the forwarder's death: two on the logged max-retries line, one on `forward()` rejecting. On a slow or loaded runner the crash-retry cycle outlasts the sleep. The two log assertions see an empty array and fail with `expected [] to include '[helio] Stdio forwarder: max retries (0) exceeded'`, and a `forward()` issued before the child's `close` handler writes into a dead pipe and raises an unhandled `write EPIPE`. The suite goes red with nothing wrong in the proxy; since #338 that also skips the benchmark step, and the release pipeline's CI gate runs the same suite. One commit, `fix(test): wait for the stdio death line instead of a fixed sleep`:

- One helper under the file's Helpers banner, `waitForDeathLine`, polls the `console.error` spy with `vi.waitFor` every 20 ms for up to 4 s, inside each test's 5 s budget. The assertion stays `toContain` on the exact line, so a line that never arrives fails with the same text as before, after 4 s instead of 100 ms.
- The two death-line tests replace their sleep with the wait. Their pinned strings, `[helio]` bare and `[helio][files]` tagged, are unchanged.
- The dead-rejection test gains the same spy shape as its neighbors and waits for the bare death line before it calls `forward()`. The line is logged only after the forwarder is marked dead and its child is gone, so the call throws on the dead check and never reaches stdin. That is what retires the EPIPE face rather than just the empty-array one.
- One `### Fixed` bullet under Unreleased. The docs-drift guard lists the transport directory, so the changelog touch is what lets a test-only change through it.

`stdio-wrapper.ts` is not changed: no `isDead()` accessor, no death event. The built `packages/proxy/dist/cli.js` hashes the same as main, `23438e89...db25d`, so the runtime evidence recorded against `0143ea7` stays valid. No vitest config change, no `retry`, no budget change. The auto-restart test's 500 ms sleep is a different wait with a different failure (a 10 s whole-test timeout recorded on #271) and stays as it is.

Closes #340

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

`packages/proxy` means the one test file; Root means `CHANGELOG.md`. No runtime source changes.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode: no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. From `packages/proxy`, `pnpm exec vitest run src/transport/stdio-wrapper.test.ts` passes 13/13. Repeat it; it stays green in isolation, as it did on main, because isolation is not where the race lands.
2. The old face, on demand: check out `main`, change the `100` in the three `setTimeout(resolve, 100)` sleeps of that file (lines 184, 205, 226) to `0`, and run the same command. The two death-line tests fail with `expected [] to include '[helio] Stdio forwarder: max retries (0) exceeded'` and its `[helio][files]` twin. On this branch there is no sleep to shorten.
3. The wait is not a no-op: in the helper, set the `timeout` to `1` and all three tests fail with the same `toContain` text; restore it, comment out the `console.error` call in `stdio-wrapper.ts` (the death line), and all three fail after about 4 s with the same text. Restore both.
4. `pnpm build` then `shasum -a 256 packages/proxy/dist/cli.js` prints the same hash as on main.

## Additional Context

The fix is the shape #340 proposed, `vi.waitFor` as `governed-forwarder.test.ts` already uses it, with a 4 s ceiling inside the 5 s budgets so the test's own timeout stays the outer guard. Under the full workspace suite at one-minute loads from 8 to 24 the file showed no face in three consecutive runs; one of those runs failed on the two-upstream `ECONNRESET` face already recorded on #271, which is a different file and is noted there after this merges. #340's table labels line 184 as the auto-restart test; that line is the dead-rejection test's sleep, and the auto-restart test's sleep is line 267 on main. Both notes go to #271 with the retired faces.
