### PR TITLE
docs(changelog): roll unreleased entries into 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Maintainer notes:
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-09-07
+
 ### Added
 
 - **`helio init --sandbox [dir]` writes the sidecar layout.** Three
@@ -1409,7 +1411,8 @@ Helio's first public release.
 - Secret scanning is now part of the default quality gate (pre-commit + CI),
   designed to prevent accidental credential commits before merge.
 
-[Unreleased]: https://github.com/gethelio/helio/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/gethelio/helio/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/gethelio/helio/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/gethelio/helio/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/gethelio/helio/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/gethelio/helio/compare/v0.11.1...v0.12.0


### PR DESCRIPTION
## Description

Roll the `Unreleased` entries into a new `## [0.14.0] - 2026-09-07` section ahead of the `v0.14.0` tag. The diff is a pure insertion: the new dated heading and its blank line under `## [Unreleased]`, plus the footer compare links (`[Unreleased]` repointed at `v0.14.0...HEAD`, a new `[0.14.0]` line above `[0.13.1]`). Every entry moves byte-identical; a range diff between `main` and this branch over the moved block is empty, and the bullet count (13) is unchanged.

The section carries the audited policy reloads with the config hash on every record, the `HELIO_CONFIG_SHA256` pin, `helio config hash`, and the startup posture line (#356, which also closes #341 and #351), the sidecar and separate-user deployment recipes (#354), `helio init --sandbox` (#355), the README enforcement claims by tier (#357), the note on where the audit database must not be opened from (#362), and the stdio death-line test fix (#360). Prettier was not run on this file: entries move unchanged and `format:check` passes as is.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [ ] TypeScript strict mode — no `any` types or `@ts-ignore` without justification (not applicable: changelog only)
- [ ] I have added or updated tests for my changes (not applicable: changelog only)
- [ ] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `git diff main...HEAD -- CHANGELOG.md | grep -E '^[+-]' | grep -vE '^\+\+\+|^---'` shows exactly five lines: the new heading, its blank line, and the three footer lines.
2. `diff <(git show main:CHANGELOG.md | awk 'NR>=22 && NR<=144') <(awk 'NR>=24 && NR<=146' CHANGELOG.md)` prints nothing, and `grep -cE '^- '` over each range gives 13.
3. `pnpm format:check && pnpm lint && pnpm typecheck && pnpm docs:check:samples` pass (`Config samples: 92 checked, 90 passed, 0 failed, 2 skipped`).

## Additional Context

Release prep for `v0.14.0`. The tag follows once this is on `main` and the pre-flight gauntlet passes.
