### PR TITLE
docs: state the structural grade and the Docker Desktop mount limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,16 @@ Maintainer notes:
   behind it; the enforcement-grades section states that claim's one
   condition in the same-user install and names the deployments where
   it falls away. The proxy package README mirrors it.
+- **The docs say where the audit database must not be opened from.**
+  On Docker Desktop, a host process that opens a bind-mounted audit
+  database while the container holds it leaves the container on a
+  stale write-ahead log, and the container's next write and shutdown
+  checkpoint corrupt the file (`docs/audit.md`, `docker/README.md`).
+  The shipped recipes keep the database on a named volume and are not
+  affected; export from inside the container or stop it first. The
+  adapter API page states the structural grade with the co-located
+  process qualifier the README carries, and the Docker quickstart says
+  its single-file config mount reloads on in-place saves only.
 
 ### Fixed
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -191,6 +191,23 @@ the volume too:
 docker compose down -v
 ```
 
+The volume rather than a host directory is deliberate. On Docker
+Desktop, opening a bind-mounted audit database from the host
+(`sqlite3`, or `helio export` run on the host) while the container
+holds it leaves the container on a stale write-ahead log, and its next
+write and shutdown checkpoint leave a file that is no longer a SQLite
+database (the next boot fails with `SQLITE_NOTADB`). That is a
+limitation of SQLite's WAL mode across a virtualized bind mount, and a
+named volume is not host-readable, so the demo never gets there. To
+read the records, export from inside the container:
+
+```bash
+docker compose exec -T helio node packages/proxy/dist/cli.js export -c /config/helio.yaml > audit.json
+```
+
+Or stop the container first. See
+[Storage Backend](../docs/audit.md#storage-backend).
+
 ## Security model
 
 By default the quickstart binds **both** published ports to
@@ -245,12 +262,17 @@ container from writing its own config; it does nothing about a writer
 on the host. A process that can write `docker/helio.docker.yaml`,
 including a coding agent working in this checkout, changes policy on
 the running container through hot reload, and a `docker restart`
-loads the changed file again. That is fine for the demo. For a layout
-where the config and the upstream are out of the agent's reach and
-Helio is off the agent's network (the dashboard is unreachable by
-service name or address; a port published to the host stays reachable
-from containers through Docker Desktop's host gateway), use the
-[sidecar recipe](../docs/deployment-sidecar.md).
+loads the changed file again. That is fine for the demo. The mount is
+the single file, not its directory, so it reloads on an in-place save;
+an editor that saves by writing a temporary file and renaming it over
+the original gives the file a new inode, the running container keeps
+the old one, and the edit lands at `docker compose up --force-recreate`
+(the sidecar recipe mounts a directory, which reloads on both save
+styles). For a layout where the config and the upstream are out of the
+agent's reach and Helio is off the agent's network (the dashboard is
+unreachable by service name or address; a port published to the host
+stays reachable from containers through Docker Desktop's host
+gateway), use the [sidecar recipe](../docs/deployment-sidecar.md).
 
 To refuse a changed file instead of reloading it, uncomment the
 `HELIO_CONFIG_SHA256` line in `docker-compose.yml` and set the variable

--- a/docs/adapter-api.md
+++ b/docs/adapter-api.md
@@ -13,15 +13,15 @@ The governance API lives on the **SDK sideband** — the local server on `127.0.
 
 ## Why this exists, and what it does not promise
 
