### PR TITLE
fix(ci): generate the release SBOM from the lockfile for the proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,15 @@ jobs:
           fi
           echo "::notice title=Dependency audit skipped::No dependency manifest or install input changed in this PR (package.json / pnpm-lock.yaml / pnpm-workspace.yaml / .npmrc / .pnpmfile.* / patches/). The full-tree audit is enforced on main, on release, and by the daily Security Audit workflow."
 
+      # The release SBOM's generator and guard run on every push and
+      # pull request so a pnpm or manifest change that breaks them is
+      # red here, not at the next tag (the asset shipped empty for
+      # three releases while nothing ran it, issue #349). Written to
+      # the runner's temp directory: the document is prettier-dirty
+      # and `pnpm format:check` scans the workspace below.
+      - name: Generate and check the SBOM
+        run: scripts/generate-sbom.sh "$RUNNER_TEMP/sbom.json"
+
       - name: Build
         run: pnpm build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # Attestations (explicit for documentation): attach full build
           # provenance to the image. No image SBOM here — the `sbom` job below
-          # publishes a CycloneDX dependency SBOM as a release asset instead.
+          # publishes a CycloneDX SBOM of the proxy's lockfile-pinned production
+          # tree as a release asset instead.
           provenance: mode=max
           sbom: false
           cache-from: type=gha
@@ -282,12 +283,30 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Generate CycloneDX SBOM
-        run: npx @cyclonedx/cyclonedx-npm --output-file sbom.json --output-format json
-          --omit=dev
+      - name: Set package versions
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: scripts/set-release-version.sh "$VERSION"
+
+      # Production packages only: `pnpm sbom` reads license and author
+      # metadata from the store, so the store must hold the proxy's
+      # production tree, and nothing here needs the dev tree or a
+      # native build.
+      - name: Install production dependencies
+        run: pnpm install --frozen-lockfile --prod --ignore-scripts
+
+      # CycloneDX 1.6 of @gethelio/proxy's production tree as
+      # pnpm-lock.yaml pins it, at the tag's version; the script fails
+      # the job on an empty, mis-scoped, incomplete, or unlicensed
+      # inventory (issue #349).
+      - name: Generate and check the SBOM
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: scripts/generate-sbom.sh sbom.json "$VERSION"
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ coverage
 /build
 dist/
 dist
+# release SBOM written at the root by scripts/generate-sbom.sh (prettier-dirty)
+/sbom.json
 
 # misc
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ pnpm-lock.yaml
 packages/python-sdk
 .claude/
 .superpowers/
+/sbom.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ Maintainer notes:
 
 ## [Unreleased]
 
