### PR TITLE
fix(deps): upgrade js-yaml and hono for four runtime advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,21 @@ Maintainer notes:
   empty modules directory, the same packages the release `sbom.json`
   lists, and CI asserts that the image holds exactly that set.
 
+### Security
+
+- **js-yaml `4.3.1` → `4.3.2`** (GHSA-2883-xcg3-v3hh: `maxTotalMergeKeys`
+  did not bound CPU use for a sequence of empty merge sources). js-yaml
+  parses `helio.yaml`, which is operator-authored, so there is no remote
+  input path; the parser of a governance proxy is upgraded regardless.
+  The patch ships on the maintained v4 line, so no API changes.
+- **hono `4.12.34` → `4.13.7`** (GHSA-crvj-82cr-hjcx: the query parser
+  read parameters after the URL fragment; GHSA-g6gw-c38x-mqfc: unbounded
+  dot-notation nesting in `parseBody()`; GHSA-gqvv-2mrq-wpjv: `toSSG()`
+  path normalization). The proxy reads query strings through Hono on its
+  dashboard and SSE routes, the one served path the fixes reach; it does
+  not use `parseBody()`, `toSSG()`, or `hono/jsx` (whose XSS 4.13.7 also
+  closes). A minor release within the v4 line.
+
 ## [0.14.0] - 2026-09-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "9.39.4",
     "eslint-plugin-react-hooks": "7.0.1",
     "husky": "9.1.7",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "prettier": "3.8.1",
     "typescript": "5.9.3",
     "typescript-eslint": "8.57.1"

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -61,8 +61,8 @@
     "better-sqlite3": "12.8.0",
     "chokidar": "5.0.0",
     "commander": "14.0.3",
-    "hono": "4.12.34",
-    "js-yaml": "4.3.1",
+    "hono": "4.13.7",
+    "js-yaml": "4.3.2",
     "picomatch": "4.0.4",
     "safe-regex2": "5.0.0",
     "zod": "4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 9.1.7
         version: 9.1.7
       js-yaml:
-        specifier: 4.3.1
-        version: 4.3.1
+        specifier: 4.3.2
+        version: 4.3.2
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -98,7 +98,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: 2.0.12
-        version: 2.0.12(hono@4.12.34)
+        version: 2.0.12(hono@4.13.7)
       '@slack/web-api':
         specifier: 7.15.0
         version: 7.15.0
@@ -112,11 +112,11 @@ importers:
         specifier: 14.0.3
         version: 14.0.3
       hono:
-        specifier: 4.12.34
-        version: 4.12.34
+        specifier: 4.13.7
+        version: 4.13.7
       js-yaml:
-        specifier: 4.3.1
-        version: 4.3.1
+        specifier: 4.3.2
+        version: 4.3.2
       picomatch:
         specifier: 4.0.4
         version: 4.0.4
@@ -1795,8 +1795,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.34:
-    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -1901,8 +1901,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@29.0.1:
@@ -3173,7 +3173,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3190,9 +3190,9 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@hono/node-server@2.0.12(hono@4.12.34)':
+  '@hono/node-server@2.0.12(hono@4.13.7)':
     dependencies:
-      hono: 4.12.34
+      hono: 4.13.7
 
   '@humanfs/core@0.19.1': {}
 