-Helio's headline guarantee is **structural** enforcement: an agent speaking MCP physically cannot reach a tool except through the proxy. Hook-based frameworks run their tools in-process, so there is nothing to proxy — the framework's hook dispatcher is the enforcement point, and Helio supplies the decision. This is the standard policy-decision-point / policy-enforcement-point split.
+Helio's strongest grade is **structural** enforcement: on the stdio MCP path Helio owns the child process it spawned, so nothing on that path routes around it; what a co-located process can still do is stated in [SECURITY.md](../SECURITY.md#process-and-filesystem-boundaries). Hook-based frameworks run their tools in-process, so there is nothing to proxy; the framework's hook dispatcher is the enforcement point, and Helio supplies the decision. This is the standard policy-decision-point / policy-enforcement-point split.
 
 Helio classifies every governed call by **enforcement grade**. The audit `origin` column separates host-enforced calls (the adapter's origin string) from proxy-path calls (`mcp`); whether an `mcp` record was structural or network is a property of the deployment's upstream transport, not something the record captures:
 
-| Grade           | Path                     | Guarantee                                                          |
-| --------------- | ------------------------ | ------------------------------------------------------------------ |
-| `structural`    | stdio MCP                | Helio owns the only path to the tool.                              |
-| `network`       | HTTP MCP                 | Structural given the operator controls egress.                     |
-| `host-enforced` | hook adapters (this API) | Enforcement by the host framework's hook gate; decisions by Helio. |
+| Grade           | Path                     | What holds                                                                                                              |
+| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `structural`    | stdio MCP                | Helio owns the child process it spawned; a co-located process that can run the same command line is outside this grade. |
+| `network`       | HTTP MCP                 | Structural given the operator controls egress.                                                                          |
+| `host-enforced` | hook adapters (this API) | Enforcement by the host framework's hook gate; decisions by Helio.                                                      |
 
 The host-enforced grade is **cooperative**: it works only if the adapter faithfully calls `/evaluate`, honors the decision, and reports `/audit`. A malicious in-process skill that bypasses the hook is outside what this API can prevent (`/install-scan` exists to gate exactly that vector). Helio does not market the hook path as proxy-grade, and neither should you.
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -145,6 +145,8 @@ Where the agent can write the audit file, a reload record is deletable after the
 
 Audit records are stored in a local SQLite database using WAL (Write-Ahead Logging) mode for optimal concurrent read/write performance.
 
+WAL mode needs coherent shared memory between every connection to the file, and a Docker Desktop bind mount does not provide it across the VM boundary. So when the proxy runs in a container on Docker Desktop with the database on a host directory bind-mounted into the container, do not open the file from the host (`sqlite3`, or `helio export` run on the host) while the container holds it. The host connection checkpoints and truncates the write-ahead log under the container's open connection, the container's next audit write lands on its stale view of the log, and its shutdown checkpoint then writes a main file that is no longer a SQLite database: the next start fails in the audit store with `SQLITE_NOTADB`, and the audit trail and the budget ledger in that file are gone. Keep the database on a named volume, as the shipped Docker recipes do, and export from inside the container (`docker compose exec -T helio node packages/proxy/dist/cli.js export -c /config/helio.yaml > audit.json`, run from the compose directory), or stop the container before opening the file from the host. Docker on Linux, where the host and the container share one kernel, is expected to be unaffected; it is untested.
+
 **Database configuration:**
 
 ```yaml

--- a/packages/proxy/src/transport/sse.ts
+++ b/packages/proxy/src/transport/sse.ts
@@ -24,11 +24,16 @@ const encoder = new TextEncoder()
 
 const MCP_SESSION_HEADER = 'mcp-session-id'
 
-// Stale-session sweeper tuning. Mirrors the dashboard SSE sweep in
-// dashboard/api.ts: a session that has not had a successful write in
-// STALE_THRESHOLD_MS (~3 missed heartbeats at 30s cadence) is evicted so
-// the session map cannot grow unboundedly when clients disappear without
-// a clean abort signal.
+// Stale-session sweeper tuning. A session whose lastActivity is older than
+// STALE_THRESHOLD_MS is evicted (the map entry dropped and the writer
+// closed) so the session map cannot grow unboundedly when clients
+// disappear without a clean abort signal. lastActivity is set when the
+// session is created and refreshed at every write ATTEMPT in
+// writeSessionEvent, before the write settles, not on success. The
+// dashboard SSE sweep in dashboard/api.ts lands on the same numbers at its
+// 30 s heartbeat default (a 90 s threshold, a 60 s sweep) but derives them
+// from that heartbeat, heartbeats its connections, and refreshes lastWrite
+// only when a write completes, so this block is not a mirror of that one.
 const STALE_THRESHOLD_MS = 90_000
 const SWEEP_INTERVAL_MS = 60_000
 
@@ -43,10 +48,11 @@ const SWEEP_INTERVAL_MS = 60_000
 // disables the cap silently disables a governance control.
 //
 // Do NOT add a periodic keepalive/heartbeat write to the downstream /sse
-// stream. lastActivity is refreshed only on successful writes, so a
-// held-open unproven session goes idle and is swept within
-// STALE_THRESHOLD_MS + SWEEP_INTERVAL_MS; a heartbeat would refresh it
-// forever and let held-open connections pin the cap indefinitely.
+// stream. lastActivity is refreshed only when writeSessionEvent attempts a
+// write, and a held-open unproven session receives no writes at all, so it
+// goes idle and is swept within STALE_THRESHOLD_MS + SWEEP_INTERVAL_MS; a
+// heartbeat would refresh it forever and let held-open connections pin the
+// cap indefinitely.
 const MAX_CONCURRENT_SESSIONS = 1024
 
 // Cap-refusal log window. Deliberately time-based, unlike the origin


### PR DESCRIPTION
## Description

Four documentation corrections and one changelog entry, in one commit, `docs: state the structural grade and the Docker Desktop mount limits`. Comment lines only in `packages/proxy/src/transport/sse.ts`; no runtime line changes.

- `docs/adapter-api.md` states the structural enforcement grade the way the README and SECURITY.md state it: on the stdio path Helio owns the child process it spawned, and a co-located process that can run the same command line is outside the grade, with a link to the "Process and filesystem boundaries" section. The grade table's "Guarantee" column is renamed "What holds" and its `structural` cell carries the same qualifier.
- `docs/audit.md` says, under Storage Backend, that on Docker Desktop the audit database must not be opened from the host while a container holds it: WAL mode needs coherent shared memory between connections, which a bind mount does not provide across the VM boundary; a host open checkpoints and truncates the write-ahead log under the container, the container's next write lands on a stale view, and its shutdown checkpoint leaves a file that is no longer a SQLite database (the next start fails with `SQLITE_NOTADB`; the audit trail and the budget ledger are gone). The safe paths: keep the database on a named volume, as the shipped recipes do, and export from inside the container, or stop the container first. Docker on Linux is expected to be unaffected and is untested.
- `docker/README.md` (no package box; named here) gains a paragraph under "Reset the demo" saying why the quickstart keeps the database on the `helio-data` volume rather than a host directory, with the in-container export command in a fence, and one sentence in the security model's config-mount paragraph: the single-file bind mount reloads on an in-place save, while an editor that saves by writing a temporary file and renaming it over the original leaves the running container on the old inode until `docker compose up --force-recreate` (the sidecar recipe mounts a directory, which reloads on both save styles).
- `packages/proxy/src/transport/sse.ts`: the two sweeper comment blocks now describe the mechanism the code implements. `lastActivity` is refreshed at every write attempt in `writeSessionEvent`, before the write settles, not on success; the sweeper drops the map entry and closes the writer; and the block is not a mirror of the dashboard sweep, which lands on the same 90 s / 60 s numbers at its 30 s heartbeat default but derives them from that heartbeat, heartbeats its connections, and refreshes `lastWrite` only when a write completes. The no-heartbeat rule and its conclusion are unchanged.
- `CHANGELOG.md`: one `### Changed` bullet under Unreleased recording the Docker Desktop finding, the shipped recipes' named volume, the two safe paths, the adapter-page wording, and the quickstart's mount note.

The built `packages/proxy/dist/cli.js` hashes the same as at `0143ea7` and `6bff2a3`, `23438e890c7ced217b835bc7a332e39e00da06027b2c7d448d541469de5db25d`, so the enforcement-boundary transcripts taken on `0143ea7` still describe the shipped code. `docker/docker-compose.yml` keeps the single-file mount (the sentence form was ruled over a directory-mount switch); `SECURITY.md`, the README pair, the sidecar page, and the sandbox scaffold are not touched.

Closes #358
Closes #359
Closes #353
Closes #329

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

`packages/proxy` means the comment blocks in `sse.ts`; Root means `CHANGELOG.md`; `docs/` means `adapter-api.md` and `audit.md`. `docker/README.md` has no box.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode: no `any` types or `@ts-ignore` without justification
- [ ] I have added or updated tests for my changes (not applicable: documentation and comment lines; the `/sse` sweeper suite passes unchanged, 36/36)
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. The wording inventory: `grep -rn -i "guarantee" README.md packages/proxy/README.md docs SECURITY.md docker/README.md` returns exactly `docs/audit.md:27` and `docs/configuration.md:212` (both about a rejection, neither about the boundary); `grep -rn -i "cannot be bypassed\|can't be bypassed\|bypass governance"` and `grep -rn -i "tamper-proof\|tamperproof\|\bcage\b\|prevents tampering"` over the same paths are empty; `grep -n 'physically cannot reach\|owns the only path' docs/adapter-api.md` is empty.
2. Comment lines only: `git diff main...HEAD -- packages/proxy/src/transport/sse.ts | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]\s*//'` prints nothing. `pnpm --filter @gethelio/proxy exec vitest run src/transport/sse.test.ts` passes 36/36.
3. The table: `git diff -w main...HEAD -- docs/adapter-api.md` shows four lines (the prose line, the header, the separator, and the `structural` row); the rest of the table diff is prettier's re-padding.
4. The links: `grep -n '^## Process and filesystem boundaries' SECURITY.md` and `grep -n '^## Storage Backend' docs/audit.md` find the anchors the two new links point at.
5. The export fence, against the quickstart: in `docker/`, `HELIO_DASHBOARD_SECRET=$(openssl rand -hex 32) docker compose up -d`, make one `tools/call` through `http://127.0.0.1:3000/mcp`, then run the fence as written (`docker compose exec -T helio node packages/proxy/dist/cli.js export -c /config/helio.yaml > audit.json`); `audit.json` on the host is a JSON array with the record. `docker compose down -v` afterwards if no `helio` volume existed before.
6. `pnpm build` then `shasum -a 256 packages/proxy/dist/cli.js` prints `23438e890c7ced217b835bc7a332e39e00da06027b2c7d448d541469de5db25d`, the same as on main.

## Additional Context

#329 says the `/sse` sweeper "only drops the map entry" while the dashboard sweeper severs; that is wrong at the SHA the issue cites (`8da3591`) and at this fix: the `/sse` sweeper has closed the writer at eviction since the first public release (`538f3f0`). The asymmetry that holds is the refresh semantics (attempt-time here, completed-write there) and the heartbeat, and the rewritten comment says exactly that. The attempt-time mechanism is as the issue describes.

#358 says `git diff -w` shows three content lines for the table; it shows four, because the separator row's dashes grow with the widened column and `-w` ignores spaces, not dashes.

The #353 sentence names what was observed (`docker compose up --force-recreate` boots the renamed file) and stays silent on what a `docker restart` does with a rename-saved single-file mount, because nobody has observed it. The paragraph's older clause about `docker restart` describes an in-place host write and is unchanged.

The Docker Desktop finding is a documented SQLite WAL limitation over a virtualized bind mount, reproduced on the released `0.13.1` image and on a source build of `0143ea7`; Helio cannot reliably tell a virtualized bind mount from a local disk from inside the container, so the fix is documentation, not a code guard. The `helio init --sandbox` scaffold, the sidecar recipe, and the quickstart all keep `/data` on a named volume and are not affected.