+### Fixed
+
+- **The release SBOM now inventories the proxy's production
+  dependency tree.** Every `sbom.json` attached to a release so far
+  listed zero components: the generator ran at the workspace root,
+  whose package has no runtime dependencies. The release pipeline
+  now writes the CycloneDX 1.6 document with `pnpm sbom` for
+  `@gethelio/proxy` at the tag's version, straight from
+  `pnpm-lock.yaml`, and fails the release if the inventory is empty,
+  names the wrong package or version, misses a direct dependency, or
+  carries an unlicensed component. The same check runs in CI.
+
 ## [0.14.0] - 2026-09-07
 
 ### Added

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -42,7 +42,7 @@ The dashboard source lives in the internal workspace package `packages/dashboard
 | `react-router` | Client-side routing for the 5 dashboard pages             | Declarative, data-router-compatible, no external state libraries |
 | `recharts`     | Time-series, pie, and bar charts on the Analytics page    | Pure React, composable, no global theme context                  |
 
-These packages are **bundled** into dashboard static files at build time (`dist/assets/*.js`) and then copied into `@gethelio/proxy` (`dist/dashboard-assets/`) during proxy build. They remain listed as `dependencies` (not `devDependencies`) in this workspace package so CycloneDX SBOM generation with `--omit=dev` still captures the shipped frontend dependency tree.
+These packages are **bundled** into dashboard static files at build time (`dist/assets/*.js`) and then copied into `@gethelio/proxy` (`dist/dashboard-assets/`) during proxy build. They stay listed as `dependencies` (not `devDependencies`) because their code ships in the release artifact. The `sbom.json` attached to each GitHub Release inventories the proxy's production dependency tree as `pnpm-lock.yaml` pins it (`scripts/generate-sbom.sh`), type-definition packages included where a runtime dependency declares them (`@types/node` and `@types/retry` through `@slack/web-api`, `undici-types` through `@types/node`); the bundled frontend tree is not part of that document.
 
 ### Dev Dependencies (build-only)
 

--- a/scripts/generate-sbom.sh
+++ b/scripts/generate-sbom.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Generate the release SBOM for @gethelio/proxy and refuse an empty or
+# mis-scoped one.
+#
+# The document is CycloneDX 1.6 JSON written by `pnpm sbom` from
+# pnpm-lock.yaml, scoped to the proxy package's production tree: the
+# tree CI tests at the tag and the tree docker/Dockerfile installs. The
+# checks exist because the asset shipped empty for three releases
+# without anything noticing (issue #349).
+#
+# Usage: scripts/generate-sbom.sh <output-file> [expected-version]
+#   expected-version defaults to packages/proxy/package.json's version.
+#   The release workflow passes the tag's version after
+#   scripts/set-release-version.sh has stamped it.
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+OUT="${1:?usage: $0 <output-file> [expected-version]}"
+MANIFEST="${ROOT_DIR}/packages/proxy/package.json"
+EXPECTED_VERSION="${2:-$(jq -r .version "${MANIFEST}")}"
+EXPECTED_PURL="pkg:npm/%40gethelio/proxy@${EXPECTED_VERSION}"
+
+fail() {
+  echo "SBOM CHECK FAIL: $1" >&2
+  exit 1
+}
+
+cd "${ROOT_DIR}"
+rm -f "${OUT}"
+pnpm sbom --sbom-format cyclonedx --sbom-spec-version 1.6 \
+  --sbom-type application --prod --filter @gethelio/proxy \
+  --fail-if-no-match --out "${OUT}"
+[[ -f "${OUT}" ]] || fail "pnpm sbom wrote no file at ${OUT}"
+
+count="$(jq '.components | length' "${OUT}")"
+[[ "${count}" -gt 0 ]] || fail "components is empty"
+
+purl="$(jq -r '.metadata.component.purl // ""' "${OUT}")"
+[[ "${purl}" == "${EXPECTED_PURL}" ]] \
+  || fail "metadata.component.purl is '${purl}', expected '${EXPECTED_PURL}'"
+
+while IFS=$'\t' read -r name version; do
+  jq -e --arg n "${name}" --arg v "${version}" '
+    [.components[]
+     | select(((.group // "") + (if .group then "/" else "" end) + .name) == $n
+              and .version == $v)]
+    | length == 1' "${OUT}" >/dev/null \
+    || fail "direct dependency ${name}@${version} is not listed exactly once"
+done < <(jq -r '.dependencies | to_entries[] | "\(.key)\t\(.value)"' "${MANIFEST}")
+
+unlicensed="$(jq '[.components[] | select(.licenses == null)] | length' "${OUT}")"
+[[ "${unlicensed}" -eq 0 ]] \
+  || fail "${unlicensed} components carry no license (was the store populated before pnpm sbom?)"
+
+echo "SBOM OK: ${purl}, ${count} components, every direct dependency listed once, all licensed"


### PR DESCRIPTION
## Description

Every `sbom.json` attached to a GitHub Release so far listed zero components. The `sbom` job ran `@cyclonedx/cyclonedx-npm --omit=dev` at the workspace root, whose package is the private workspace shell with no runtime dependencies, so the document was schema-valid and empty, with a nameless root component. Neither of the issue's two suggestions works with pnpm's layout: from inside `packages/proxy` the npm generator exits on `npm ls` errors (or, with the errors ignored, inventories the hoisted dev tree), and the packed tarball resolves against the registry and misstates the image (axios 1.20.0 where the workspace override pins 1.18.1).

This PR writes the document with pnpm's native `pnpm sbom`, scoped to `@gethelio/proxy` with `--prod` at the tag's version, straight from `pnpm-lock.yaml`: the tree CI tested at the tag and the tree the Docker image installs. A new `scripts/generate-sbom.sh` wraps the command and fails the job when the inventory is empty, names the wrong package or version, misses a direct dependency, or carries an unlicensed component (the last one catches a run against an unpopulated store, which exits 0 and drops every license). The release `sbom` job now stamps the version before generating and installs production packages only; the same script runs in CI on every push and pull request, writing to the runner's temp directory, so a pnpm or manifest change that breaks the generator is red on the PR that causes it rather than at the next tag.

`DEPENDENCIES.md` stops claiming the dashboard's `dependencies` placement feeds the SBOM (it never did) and says what the asset inventories. No dependency is added; the `@cyclonedx/*` tool is deleted, not pinned. No `packages/*` or `docker/Dockerfile` change. `sbom: false` on the image stays.

Closes #349

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [ ] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. From the repository root with the workspace installed, run `scripts/generate-sbom.sh /tmp/sbom.json`. Expected: `SBOM OK: pkg:npm/%40gethelio/proxy@0.0.0, 91 components, every direct dependency listed once, all licensed`. `jq '.components | length' /tmp/sbom.json` is 91 and `jq -r '.metadata.component.purl' /tmp/sbom.json` names the proxy.
2. Prove the guard would have refused every shipped asset: `gh release download v0.14.0 --pattern sbom.json --output /tmp/old.json`, then run the check block of the script (from `count=` to the final `echo`, with `fail()` and `OUT=/tmp/old.json`, `MANIFEST=packages/proxy/package.json`, `EXPECTED_PURL='pkg:npm/%40gethelio/proxy@0.14.0'` set by hand). Expected: `SBOM CHECK FAIL: components is empty`, exit 1.
3. Prove the version check: `scripts/generate-sbom.sh /tmp/sbom.json 1.2.3` without stamping. Expected: `SBOM CHECK FAIL: metadata.component.purl is 'pkg:npm/%40gethelio/proxy@0.0.0', expected 'pkg:npm/%40gethelio/proxy@1.2.3'`.
4. Prove the store check: add `--lockfile-only` to the `pnpm sbom` line and rerun. Expected: `SBOM CHECK FAIL: 91 components carry no license (was the store populated before pnpm sbom?)`. Revert.
5. In this PR's CI run, the new `Generate and check the SBOM` step in the CI job logs the `SBOM OK` line. The release `sbom` job is exercised by the next tag.

## Additional Context

The tests for this change are the script's own checks, exercised against real documents (the shipped v0.14.0 asset, the old generator's output, an unfiltered `pnpm sbom` document) and seven mutations of the script (lockfile-only, an empty store, an unstamped version, a deleted and a duplicated direct dependency, a missing filter, a filter that matches nothing with and without `--fail-if-no-match`); each showed the predicted failure. A `--filter` that matches nothing exits 0 and writes no file on pnpm 11.13.0, which is why the script removes the output path first, checks it exists after, and passes `--fail-if-no-match`.

Follow-ups, filed after the merge:

- The Docker `prod-deps` stage installs every workspace package's production tree at the root, so the runtime image carries the dashboard's react, react-dom, react-router, and recharts on disk without loading them; a `--filter @gethelio/proxy` there would make the release SBOM an exact statement of the image (bug).
- A dashboard-bundle SBOM as a second release asset via `pnpm sbom --split`, once `scripts/set-release-version.sh` also stamps `packages/dashboard` (feature). The `DEPENDENCIES.md` paragraph gains a pointer to it then.
- Backfill: regenerate `sbom.json` for `v0.13.0`, `v0.13.1`, and `v0.14.0` from each tag's lockfile with this script and replace the empty assets, with a note in each release body.