@@ -3226,7 +3226,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.34)
+      '@hono/node-server': 2.0.12(hono@4.13.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3236,7 +3236,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.34
+      hono: 4.13.7
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4342,7 +4342,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.34: {}
+  hono@4.13.7: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -4422,7 +4422,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Description

The post-merge main run for #369 (`34336032749` on `686eba1`) went red at the audit step: a high advisory, GHSA-2883-xcg3-v3hh, landed against js-yaml at 21:24 UTC on 2026-09-08, seven hours after the last green main run. The audit prints the eslint path, but `js-yaml@4.3.1` is also a direct runtime dependency of `@gethelio/proxy`: it parses `helio.yaml` in the config loader and is one of the 91 packages the release `sbom.json` lists. The same night three moderate advisories landed against hono (GHSA-crvj-82cr-hjcx, GHSA-g6gw-c38x-mqfc, GHSA-gqvv-2mrq-wpjv), all in the shipped runtime per `pnpm audit --prod`. No override names either package; both are exact pins that the resolver could not move on its own.

This PR moves the pins: js-yaml `4.3.1` to `4.3.2` (root devDependency and the proxy's runtime dependency; the maintained v4 line, not the 5.x major) and hono `4.12.34` to `4.13.7` (the current patch on the v4 line; 4.13.5 carries the three fixes, 4.13.7 also closes an XSS in `hono/jsx`, which the proxy does not use). The lockfile moves these two packages and nothing else; the `@hono/node-server@2.0.12` entry only follows its peer suffix. `CHANGELOG.md` gains a `### Security` section under Unreleased in the file's existing shape.

Vetted before installing, all read-only:

- js-yaml 4.3.2 was published 2026-08-26, thirteen days before the advisory. The sole publisher (`vitaly`) is unchanged across 4.3.0, 4.3.1, and 4.3.2; no install hook; the one dependency (`argparse ^2.0.1`) is unchanged. There is no provenance attestation, so the tarball diff was read in full: 27 source lines in `lib/loader.js` (a per-source charge against the `maxTotalMergeKeys` budget and a cap of 100 on a merge sequence), mirrored into the four dist files and their maps, and the version line in `package.json`.
- hono 4.13.5 was published 2026-08-26, thirteen days before its advisories; 4.13.7 on 2026-09-04. Every version is published through GitHub Actions with a provenance attestation, declares no install hook and no dependency, and `@hono/node-server@2.0.12` declares `hono: ^4`. The diff in the files the proxy reaches (`utils/url.js`, `request.js`) is the query parser stopping at the fragment and a decode fast path; the proxy reads query strings through `c.req.query()` on the dashboard and SSE routes and uses none of `parseBody()`, `toSSG()`, the `accepts` helper, or `hono/jsx`.
- Neither version is younger than pnpm 11's 24-hour release-age guard, and `pnpm-workspace.yaml` is untouched (no `minimumReleaseAgeExclude` was written). Both lockfile integrities equal the registry's `dist.integrity` for the vetted versions.

After the install: `pnpm audit --audit-level=high` exits 0, `pnpm audit --prod --audit-level=moderate` reports no known vulnerabilities, and the full-tree audit at moderate lists the five dev-only advisories that predate this PR (two Vitest, two qs through the MCP SDK devDependency, humanfs), which stay for their own PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode — no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. `pnpm install --frozen-lockfile`, then `pnpm audit --audit-level=high`. Expected: exit 0 with no high advisory (five moderates and one ignored low remain, all dev-only).
2. `pnpm audit --prod --audit-level=moderate`. Expected: `No known vulnerabilities found`.
3. `git diff main..HEAD -- pnpm-lock.yaml | grep '^[-+]  [a-z@]'`. Expected: only the `hono@4.12.34` to `hono@4.13.7` and `js-yaml@4.3.1` to `js-yaml@4.3.2` entries and the `@hono/node-server@2.0.12(hono@...)` peer suffix.
4. `pnpm build && pnpm test`. Expected: dashboard 406 tests and proxy 3177 tests pass. `pnpm --filter @gethelio/proxy benchmark` keeps the governed overhead p99 under the 5 ms gate.
5. This PR touches two manifests and the lockfile, so CI runs the full-tree audit on the PR itself rather than skipping it.

## Additional Context

Locally: format, lint, typecheck, docs check, build, and the benchmark gate (governed overhead p99 0.33 ms) pass on the new tree. The first workspace-parallel `pnpm test` run showed four proxy failures at a host load average above 10, two of them in the CLI suite at 76 seconds, the timing shape of the stdio flakes tracked in #271 and #340; an isolated proxy rerun and a second full workspace run both passed everything, so those four are unreproduced rather than explained.

Once this merges, the post-merge main run is the first green main since `686eba1` and also the first main-branch execution of the `Generate and check the SBOMs` step from #369, which the red audit skipped.

The five remaining moderates (Vitest, qs, humanfs) are dev-only and wait for their own PR, as the qs and humanfs ones already did after v0.14.0.
