### PR TITLE
fix(test): bind the fixtures to 127.0.0.1 and replace the suite's timing guesses with polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ Maintainer notes:
 
 ### Fixed
 
+- **The test suite no longer fails on ports other processes hold.**
+  Every in-process test fixture bound the IPv6 wildcard on port 0, and
+  macOS hands such a bind a port another process already holds on
+  `127.0.0.1`; connections to the fixture then reached that process,
+  which answered with its own bytes or reset the socket. The fixtures
+  now bind `127.0.0.1`, where the kernel skips every held port, and
+  the CLI tests' spawned proxies pick ports below every ephemeral
+  range so they cannot land on one a port-0 listener holds.
 - **The release SBOM now inventories the proxy's production
   dependency tree.** Every `sbom.json` attached to a release so far
   listed zero components: the generator ran at the workspace root,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,11 @@ Maintainer notes:
   which answered with its own bytes or reset the socket. The fixtures
   now bind `127.0.0.1`, where the kernel skips every held port, and
   the CLI tests' spawned proxies pick ports below every ephemeral
-  range so they cannot land on one a port-0 listener holds.
+  range so they cannot land on one a port-0 listener holds. The stdio
+  crash-restart test waits for the restarted child through a marker
+  file instead of sleeping a fixed 500 ms before it forwards a request,
+  and the full end-to-end test polls the approval queue instead of
+  sleeping a fixed 100 ms before it reads a pending approval.
 - **The release SBOM now inventories the proxy's production
   dependency tree.** Every `sbom.json` attached to a release so far
   listed zero components: the generator ran at the workspace root,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ Maintainer notes:
   file instead of sleeping a fixed 500 ms before it forwards a request,
   and the full end-to-end test polls the approval queue instead of
   sleeping a fixed 100 ms before it reads a pending approval.
+  The governance integration test no longer asserts end-to-end latency
+  percentiles that measured the box rather than the proxy (the
+  benchmark script's governed-overhead gate is the latency check); it
+  still requires its thousand governed calls to complete and be
+  audited. The audit writer test pins that `push` never writes
+  synchronously instead of timing a hundred calls, and the CLI tests
+  that poll a spawned proxy's health endpoint fail at once with the
+  child's stderr when it exits first.
 - **The release SBOM now inventories the proxy's production
   dependency tree.** Every `sbom.json` attached to a release so far
   listed zero components: the generator ran at the workspace root,

--- a/packages/proxy/scripts/benchmark.ts
+++ b/packages/proxy/scripts/benchmark.ts
@@ -134,7 +134,7 @@ async function main(): Promise<void> {
   })
   const forwarder1 = new UpstreamForwarder({ url: config1.upstream.url as string })
   const app1 = createApp(config1, forwarder1)
-  const proxy1 = startOnDynamicPort(app1)
+  const proxy1 = await startOnDynamicPort(app1)
   const proxyUrl1 = `http://127.0.0.1:${String(proxy1.port)}/mcp`
 
   for (let i = 0; i < WARMUP_COUNT; i++) {
@@ -178,7 +178,7 @@ async function main(): Promise<void> {
   const auditWriter = new AuditWriter({ store: auditStore, bufferSize: 2000 })
   const governed = new GovernedForwarder(forwarder2, policy, { auditWriter })
   const app2 = createApp(config2, governed)
-  const proxy2 = startOnDynamicPort(app2)
+  const proxy2 = await startOnDynamicPort(app2)
   const proxyUrl2 = `http://127.0.0.1:${String(proxy2.port)}/mcp`
 
   // Prime annotation cache (intentionally before memory snapshots so the

--- a/packages/proxy/src/__tests__/e2e-full.test.ts
+++ b/packages/proxy/src/__tests__/e2e-full.test.ts
@@ -252,7 +252,7 @@ beforeAll(async () => {
 
   // 9. Create and start proxy server
   const app = createApp(config, governed)
-  proxyManaged = startOnDynamicPort(app)
+  proxyManaged = await startOnDynamicPort(app)
   proxyUrl = `http://127.0.0.1:${String(proxyManaged.port)}/mcp`
 
   // 10. Start sideband server (evidence API + governance endpoints)
@@ -267,7 +267,7 @@ beforeAll(async () => {
     sweepIntervalMs: 0,
   })
   const sidebandApp = createSidebandApp(evidenceStore, { governance: governanceService })
-  sidebandManaged = startOnDynamicPort(sidebandApp)
+  sidebandManaged = await startOnDynamicPort(sidebandApp)
   sidebandUrl = `http://127.0.0.1:${String(sidebandManaged.port)}`
 
   // 11. Start dashboard API server
@@ -283,7 +283,7 @@ beforeAll(async () => {
     },
     { staticDir: undefined },
   )
-  dashboardManaged = startOnDynamicPort(dashboardApp)
+  dashboardManaged = await startOnDynamicPort(dashboardApp)
   dashboardUrl = `http://127.0.0.1:${String(dashboardManaged.port)}`
 })
 

--- a/packages/proxy/src/__tests__/e2e-full.test.ts
+++ b/packages/proxy/src/__tests__/e2e-full.test.ts
@@ -8,7 +8,7 @@
  * This is the gold standard. If it passes, the MVP works.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { startHttpMcpServer } from './helpers/mcp-test-server.js'
 import { startOnDynamicPort, makeConfig, sendMcpRequest } from './helpers/test-utils.js'
 import type { ManagedServer } from './helpers/test-utils.js'
@@ -325,6 +325,22 @@ function getResultText(body: Record<string, unknown>): string {
 // Tests
 // ---------------------------------------------------------------------------
 
+/**
+ * Wait until the approval queue holds a pending ticket and return the
+ * pending list. A fixed sleep here outran the request under load.
+ */
+async function waitForPendingApproval(
+  queue: ApprovalQueue,
+): Promise<ReturnType<ApprovalQueue['listPending']>> {
+  await vi.waitFor(
+    () => {
+      expect(queue.listPending().length).toBeGreaterThanOrEqual(1)
+    },
+    { timeout: 4000, interval: 20 },
+  )
+  return queue.listPending()
+}
+
 describe('E2E: full MVP integration', () => {
   // Tests share mutable state (audit store, rate/spend limiters, evidence store,
   // approval queue, event collector) and MUST run in sequential order.
@@ -502,13 +518,7 @@ describe('E2E: full MVP integration', () => {
       arguments: { amount: 100, currency: 'USD', to_account: 'acct-1' },
     })
 
-    // Wait for the HTTP request to reach the proxy and create the ticket.
-    // The ticket is created synchronously inside ApprovalRouter.submit(),
-    // so 100ms is sufficient for the HTTP round-trip. A polling loop would
-    // be more robust but adds complexity for minimal gain in a sequential test.
-    await new Promise((r) => setTimeout(r, 100))
-    const pending = approvalQueue.listPending()
-    expect(pending.length).toBeGreaterThanOrEqual(1)
+    const pending = await waitForPendingApproval(approvalQueue)
     const ticketId = pending[0]?.id ?? ''
 
     // Approve via REST API on the dashboard sideband (/approvals is no
@@ -554,9 +564,7 @@ describe('E2E: full MVP integration', () => {
       arguments: { amount: 200, currency: 'USD', to_account: 'acct-2' },
     })
 
-    await new Promise((r) => setTimeout(r, 100))
-    const pending = approvalQueue.listPending()
-    expect(pending.length).toBeGreaterThanOrEqual(1)
+    const pending = await waitForPendingApproval(approvalQueue)
     const ticketId = pending[0]?.id ?? ''
 
     const denyRes = await fetch(`${dashboardUrl}/api/approvals/${ticketId}/deny`, {
@@ -775,9 +783,7 @@ describe('E2E: full MVP integration', () => {
       { sessionId },
     )
 
-    await new Promise((r) => setTimeout(r, 100))
-    const pending = approvalQueue.listPending()
-    expect(pending.length).toBeGreaterThanOrEqual(1)
+    await waitForPendingApproval(approvalQueue)
 
     approvalRouter.close()
 

--- a/packages/proxy/src/__tests__/e2e-python-sdk-sideband.test.ts
+++ b/packages/proxy/src/__tests__/e2e-python-sdk-sideband.test.ts
@@ -95,7 +95,7 @@ e2eDescribe('E2E: Python SDK → sideband → proxy → evidence grounding', () 
     const { policy } = compilePolicies(config.policies)
     const governed = new GovernedForwarder(forwarder, policy, { evidenceStore })
     const app = createApp(config, governed)
-    proxyManaged = startOnDynamicPort(app)
+    proxyManaged = await startOnDynamicPort(app)
     proxyUrl = `http://127.0.0.1:${String(proxyManaged.port)}/mcp`
 
     // Prime annotation cache
@@ -106,7 +106,7 @@ e2eDescribe('E2E: Python SDK → sideband → proxy → evidence grounding', () 
     // end-to-end over real HTTP — not just via Hono's in-memory
     // `app.request()` simulator used by `evidence/api.test.ts`.
     const sidebandApp = createSidebandApp(evidenceStore, { token: SDK_TOKEN })
-    sidebandManaged = startOnDynamicPort(sidebandApp)
+    sidebandManaged = await startOnDynamicPort(sidebandApp)
     sidebandUrl = `http://127.0.0.1:${String(sidebandManaged.port)}`
   })
 

--- a/packages/proxy/src/__tests__/helpers/test-utils.ts
+++ b/packages/proxy/src/__tests__/helpers/test-utils.ts
@@ -1,4 +1,3 @@
-import type { AddressInfo } from 'node:net'
 import type { Hono } from 'hono'
 import { serve } from '@hono/node-server'
 import type { ServerType } from '@hono/node-server'
@@ -11,27 +10,33 @@ export interface ManagedServer {
   close: () => Promise<void>
 }
 
-/** Extract the assigned port from a running server. */
-export function getPort(server: ServerType): number {
-  const addr = server.address() as AddressInfo
-  return addr.port
-}
-
-/** Start a Hono app on a dynamic port (port 0). */
-export function startOnDynamicPort(app: Hono): ManagedServer {
-  const server = serve({ fetch: app.fetch, port: 0 })
-  const port = getPort(server)
-  return {
-    server,
-    port,
-    close: () =>
-      new Promise<void>((resolve, reject) => {
-        server.close((err) => {
-          if (err) reject(err)
-          else resolve()
-        })
-      }),
-  }
+/**
+ * Start a Hono app on a dynamic port (port 0), bound to 127.0.0.1 so the
+ * kernel never hands it a port another process already holds on that
+ * address (issue #271: an IPv6-wildcard bind(0) is handed such ports on
+ * macOS, and the other process then answers the fixture's traffic).
+ * Binding a named host resolves asynchronously, so the port is known
+ * only once the server is listening.
+ */
+export function startOnDynamicPort(app: Hono): Promise<ManagedServer> {
+  return new Promise((resolve, reject) => {
+    const server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) => {
+      resolve({
+        server,
+        port: info.port,
+        close: () =>
+          new Promise<void>((done, fail) => {
+            server.close((err) => {
+              if (err) fail(err)
+              else done()
+            })
+          }),
+      })
+    })
+    // Port 0 on 127.0.0.1 cannot collide, but a listen failure must
+    // reject rather than hang the caller to its test timeout.
+    server.once('error', reject)
+  })
 }
 
 /** Promisified server.close(). */

--- a/packages/proxy/src/__tests__/integration-events-liveness.test.ts
+++ b/packages/proxy/src/__tests__/integration-events-liveness.test.ts
@@ -37,11 +37,11 @@ interface LiveDashboard {
   closeAll: () => Promise<void>
 }
 
-function makeLiveDashboard(options: {
+async function makeLiveDashboard(options: {
   sseHeartbeatMs: number
   maxSseConnections?: number
   sweepIntervalMs?: number
-}): LiveDashboard {
+}): Promise<LiveDashboard> {
   const auditStore = new AuditStore({
     path: ':memory:',
     retention: '90d',
@@ -72,7 +72,7 @@ function makeLiveDashboard(options: {
     },
     options,
   )
-  const managed = startOnDynamicPort(lifecycle.app)
+  const managed = await startOnDynamicPort(lifecycle.app)
   const closeAll = async (): Promise<void> => {
     lifecycle.close()
     await managed.close()
@@ -190,7 +190,7 @@ async function pollUntil(
 
 describe('GET /api/events — sweeper sever over the real transport (issue #327)', () => {
   it('severs a dead-but-unaborted connection at sweep: server-side socket destroyed', async () => {
-    const fx = makeLiveDashboard({
+    const fx = await makeLiveDashboard({
       sseHeartbeatMs: 1000,
       maxSseConnections: 1,
       sweepIntervalMs: 1000,
@@ -263,7 +263,7 @@ describe('GET /api/events — sweeper sever over the real transport (issue #327)
     // keep its graceful-end contract — the in-process drain test cannot
     // see a sever (no server socket there), so the boundary is pinned
     // here, on the wire.
-    const fx = makeLiveDashboard({ sseHeartbeatMs: 5000 })
+    const fx = await makeLiveDashboard({ sseHeartbeatMs: 5000 })
     const client = openRawSseClient(fx.port)
     try {
       // A healthy READING client (never paused) is admitted, then the

--- a/packages/proxy/src/__tests__/integration-governance.test.ts
+++ b/packages/proxy/src/__tests__/integration-governance.test.ts
@@ -5,7 +5,8 @@
  * mock MCP server → proxy with policies + audit → SQLite.
  *
  * Covers: all matcher types, first-match-wins ordering, destructive
- * detection, hot-reload, response capture, and performance (<5ms p99).
+ * detection, hot-reload, response capture, and a thousand governed calls
+ * completing and being audited (latency is the benchmark script's gate).
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
@@ -458,15 +459,15 @@ policies:
 })
 
 // ---------------------------------------------------------------------------
-// Suite 4: Performance benchmark (1,000 calls with policy + audit)
+// Suite 4: 1,000 governed calls with policy + audit complete and are audited
 // ---------------------------------------------------------------------------
 
-describe('performance (<5ms p99 with policy + audit)', { timeout: 30_000 }, () => {
+describe('1000 governed calls complete and are audited', { timeout: 60_000 }, () => {
   const WARMUP = 20
   const MEASURE = 1000
 
-  it(`p99 latency for ${String(MEASURE)} governed tool calls is reasonable`, async () => {
-    // Use a large buffer to avoid mid-benchmark auto-flush blocking
+  it(`${String(MEASURE)} governed tool calls complete and are audited`, async () => {
+    // Use a large buffer so no threshold flush runs mid-loop
     const proxy = await createGovernedProxyWithAudit(
       {
         default: 'deny',
@@ -492,29 +493,15 @@ describe('performance (<5ms p99 with policy + audit)', { timeout: 30_000 }, () =
         })
       }
 
-      // Measure
-      const durations: number[] = []
+      // The calls. Latency is not asserted here: inside a parallel vitest
+      // run these numbers measure the box, not the proxy. The latency gate
+      // is `pnpm --filter @gethelio/proxy benchmark` (governed overhead p99).
       for (let i = 0; i < MEASURE; i++) {
-        const start = performance.now()
         await sendMcpRequest(proxy.url, 'tools/call', {
           name: 'get_weather',
           arguments: { city: 'London' },
         })
-        durations.push(performance.now() - start)
       }
-
-      // Calculate stats
-      const sorted = [...durations].sort((a, b) => a - b)
-      const p99idx = Math.ceil(0.99 * sorted.length) - 1
-      const p99 = sorted[Math.max(0, p99idx)] ?? 0
-      const p95idx = Math.ceil(0.95 * sorted.length) - 1
-      const p95 = sorted[Math.max(0, p95idx)] ?? 0
-
-      // Vitest + concurrent test suites add significant overhead.
-      // The dedicated benchmark script (pnpm benchmark) is the authoritative <5ms check.
-      // Here we verify no major regression while tolerating occasional worker-load spikes.
-      expect(p95).toBeLessThan(50)
-      expect(p99).toBeLessThan(100)
 
       // Verify audit records were written
       proxy.auditWriter.flush()

--- a/packages/proxy/src/__tests__/integration-governance.test.ts
+++ b/packages/proxy/src/__tests__/integration-governance.test.ts
@@ -43,7 +43,7 @@ afterAll(async () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createGovernedProxyWithAudit(
+async function createGovernedProxyWithAudit(
   policiesConfig: PoliciesConfig,
   options?: { environment?: string; includeResponses?: boolean; bufferSize?: number },
 ) {
@@ -74,7 +74,7 @@ function createGovernedProxyWithAudit(
   })
 
   const app = createApp(config, governed)
-  const managed = startOnDynamicPort(app)
+  const managed = await startOnDynamicPort(app)
 
   return {
     url: `http://127.0.0.1:${String(managed.port)}/mcp`,
@@ -117,10 +117,10 @@ async function postJson(
 // ---------------------------------------------------------------------------
 
 describe('full pipeline with 5+ rules', () => {
-  let proxy: ReturnType<typeof createGovernedProxyWithAudit>
+  let proxy: Awaited<ReturnType<typeof createGovernedProxyWithAudit>>
 
   beforeAll(async () => {
-    proxy = createGovernedProxyWithAudit(
+    proxy = await createGovernedProxyWithAudit(
       {
         default: 'deny',
         dry_run: false,
@@ -272,10 +272,10 @@ describe('full pipeline with 5+ rules', () => {
 // ---------------------------------------------------------------------------
 
 describe('destructive detection', () => {
-  let proxy: ReturnType<typeof createGovernedProxyWithAudit>
+  let proxy: Awaited<ReturnType<typeof createGovernedProxyWithAudit>>
 
   beforeAll(async () => {
-    proxy = createGovernedProxyWithAudit({
+    proxy = await createGovernedProxyWithAudit({
       default: 'allow',
       dry_run: false,
       flag_destructive: 'log',
@@ -391,7 +391,7 @@ policies:
     watcher.start()
 
     const app = createApp(config, governed)
-    proxy = startOnDynamicPort(app)
+    proxy = await startOnDynamicPort(app)
     proxyUrl = `http://127.0.0.1:${String(proxy.port)}/mcp`
 
     await wait(100)
@@ -467,7 +467,7 @@ describe('performance (<5ms p99 with policy + audit)', { timeout: 30_000 }, () =
 
   it(`p99 latency for ${String(MEASURE)} governed tool calls is reasonable`, async () => {
     // Use a large buffer to avoid mid-benchmark auto-flush blocking
-    const proxy = createGovernedProxyWithAudit(
+    const proxy = await createGovernedProxyWithAudit(
       {
         default: 'deny',
         dry_run: false,
@@ -531,7 +531,7 @@ describe('performance (<5ms p99 with policy + audit)', { timeout: 30_000 }, () =
 
 describe('dry-run mode', () => {
   it('per-rule dry_run returns synthetic response without contacting upstream', async () => {
-    const proxy = createGovernedProxyWithAudit({
+    const proxy = await createGovernedProxyWithAudit({
       default: 'allow',
       dry_run: false,
       rules: [{ name: 'shadow-weather', match: { tool: 'get_weather' }, action: 'dry_run' }],
@@ -567,7 +567,7 @@ describe('dry-run mode', () => {
   })
 
   it('global dry_run prevents forwarding and returns would_forward: true for allow', async () => {
-    const proxy = createGovernedProxyWithAudit({
+    const proxy = await createGovernedProxyWithAudit({
       default: 'allow',
       dry_run: true,
       rules: [{ name: 'allow-weather', match: { tool: 'get_weather' }, action: 'allow' }],
@@ -603,7 +603,7 @@ describe('dry-run mode', () => {
   })
 
   it('global dry_run with deny shows would_forward: false', async () => {
-    const proxy = createGovernedProxyWithAudit({
+    const proxy = await createGovernedProxyWithAudit({
       default: 'deny',
       dry_run: true,
       rules: [],
@@ -633,7 +633,7 @@ describe('dry-run mode', () => {
   })
 
   it('stamps resultType: complete on the dry-run result for a door-passing modern request', async () => {
-    const proxy = createGovernedProxyWithAudit({
+    const proxy = await createGovernedProxyWithAudit({
       default: 'allow',
       dry_run: true,
       rules: [],

--- a/packages/proxy/src/__tests__/integration-header-agreement.test.ts
+++ b/packages/proxy/src/__tests__/integration-header-agreement.test.ts
@@ -83,7 +83,7 @@ describe('inbound header/body agreement through production wiring (issue #226)',
     )
     // The cli.ts recorder composition, verbatim: callback → builder →
     // pushImmediate.
-    proxy = startOnDynamicPort(
+    proxy = await startOnDynamicPort(
       createApp(config, governedForwarder, {
         onHeaderMismatch: (rejection) => {
           auditWriter.pushImmediate(buildHeaderMismatchAuditRecord(rejection, config.environment))
@@ -496,7 +496,7 @@ describe('chained proxies keep the era cache stable (issue #226, R1 F1 regressio
       compilePolicies({ default: 'allow', dry_run: false, rules: [] }).policy,
       {},
     )
-    proxyB = startOnDynamicPort(createApp(configB, governedB))
+    proxyB = await startOnDynamicPort(createApp(configB, governedB))
 
     const configA = makeConfig({
       upstream: {
@@ -512,7 +512,7 @@ describe('chained proxies keep the era cache stable (issue #226, R1 F1 regressio
       compilePolicies({ default: 'allow', dry_run: false, rules: [] }).policy,
       {},
     )
-    proxyA = startOnDynamicPort(createApp(configA, governedA))
+    proxyA = await startOnDynamicPort(createApp(configA, governedA))
     proxyAUrl = `http://127.0.0.1:${String(proxyA.port)}/mcp`
   })
 

--- a/packages/proxy/src/__tests__/integration-http.test.ts
+++ b/packages/proxy/src/__tests__/integration-http.test.ts
@@ -32,7 +32,7 @@ describe('Streamable HTTP integration', () => {
     })
 
     const app = createApp(config, forwarder)
-    proxy = startOnDynamicPort(app)
+    proxy = await startOnDynamicPort(app)
     proxyUrl = `http://127.0.0.1:${String(proxy.port)}/mcp`
   })
 
@@ -193,7 +193,7 @@ describe('Streamable HTTP integration', () => {
 
     const forwarder = new StreamableHttpForwarder({ url: config.upstream.url as string })
     const app = createApp(config, forwarder)
-    const badProxy = startOnDynamicPort(app)
+    const badProxy = await startOnDynamicPort(app)
 
     try {
       const { status, body } = await sendMcpRequest(
@@ -220,7 +220,7 @@ describe('Streamable HTTP integration', () => {
       })
     })
 
-    const malformedUpstream = startOnDynamicPort(upstreamApp)
+    const malformedUpstream = await startOnDynamicPort(upstreamApp)
     const config = makeConfig({
       upstream: {
         url: `http://127.0.0.1:${String(malformedUpstream.port)}/mcp`,
@@ -229,7 +229,7 @@ describe('Streamable HTTP integration', () => {
     })
     const forwarder = new StreamableHttpForwarder({ url: config.upstream.url as string })
     const app = createApp(config, forwarder)
-    const proxy = startOnDynamicPort(app)
+    const proxy = await startOnDynamicPort(app)
 
     try {
       const { status, body } = await sendMcpRequest(
@@ -270,7 +270,7 @@ describe('Policy evaluation (Streamable HTTP)', () => {
   })
 
   /** Create a proxy with the given policy config and return its URL + close handle. */
-  function createGovernedProxy(policiesConfig: {
+  async function createGovernedProxy(policiesConfig: {
     default?: 'allow' | 'deny'
     rules: Array<Record<string, unknown>>
   }) {
@@ -287,7 +287,7 @@ describe('Policy evaluation (Streamable HTTP)', () => {
       environment: config.environment,
     })
     const app = createApp(config, governed)
-    const managed = startOnDynamicPort(app)
+    const managed = await startOnDynamicPort(app)
     return {
       url: `http://127.0.0.1:${String(managed.port)}/mcp`,
       close: managed.close,
@@ -295,7 +295,7 @@ describe('Policy evaluation (Streamable HTTP)', () => {
   }
 
   it('allowed tool call passes through and returns upstream response', async () => {
-    const proxy = createGovernedProxy({
+    const proxy = await createGovernedProxy({
       default: 'deny',
       rules: [{ match: { tool: 'get_weather' }, action: 'allow' }],
     })
@@ -314,7 +314,7 @@ describe('Policy evaluation (Streamable HTTP)', () => {
   })
 
   it('denied tool call returns JSON-RPC error without contacting upstream', async () => {
-    const proxy = createGovernedProxy({
+    const proxy = await createGovernedProxy({
       default: 'allow',
       rules: [
         {
@@ -348,7 +348,7 @@ describe('Policy evaluation (Streamable HTTP)', () => {
   })
 
   it('default deny blocks unmatched tools', async () => {
-    const proxy = createGovernedProxy({
+    const proxy = await createGovernedProxy({
       default: 'deny',
       rules: [{ match: { tool: 'get_weather' }, action: 'allow' }],
     })
@@ -369,7 +369,7 @@ describe('Policy evaluation (Streamable HTTP)', () => {
   })
 
   it('non-tool methods pass through regardless of policy', async () => {
-    const proxy = createGovernedProxy({
+    const proxy = await createGovernedProxy({
       default: 'deny',
       rules: [{ match: { tool: '*' }, action: 'deny' }],
     })
@@ -386,7 +386,7 @@ describe('Policy evaluation (Streamable HTTP)', () => {
   })
 
   it('annotation-based matching works after tools/list populates cache', async () => {
-    const proxy = createGovernedProxy({
+    const proxy = await createGovernedProxy({
       default: 'allow',
       rules: [{ match: { annotations: { destructiveHint: true } }, action: 'deny' }],
     })
@@ -430,7 +430,7 @@ describe('Audit response capture (Streamable HTTP)', () => {
     await upstream.close()
   })
 
-  function createGovernedProxyWithAudit(
+  async function createGovernedProxyWithAudit(
     policiesConfig: {
       default?: 'allow' | 'deny'
       rules: Array<Record<string, unknown>>
@@ -461,7 +461,7 @@ describe('Audit response capture (Streamable HTTP)', () => {
       auditWriter,
     })
     const app = createApp(config, governed)
-    const managed = startOnDynamicPort(app)
+    const managed = await startOnDynamicPort(app)
 
     return {
       url: `http://127.0.0.1:${String(managed.port)}/mcp`,
@@ -475,7 +475,7 @@ describe('Audit response capture (Streamable HTTP)', () => {
   }
 
   it('allowed call stores full upstream response when include_responses is true', async () => {
-    const proxy = createGovernedProxyWithAudit({ default: 'allow', rules: [] }, true)
+    const proxy = await createGovernedProxyWithAudit({ default: 'allow', rules: [] }, true)
 
     try {
       await sendMcpRequest(proxy.url, 'tools/call', {
@@ -502,7 +502,7 @@ describe('Audit response capture (Streamable HTTP)', () => {
   })
 
   it('allowed call stores response summary when include_responses is false', async () => {
-    const proxy = createGovernedProxyWithAudit({ default: 'allow', rules: [] }, false)
+    const proxy = await createGovernedProxyWithAudit({ default: 'allow', rules: [] }, false)
 
     try {
       await sendMcpRequest(proxy.url, 'tools/call', {
@@ -533,7 +533,7 @@ describe('Audit response capture (Streamable HTTP)', () => {
   })
 
   it('denied call stores null upstream_response regardless of flag', async () => {
-    const proxy = createGovernedProxyWithAudit({
+    const proxy = await createGovernedProxyWithAudit({
       default: 'allow',
       rules: [{ match: { tool: 'delete_*' }, action: 'deny' }],
     })
@@ -559,7 +559,7 @@ describe('Audit response capture (Streamable HTTP)', () => {
   })
 
   it('audit record captures full metadata end-to-end', async () => {
-    const proxy = createGovernedProxyWithAudit({ default: 'allow', rules: [] })
+    const proxy = await createGovernedProxyWithAudit({ default: 'allow', rules: [] })
 
     try {
       await sendMcpRequest(
@@ -599,8 +599,8 @@ describe('Audit response capture (Streamable HTTP)', () => {
         headers: { 'content-type': 'text/plain' },
       })
     })
-    const malformedUpstream = startOnDynamicPort(upstreamApp)
-    const proxy = createGovernedProxyWithAudit(
+    const malformedUpstream = await startOnDynamicPort(upstreamApp)
+    const proxy = await createGovernedProxyWithAudit(
       { default: 'allow', rules: [] },
       true,
       `http://127.0.0.1:${String(malformedUpstream.port)}/mcp`,
@@ -625,7 +625,7 @@ describe('Audit response capture (Streamable HTTP)', () => {
   })
 
   it('connection-level forwarding failure writes audit row with null upstream_http_status', async () => {
-    const proxy = createGovernedProxyWithAudit(
+    const proxy = await createGovernedProxyWithAudit(
       { default: 'allow', rules: [] },
       true,
       'http://127.0.0.1:19999/mcp',
@@ -667,7 +667,7 @@ describe('Static upstream headers', () => {
       capturedAuth = c.req.header('authorization')
       return c.json({ jsonrpc: '2.0', id: 1, result: { tools: [] } })
     })
-    upstreamServer = startOnDynamicPort(upstreamApp)
+    upstreamServer = await startOnDynamicPort(upstreamApp)
 
     const config = makeConfig({
       upstream: {
@@ -680,7 +680,7 @@ describe('Static upstream headers', () => {
 
     const { forwarder } = await createForwarderFromConfig(config)
     const app = createApp(config, forwarder)
-    proxy = startOnDynamicPort(app)
+    proxy = await startOnDynamicPort(app)
     proxyUrl = `http://127.0.0.1:${String(proxy.port)}/mcp`
   })
 

--- a/packages/proxy/src/__tests__/integration-modern-sessionless.test.ts
+++ b/packages/proxy/src/__tests__/integration-modern-sessionless.test.ts
@@ -92,7 +92,7 @@ describe('modern sessionless client against a modern-only upstream', () => {
       compilePolicies({ default: 'allow', dry_run: false, rules: [] }).policy,
       { auditWriter },
     )
-    proxy = startOnDynamicPort(createApp(config, governedForwarder))
+    proxy = await startOnDynamicPort(createApp(config, governedForwarder))
     proxyUrl = `http://127.0.0.1:${String(proxy.port)}/mcp`
   })
 

--- a/packages/proxy/src/__tests__/integration-modern-upstream.test.ts
+++ b/packages/proxy/src/__tests__/integration-modern-upstream.test.ts
@@ -67,7 +67,7 @@ describe('2026-07-28-only ("modern-only") upstream', () => {
         auditWriter,
       },
     )
-    proxy = startOnDynamicPort(createApp(config, governedForwarder))
+    proxy = await startOnDynamicPort(createApp(config, governedForwarder))
     proxyUrl = `http://127.0.0.1:${String(proxy.port)}/mcp`
   })
 

--- a/packages/proxy/src/__tests__/integration-sideband.test.ts
+++ b/packages/proxy/src/__tests__/integration-sideband.test.ts
@@ -21,7 +21,7 @@ const store = new EvidenceStore({
 
 const sidebandApp = createSidebandApp(store)
 // Start before all tests (eagerly, outside beforeAll to keep it simple)
-const server: ManagedServer = startOnDynamicPort(sidebandApp)
+const server: ManagedServer = await startOnDynamicPort(sidebandApp)
 const baseUrl = `http://127.0.0.1:${String(server.port)}`
 
 afterAll(async () => {
@@ -174,7 +174,7 @@ describe('Sideband API integration', () => {
       allowedEvidenceKeys: ['orders.lookup'],
     })
     const localApp = createSidebandApp(localStore)
-    const localServer = startOnDynamicPort(localApp)
+    const localServer = await startOnDynamicPort(localApp)
     const localBaseUrl = `http://127.0.0.1:${String(localServer.port)}`
 
     try {
@@ -205,7 +205,7 @@ describe('Sideband API integration', () => {
   it('POST /context returns 503 when store is closed', async () => {
     const localStore = new EvidenceStore({ cleanupIntervalMs: 0 })
     const localApp = createSidebandApp(localStore)
-    const localServer = startOnDynamicPort(localApp)
+    const localServer = await startOnDynamicPort(localApp)
     const localBaseUrl = `http://127.0.0.1:${String(localServer.port)}`
 
     try {

--- a/packages/proxy/src/__tests__/integration-sse.test.ts
+++ b/packages/proxy/src/__tests__/integration-sse.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest'
-import type { AddressInfo } from 'node:net'
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
 import type { ServerType } from '@hono/node-server'
@@ -20,8 +19,10 @@ interface MockSseUpstream {
 /**
  * Create a mock MCP server that speaks SSE transport.
  * Returns actual MCP-style responses for tools/list, tools/call, etc.
+ * Bound to 127.0.0.1 so the kernel cannot hand it a port another process
+ * holds (issue #271); the port is known once the server is listening.
  */
-function createMockSseUpstream(): MockSseUpstream {
+function createMockSseUpstream(): Promise<MockSseUpstream> {
   const app = new Hono()
   const writers: WritableStreamDefaultWriter<Uint8Array>[] = []
   const encoder = new TextEncoder()
@@ -87,10 +88,12 @@ function createMockSseUpstream(): MockSseUpstream {
     return c.body(null, 202)
   })
 
-  const server = serve({ fetch: app.fetch, port: 0 })
-  const port = (server.address() as AddressInfo).port
-
-  return { server, port }
+  return new Promise((resolve, reject) => {
+    const server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) => {
+      resolve({ server, port: info.port })
+    })
+    server.once('error', reject)
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -213,7 +216,7 @@ describe('SSE integration', () => {
   const activeSessions: SseClientSession[] = []
 
   beforeAll(async () => {
-    mockUpstream = createMockSseUpstream()
+    mockUpstream = await createMockSseUpstream()
 
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mockUpstream.port)}/`,
@@ -228,7 +231,7 @@ describe('SSE integration', () => {
     })
 
     const app = createApp(config, forwarder)
-    proxy = startOnDynamicPort(app)
+    proxy = await startOnDynamicPort(app)
     proxyPort = proxy.port
   })
 

--- a/packages/proxy/src/__tests__/integration-stdio.test.ts
+++ b/packages/proxy/src/__tests__/integration-stdio.test.ts
@@ -88,7 +88,7 @@ describe('Stdio integration', () => {
     })
 
     const app = createApp(config, forwarder)
-    proxy = startOnDynamicPort(app)
+    proxy = await startOnDynamicPort(app)
     proxyUrl = `http://127.0.0.1:${String(proxy.port)}/mcp`
   })
 

--- a/packages/proxy/src/__tests__/integration-streamable-http-session.test.ts
+++ b/packages/proxy/src/__tests__/integration-streamable-http-session.test.ts
@@ -31,7 +31,7 @@ describe('Streamable HTTP session-enforcing upstream', () => {
       built.forwarder,
       compilePolicies({ default: 'allow', dry_run: false, rules: [] }).policy,
     )
-    proxy = startOnDynamicPort(createApp(config, governedForwarder))
+    proxy = await startOnDynamicPort(createApp(config, governedForwarder))
     proxyUrl = `http://127.0.0.1:${String(proxy.port)}/mcp`
   })
 

--- a/packages/proxy/src/__tests__/integration-two-upstream.test.ts
+++ b/packages/proxy/src/__tests__/integration-two-upstream.test.ts
@@ -179,7 +179,7 @@ async function composeTwoDoors(options: {
     },
     sse: options.sse,
   })
-  const proxy = startOnDynamicPort(app)
+  const proxy = await startOnDynamicPort(app)
   const base = `http://127.0.0.1:${String(proxy.port)}`
 
   return {

--- a/packages/proxy/src/audit/writer.test.ts
+++ b/packages/proxy/src/audit/writer.test.ts
@@ -240,17 +240,18 @@ describe('AuditWriter', () => {
   // -----------------------------------------------------------------------
 
   describe('non-blocking', () => {
-    it('push returns synchronously without waiting for DB', () => {
+    it('push returns synchronously without waiting for DB', async () => {
       writer = new AuditWriter({ store, flushIntervalMs: 0 })
 
-      const start = performance.now()
       for (let i = 0; i < 100; i++) {
         writer.push(makeRecord())
       }
-      const elapsed = performance.now() - start
 
-      // 100 pushes (with 2 threshold flushes at 50 and 100) should complete very fast
-      expect(elapsed).toBeLessThan(50)
+      // The threshold at push 50 scheduled one setTimeout(0) flush (later
+      // pushes coalesce into it); nothing ran inside push().
+      expect(store.count()).toBe(0)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(store.count()).toBe(100)
     })
   })
 

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -137,14 +137,23 @@ async function startAndCaptureStderr(
 }
 
 /**
- * Write a minimal start-ready config at a randomized high port and return
- * the tempdir + config path. The caller is responsible for rmSync cleanup.
+ * A random port for a spawned `helio start`, below every OS's ephemeral
+ * range so it cannot land on a port a port-0 listener already holds
+ * (issue #271). A foreign fixed-port service there is still possible
+ * and fails loudly with EADDRINUSE in the child's stderr.
+ */
+function randomChildPort(): number {
+  return 20_000 + Math.floor(Math.random() * 10_000)
+}
+
+/**
+ * Write a minimal start-ready config at a random port and return the
+ * tempdir + config path. The caller is responsible for rmSync cleanup.
  */
 function writeStartConfig(): { dir: string; configPath: string } {
   const dir = mkdtempSync(join(tmpdir(), 'helio-cli-start-'))
   const configPath = join(dir, 'helio.yaml')
-  // High-numbered random ports avoid collisions across parallel test workers.
-  const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+  const listenPort = randomChildPort()
   const dashboardPort = listenPort + 1
   const auditPath = join(dir, 'audit.db')
   writeFileSync(
@@ -177,7 +186,7 @@ function writeStdioStartConfig(requestTimeout: string): {
 } {
   const dir = mkdtempSync(join(tmpdir(), 'helio-cli-stdio-start-'))
   const configPath = join(dir, 'helio.yaml')
-  const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+  const listenPort = randomChildPort()
   const auditPath = join(dir, 'audit.db')
   writeFileSync(
     configPath,
@@ -225,7 +234,7 @@ const STDIO_MCP_FIXTURE = join(import.meta.dirname, '__tests__', 'helpers', 'std
 function writeTwoUpstreamConfig(): { dir: string; configPath: string; listenPort: number } {
   const dir = mkdtempSync(join(tmpdir(), 'helio-cli-multi-'))
   const configPath = join(dir, 'helio.yaml')
-  const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+  const listenPort = randomChildPort()
   writeFileSync(
     configPath,
     `
@@ -1399,7 +1408,7 @@ dashboard:
       const modern = await startModernOnlyHttpMcpServer()
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-mixed-era-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       writeFileSync(
         configPath,
         `
@@ -1572,7 +1581,7 @@ audit:
       const closedPort = await getClosedPort()
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-multi-fail-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       writeFileSync(
         configPath,
         `
@@ -1612,7 +1621,7 @@ audit:
       const closedPort = await getClosedPort()
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-multi-many-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       const entries = Array.from(
         { length: 17 },
         (_, i) =>
@@ -1643,7 +1652,7 @@ audit:
     it('warns before spawning when a stdio upstream sets a url (issue #324)', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-stdio-url-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       // An absolute path under the tmpdir: a bare name would resolve through
       // PATH, and a found-but-exiting binary hits the stdio wrapper's retry
       // loop instead of failing fast with ENOENT.
@@ -1715,7 +1724,7 @@ audit:
       })
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-sse-conn-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       writeFileSync(
         configPath,
         `
@@ -2103,7 +2112,7 @@ audit:
     it('shuts down cleanly on SIGINT with an active dashboard SSE stream', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-shutdown-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       const dashboardPort = listenPort + 1
       const apiSecret = `test-secret-${String(listenPort)}`
       const auditPath = join(dir, 'audit.db')
@@ -2239,7 +2248,7 @@ audit:
 
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-prime-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       const auditPath = join(dir, 'audit.db')
       writeFileSync(
         configPath,
@@ -2321,7 +2330,7 @@ audit:
 
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-prime-call-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       const auditPath = join(dir, 'audit.db')
       writeFileSync(
         configPath,
@@ -2432,7 +2441,7 @@ audit:
 
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-approval-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       const dashboardPort = listenPort + 1
       const auditPath = join(dir, 'audit.db')
       const secret = `test-secret-${String(listenPort)}`
@@ -2560,7 +2569,7 @@ audit:
     it('generates a fresh SDK sideband bearer token when sdk.enabled is true', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-start-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       const dashboardPort = listenPort + 1
       const sdkPort = listenPort + 2
       const auditPath = join(dir, 'audit.db')
@@ -2607,7 +2616,7 @@ audit:
     it('respects a pre-set HELIO_SDK_TOKEN environment variable', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-start-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       const dashboardPort = listenPort + 1
       const sdkPort = listenPort + 2
       const auditPath = join(dir, 'audit.db')
@@ -2667,7 +2676,7 @@ audit:
     it('disables the config watcher when policies.hot_reload is false', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-start-'))
       const configPath = join(dir, 'helio.yaml')
-      const listenPort = 40_000 + Math.floor(Math.random() * 20_000)
+      const listenPort = randomChildPort()
       const dashboardPort = listenPort + 1
       const auditPath = join(dir, 'audit.db')
       writeFileSync(

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -286,6 +286,23 @@ async function waitForProxyHealth(baseUrl: string, timeoutMs: number): Promise<v
   throw new Error(`Timed out waiting for proxy health endpoint at ${baseUrl}/healthz`)
 }
 
+/** Wait for the proxy's health endpoint, or fail at once if the child exits first. */
+async function waitForProxyHealthOrExit(
+  child: ReturnType<typeof spawn>,
+  baseUrl: string,
+  timeoutMs: number,
+  stderr: () => string,
+): Promise<void> {
+  await Promise.race([
+    waitForProxyHealth(baseUrl, timeoutMs),
+    new Promise<never>((_, reject) => {
+      child.once('close', (code) => {
+        reject(new Error(`helio start exited ${String(code)} before healthy. stderr:\n${stderr()}`))
+      })
+    }),
+  ])
+}
+
 /**
  * Wait for child process exit with timeout. Resolves on 'close' (exit AND
  * stdio streams flushed) rather than 'exit', so callers may assert on
@@ -424,7 +441,7 @@ describe('CLI', () => {
         rmSync(dir1, { recursive: true, force: true })
         rmSync(dir2, { recursive: true, force: true })
       }
-    })
+    }, 15_000)
 
     it('prints the generated secret to stderr', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
@@ -587,7 +604,7 @@ describe('CLI', () => {
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }
-    })
+    }, 15_000)
 
     it('--sandbox rejects an explicit --output', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-sandbox-'))
@@ -612,7 +629,7 @@ describe('CLI', () => {
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }
-    })
+    }, 15_000)
 
     it('--sandbox writes a config that passes validate', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'helio-cli-sandbox-'))
@@ -629,7 +646,7 @@ describe('CLI', () => {
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }
-    })
+    }, 15_000)
   })
 
   // --- helio validate ---
@@ -1112,7 +1129,7 @@ dashboard:
       const first = await runCli(['secret'])
       const second = await runCli(['secret'])
       expect(first.stdout).not.toBe(second.stdout)
-    })
+    }, 15_000)
   })
 
   describe('config hash', () => {
@@ -1131,7 +1148,7 @@ dashboard:
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }
-    })
+    }, 15_000)
 
     it('exits 1 with the read error on stderr and nothing on stdout for a missing file', async () => {
       const { code, stdout, stderr } = await runCli([
@@ -1174,7 +1191,7 @@ dashboard:
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
-  })
+  }, 15_000)
 
   it('uncommenting only the budgets stub yields a config with one budget', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'helio-cli-test-'))
@@ -1202,7 +1219,7 @@ dashboard:
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
-  })
+  }, 15_000)
 
   // --- helio start ---
 
@@ -2174,7 +2191,7 @@ audit:
         })
 
         const baseUrl = `http://127.0.0.1:${String(listenPort)}`
-        await waitForProxyHealth(baseUrl, 8_000)
+        await waitForProxyHealthOrExit(child, baseUrl, 8_000, () => stderr)
 
         // The signal also times the body read below, so it must outlast the
         // 8s heartbeat bound or the race rejects with a bare AbortError.
@@ -2388,7 +2405,7 @@ audit:
         })
 
         const baseUrl = `http://127.0.0.1:${String(listenPort)}`
-        await waitForProxyHealth(baseUrl, 8_000)
+        await waitForProxyHealthOrExit(child, baseUrl, 8_000, () => stderr)
 
         const res = await fetch(`${baseUrl}/mcp`, {
           method: 'POST',
@@ -2505,7 +2522,7 @@ audit:
 
         const baseUrl = `http://127.0.0.1:${String(listenPort)}`
         const dashUrl = `http://127.0.0.1:${String(dashboardPort)}`
-        await waitForProxyHealth(baseUrl, 8_000)
+        await waitForProxyHealthOrExit(child, baseUrl, 8_000, () => stderr)
 
         // The require_approval rule holds the call open, so do NOT await yet.
         const callPromise = fetch(`${baseUrl}/mcp`, {
@@ -2747,7 +2764,7 @@ audit:
         })
 
         const baseUrl = `http://127.0.0.1:${String(listenPort)}`
-        await waitForProxyHealth(baseUrl, 8_000)
+        await waitForProxyHealthOrExit(child, baseUrl, 8_000, () => stderr)
 
         const beginMs = Date.now()
         const res = await fetch(`${baseUrl}/mcp`, {

--- a/packages/proxy/src/server.test.ts
+++ b/packages/proxy/src/server.test.ts
@@ -397,7 +397,7 @@ describe('startSidebandServer', () => {
       return new Response('ok')
     })
 
-    const port = 45_000 + Math.floor(Math.random() * 10_000)
+    const port = 20_000 + Math.floor(Math.random() * 10_000)
     const handle = startSidebandServer(app, port, '127.0.0.1')
     const holdRequest = fetch(`http://127.0.0.1:${String(port)}/hold`)
     await new Promise<void>((resolve) => {

--- a/packages/proxy/src/transport/stdio-wrapper.test.ts
+++ b/packages/proxy/src/transport/stdio-wrapper.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
+import { existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { StdioForwarder } from './stdio-wrapper.js'
 import type { McpRequest } from '../mcp/types.js'
 
@@ -247,7 +250,17 @@ describe('StdioForwarder', () => {
   }, 5000)
 
   it('auto-restarts on crash up to maxRetries', async () => {
-    // Script that crashes on first run, then works on second
+    // The script's marker files, keyed by this worker's pid (the child
+    // sees it as process.ppid). A stale first marker from an earlier run
+    // with the same worker pid would make the script skip the crash, and
+    // the test would pass without exercising a restart.
+    const marker = join(tmpdir(), 'helio-stdio-test-' + String(process.pid))
+    const restarted = marker + '.restarted'
+    rmSync(marker, { force: true })
+    rmSync(restarted, { force: true })
+
+    // Script that crashes on first run, then works on second and says so
+    // through a second marker the test can wait for.
     const crashOnceScript = `
         const fs = require('fs');
         const path = require('path');
@@ -257,6 +270,7 @@ describe('StdioForwarder', () => {
           process.exit(1);
         }
         fs.unlinkSync(marker);
+        fs.writeFileSync(marker + '.restarted', '');
         const readline = require('readline');
         const rl = readline.createInterface({ input: process.stdin });
         rl.on('line', (line) => {
@@ -277,13 +291,24 @@ describe('StdioForwarder', () => {
       maxRetries: 3,
       retryDelayMs: 50,
     })
-    await forwarder.start()
+    try {
+      await forwarder.start()
 
-    // Wait for crash + restart
-    await new Promise((resolve) => setTimeout(resolve, 500))
+      // Wait for the restarted child before forwarding: a request written
+      // to the first child's stdin is orphaned when that child exits.
+      await vi.waitFor(
+        () => {
+          expect(existsSync(restarted)).toBe(true)
+        },
+        { timeout: 8000, interval: 20 },
+      )
 
-    const result = await forwarder.forward(makeRequest(1, 'ping'))
-    expect(result.response.body).toHaveProperty('result', { ok: true })
+      const result = await forwarder.forward(makeRequest(1, 'ping'))
+      expect(result.response.body).toHaveProperty('result', { ok: true })
+    } finally {
+      rmSync(marker, { force: true })
+      rmSync(restarted, { force: true })
+    }
   }, 10000)
 
   it('close rejects pending requests', async () => {

--- a/packages/proxy/src/upstream/e2e.test.ts
+++ b/packages/proxy/src/upstream/e2e.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import type { AddressInfo } from 'node:net'
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
 import type { ServerType } from '@hono/node-server'
@@ -11,16 +10,18 @@ import type { HelioConfig } from '../config/index.js'
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Wait for a server to be listening and return the assigned port. */
-function getPort(server: ServerType): number {
-  const addr = server.address() as AddressInfo
-  return addr.port
-}
-
-/** Start a Hono app on a dynamic port. Returns the server and port. */
-function startOnDynamicPort(app: Hono): { server: ServerType; port: number } {
-  const server = serve({ fetch: app.fetch, port: 0 })
-  return { server, port: getPort(server) }
+/**
+ * Start a Hono app on a dynamic port, bound to 127.0.0.1 so the kernel
+ * cannot hand it a port another process holds (issue #271). The port is
+ * known once the server is listening, so the helper is asynchronous.
+ */
+function startOnDynamicPort(app: Hono): Promise<{ server: ServerType; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) => {
+      resolve({ server, port: info.port })
+    })
+    server.once('error', reject)
+  })
 }
 
 /** Close a server and return a promise. */
@@ -145,14 +146,14 @@ describe('upstream forwarder e2e', () => {
 
   it('forwards tools/list through the proxy and returns the upstream response', async () => {
     // Start mock upstream
-    const upstream = startOnDynamicPort(createMockUpstream())
+    const upstream = await startOnDynamicPort(createMockUpstream())
     servers.push(upstream.server)
 
     // Start proxy pointing at upstream
     const upstreamUrl = `http://127.0.0.1:${String(upstream.port)}/mcp`
     const forwarder = new StreamableHttpForwarder({ url: upstreamUrl })
     const proxyApp = createApp(makeConfig(upstreamUrl), forwarder)
-    const proxy = startOnDynamicPort(proxyApp)
+    const proxy = await startOnDynamicPort(proxyApp)
     servers.push(proxy.server)
 
     // Send tools/list through the proxy
@@ -170,13 +171,13 @@ describe('upstream forwarder e2e', () => {
   })
 
   it('forwards tools/call through the proxy', async () => {
-    const upstream = startOnDynamicPort(createMockUpstream())
+    const upstream = await startOnDynamicPort(createMockUpstream())
     servers.push(upstream.server)
 
     const upstreamUrl = `http://127.0.0.1:${String(upstream.port)}/mcp`
     const forwarder = new StreamableHttpForwarder({ url: upstreamUrl })
     const proxyApp = createApp(makeConfig(upstreamUrl), forwarder)
-    const proxy = startOnDynamicPort(proxyApp)
+    const proxy = await startOnDynamicPort(proxyApp)
     servers.push(proxy.server)
 
     const res = await fetch(`http://127.0.0.1:${String(proxy.port)}/mcp`, {
@@ -196,13 +197,13 @@ describe('upstream forwarder e2e', () => {
   })
 
   it('passes Mcp-Session-Id from upstream back to the client', async () => {
-    const upstream = startOnDynamicPort(createMockUpstream())
+    const upstream = await startOnDynamicPort(createMockUpstream())
     servers.push(upstream.server)
 
     const upstreamUrl = `http://127.0.0.1:${String(upstream.port)}/mcp`
     const forwarder = new StreamableHttpForwarder({ url: upstreamUrl })
     const proxyApp = createApp(makeConfig(upstreamUrl), forwarder)
-    const proxy = startOnDynamicPort(proxyApp)
+    const proxy = await startOnDynamicPort(proxyApp)
     servers.push(proxy.server)
 
     const res = await fetch(`http://127.0.0.1:${String(proxy.port)}/mcp`, {
@@ -219,7 +220,7 @@ describe('upstream forwarder e2e', () => {
     // Point at a port where nothing is listening
     const forwarder = new StreamableHttpForwarder({ url: 'http://127.0.0.1:19999/mcp' })
     const proxyApp = createApp(makeConfig('http://127.0.0.1:19999/mcp'), forwarder)
-    const proxy = startOnDynamicPort(proxyApp)
+    const proxy = await startOnDynamicPort(proxyApp)
     servers.push(proxy.server)
 
     const res = await fetch(`http://127.0.0.1:${String(proxy.port)}/mcp`, {

--- a/packages/proxy/src/upstream/sse-forwarder.test.ts
+++ b/packages/proxy/src/upstream/sse-forwarder.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import type { AddressInfo } from 'node:net'
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
 import type { ServerType } from '@hono/node-server'
@@ -25,8 +24,10 @@ interface MockSseServer {
  * Create a mock MCP server that speaks SSE transport.
  * GET / returns SSE stream with endpoint event.
  * POST /messages accepts JSON-RPC and pushes response on the SSE stream.
+ * Bound to 127.0.0.1 so the kernel cannot hand it a port another process
+ * holds (issue #271); the port is known once the server is listening.
  */
-function createMockSseServer(postStatus: number = 202): MockSseServer {
+function createMockSseServer(postStatus: number = 202): Promise<MockSseServer> {
   const receivedBodies: unknown[] = []
   const receivedHeaders: Record<string, string>[] = []
   const receivedGetHeaders: Record<string, string>[] = []
@@ -75,10 +76,12 @@ function createMockSseServer(postStatus: number = 202): MockSseServer {
     return c.body(null, postStatus as 202 | 500)
   })
 
-  const server = serve({ fetch: app.fetch, port: 0 })
-  const port = (server.address() as AddressInfo).port
-
-  return { server, port, receivedBodies, receivedHeaders, receivedGetHeaders }
+  return new Promise((resolve, reject) => {
+    const server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) => {
+      resolve({ server, port: info.port, receivedBodies, receivedHeaders, receivedGetHeaders })
+    })
+    server.once('error', reject)
+  })
 }
 
 function closeServer(server: ServerType): Promise<void> {
@@ -120,7 +123,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('connects and learns POST URL from endpoint event', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -133,7 +136,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('forwards a request and receives response via SSE', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -149,7 +152,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('measures durationMs', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -162,7 +165,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('strips session fields and headers from the POST body', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -186,7 +189,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('sends only transportSessionId upstream as Mcp-Session-Id, never the resolved session', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -210,7 +213,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('strips caller-supplied mcp-method and mcp-name from the request POST', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -230,7 +233,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('strips caller-supplied mcp-method and mcp-name from the notification POST', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -247,7 +250,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('never sends a caller-supplied mcp-session-id header', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -264,7 +267,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('sends transportSessionId even when a caller mcp-session-id header is present', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -282,7 +285,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('re-stamps application/json over a caller-supplied content-type on the request POST', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -299,7 +302,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('re-stamps application/json over a caller-supplied content-type on the notification POST', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -315,7 +318,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('re-stamps application/json over a constructor static-header content-type', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
       headers: { 'content-type': 'text/plain' },
@@ -334,7 +337,7 @@ describe('SseUpstreamForwarder', () => {
   it('re-stamps application/json whatever the caller content-type key casing', async () => {
     // Mirrors the mixed-case pin above: the re-stamp runs after the merge
     // lower-cases names, so a cased key cannot dodge it.
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -351,7 +354,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('drops a caller-supplied content-length so the wire carries the computed truthful length', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     // The 1500ms pin is load-bearing: pre-fix, undici honors the caller's
     // content-length promise and the POST never transmits, so the run must
     // die as this forwarder's own named timeout rejection — not Vitest's
@@ -379,7 +382,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('re-stamps text/event-stream on the connect GET over a static accept without dropping other statics', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
       headers: { accept: 'application/json', authorization: 'Bearer s' },
@@ -395,7 +398,7 @@ describe('SseUpstreamForwarder', () => {
     // An Accept-cased static must not survive alongside the seed either:
     // Node fetch combines case-distinct keys into one comma-joined wire
     // value, so only a case-collapsing merge plus re-stamp owns the header.
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
       headers: { Accept: 'application/json' },
@@ -407,7 +410,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('drops a caller-supplied accept from the request POST, leaving the runtime default', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -426,7 +429,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('drops a constructor static accept from the request POST, asserting none at the fetch layer', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
       headers: { accept: 'application/xml' },
@@ -460,7 +463,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('drops a constructor static accept from the notification POST', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
       headers: { accept: 'application/xml' },
@@ -476,7 +479,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('passes legitimate caller and static headers through untouched', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
       headers: { 'x-static': 'from-config' },
@@ -497,7 +500,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('passes a caller-supplied mcp-protocol-version through', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -527,7 +530,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('close can be called cleanly after connect', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -541,7 +544,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('handles relative endpoint URLs', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     // The mock server sends `data: /messages` (relative URL)
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
@@ -554,7 +557,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('handles concurrent requests', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -573,7 +576,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('treats id: null as a request id (not a notification)', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -592,7 +595,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('rejects a request when upstream POST fails and cleans pending state', async () => {
-    mock = createMockSseServer(500)
+    mock = await createMockSseServer(500)
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -604,7 +607,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('translates request POST fetch failures into actionable unreachable guidance', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -631,7 +634,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('translates notification POST fetch failures into actionable unreachable guidance', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })
@@ -659,7 +662,7 @@ describe('SseUpstreamForwarder', () => {
   })
 
   it('rejects immediately when downstream signal is already aborted', async () => {
-    mock = createMockSseServer()
+    mock = await createMockSseServer()
     forwarder = new SseUpstreamForwarder({
       url: `http://127.0.0.1:${String(mock.port)}/`,
     })


### PR DESCRIPTION
## Description

The "ECONNRESET class" recorded on #271 is a port collision, not a load effect. Every in-process test fixture built on `serve({ fetch, port: 0 })` binds the IPv6 wildcard, and macOS hands such a bind a port another process already holds on `127.0.0.1`; connections to the fixture then reach that process, which answers with its own bytes (the `SyntaxError: Unexpected token 'B', "Blocked by"...` face) or resets the socket when it exits (the `fetch failed` / `read ECONNRESET` faces). The maintainer's box carries 64 to 79 `cursorsan` (Cursor sandbox) listeners on `127.0.0.1` in the ephemeral range, and one full-workspace run at `f3c646c` under load caught the class live: a fixture bound `:::56887`, the client got `read ECONNRESET`, the fixture closed with zero connections, and `lsof` showed `cursorsan` holding `127.0.0.1:56887`. The class reproduces deterministically by holding a window of `127.0.0.1` ports ahead of the kernel's counter in a foreign process and running one fixture-using file (8 of 10 sideband tests fail with either text).

The other recorded faces have their own mechanisms: the governance perf test's p95/p99 bounds measure the box (a healthy proxy in the loaded suite breaches them while a proxy with a 20 ms stall on every call passes them alone; the benchmark script's governed-overhead gate catches that stall); the stdio auto-restart test sleeps a fixed 500 ms that a loaded box outruns; the writer test bounds a 0.2 ms loop to 50 ms of wall time; four CLI tests poll a spawned proxy's health endpoint without racing its exit, so a child that dies after its listening line on a held port reads as a bare 8 s timeout; and the CLI tests that boot the binary two or three times ran at vitest's 5 s default.

Three commits, one per mechanism:

- `fix(test): bind the test fixtures to 127.0.0.1 and keep CLI ports out of the ephemeral range`: the shared `startOnDynamicPort` helper and its three local copies bind `127.0.0.1` (where the kernel skips every held port) and resolve the port from the listening callback, since a named bind is asynchronous; every call site is awaited (36 in tests, two in `scripts/benchmark.ts`); the CLI tests' spawned proxies pick ports from 20000 to 29999, below every OS's ephemeral range, through one helper; the dead `getPort` export goes.
- `fix(test): wait for the stdio restart instead of sleeping`: the crash-once child writes a second marker when it restarts and the test polls for it with `vi.waitFor` (20 ms, 8 s inside the 10 s budget); both markers are removed before `start()`, which closes a vacuous green (a stale marker from an earlier run under the same worker pid made the child skip the crash); the full end-to-end test's three fixed 100 ms sleeps before reading the approval queue become one `vi.waitFor` helper.
- `fix(test): drop the benchmark bounds the script gates and pin the writer's non-blocking push`: the governance test keeps its 1020 governed calls and the audit-count assertion, drops the two percentile bounds, is renamed to what it guards, and gets a 60 s describe budget; the writer test pins that `push` never writes synchronously (the store holds nothing after the loop and every record after one timer tick); the four poll-only health waits race the child's close event through one helper so the failure carries the exit code and stderr; the eight CLI tests that boot the binary two or three times get the file's 15 s budget.

No production source changes. `scripts/benchmark.ts` changes by two `await` only; its gate, counts, and report are untouched. No vitest config change, no `retry`, no concurrency setting, no dependency change, no test deleted.

Faces, before and after (full-workspace `pnpm test`, one-minute load at the start and end; the burners are `node -e 'for(;;){}'` processes):

| Tree | Runs | Burners | Loads | Faces |
| --- | --- | --- | --- | --- |
| `f3c646c` (planning) | 2 | 0 | 5 to 12 | none |
| `f3c646c` (planning) | 5 | 4 to 8 | 18 to 62 | perf bounds in 4 of 5; ECONNRESET in 2 of 5 (sse-forwarder, header-agreement) |
| `f3c646c` (RED) | 1 | 4 | 6.6 to 16.8 | perf bounds (p95 64.02 vs 50) plus the collision live (fixture on `:::56887`, `cursorsan` on `127.0.0.1:56887`) |
| the three doors, first cut | 6 | 4 (one at 8) | 12 to 28 | 4 green; the three-boot `init --sandbox` test at the 5 s default in the two runs above load 24.9 (folded) |
| the doors after review folds | 3 | 8 | 12 to 26 | the e2e-full 100 ms sleep once (folded); a two-boot `init` test at 5 s once (folded); the final tree green at load 13.8 to 25.6 |

Across all ten implementation runs with a passive socket diagnostic loaded: zero wildcard binds, zero client-side resets, zero perf-bound, stdio, or writer faces. The diagnostic (`NODE_OPTIONS="--import <diag>" pnpm test`, logging every listen, close, and reset with both endpoints) lives in the planning evidence folder, not in the tree; it is the reproduction aid for anything that recurs.

Captures that stay out of this PR:

- `helio start` attaches no `error` handler to its three `serve()` calls, so a `listen.port`, `dashboard.port`, or `sdk.port` already in use crashes the process through the crash-drain hook (`[helio] Uncaught exception: Error: listen EADDRINUSE ...`, exit 1) after the `Helio proxy listening` line has been printed. Production, its own issue; the CLI tests now report that shape verbatim instead of an 8 s health timeout.
- The box's foreign `127.0.0.1` listeners in the ephemeral range are the partner every recorded ECONNRESET face had; not a repo defect.
- The 42 CLI tests that boot the binary once stay at vitest's 5 s default by ruling (no file-level default); a recurrence at ordinary load gets its own issue.
- The four modern-upstream timing tests recorded once on #271 with no log stay on the ledger with the diagnostic as the reproduction aid.

Closes #271

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [ ] `docs/`
- [ ] `examples/`

`packages/proxy` means test files, the test helper, and two `await` in `scripts/benchmark.ts`; Root means `CHANGELOG.md`. No runtime source changes.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode: no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. The collision, on demand, on `main`: from `packages/proxy`, predict the kernel's next ephemeral port (`node -e "const n=require('net').createServer();n.listen(0,()=>{console.log(n.address().port+1);n.close()})"`), hold 256 `127.0.0.1` ports from it in a foreign Node process whose HTTP server answers `text/plain` bodies starting `Blocked by`, then `pnpm exec vitest run src/__tests__/integration-sideband.test.ts`: 8 of 10 fail with `SyntaxError: Unexpected token 'B', "Blocked by"... is not valid JSON`. Make the foreign server destroy the socket after each request instead: the same 8 fail with `TypeError: fetch failed`. On this branch both runs pass 10/10 and the fixture binds the first port past the held window.
2. The fix is the address, not the `await`: remove `hostname: '127.0.0.1'` from `startOnDynamicPort` in `helpers/test-utils.ts` and the two runs in step 1 fail again. Restore it.
3. The stdio wait is not a no-op: in `stdio-wrapper.test.ts` set the `vi.waitFor` timeout in the auto-restart test to `1` and it fails with `expected false to be true`; restore it, remove the `this.start()` call inside `onUnexpectedExit` in `stdio-wrapper.ts`, and it fails after 8 s with the same text. Restore both.
4. The benchmark gate does what the dropped bounds could not: add a 20 ms synchronous busy loop right after `startTime` in `GovernedForwarder.handleToolsCall`; `pnpm exec vitest run src/__tests__/integration-governance.test.ts` still passes (it no longer claims latency) and `pnpm --filter @gethelio/proxy benchmark` prints `Gate: Governed (overhead) p99 ... >= 5ms FAIL` and exits 1. Restore it.
5. The writer pin: replace `this.scheduleFlushSoon()` in `AuditWriter.push` with `this.flush()` and the pinned test fails with `expected 100 to be +0`; remove the call instead and it fails with `expected +0 to be 100`. Restore it.
6. The health wait races the exit: pin `randomChildPort()` to `21000`, hold `127.0.0.1:21001` in a scratch listener, and run `pnpm exec vitest run src/cli.test.ts -t 'shuts down cleanly on SIGINT with an active dashboard SSE stream'`: it fails at once with `helio start exited 1 before healthy` and `listen EADDRINUSE ... 127.0.0.1:21001` in the embedded stderr. Swap that site back to `waitForProxyHealth` and the same setup reproduces the old `Timed out waiting for proxy health endpoint` after 8 s. Restore both.
7. `pnpm test` from the root, and `pnpm --filter @gethelio/proxy benchmark` exits 0 with its `Gate:` line.

## Additional Context

The stdio wait follows the shape #360 introduced for the death-line tests (`vi.waitFor` on a test-owned observable, the assertion text unchanged so a never-arrives reads the same). The CLI port range 20000 to 29999 is below macOS's (49152 to 65535), Linux's (32768 to 60999), and Windows's ephemeral ranges; `dashboardPort = listenPort + 1` and `sdkPort = listenPort + 2` stay, and 29999 + 2 is still below 32768. A foreign fixed-port service in that range would fail loudly with `EADDRINUSE` in the child's stderr, which the CLI tests now report. Two full-workspace runs on this box at loads up to 26 under eight burner processes are green on the final tree; the one-minute loads the ledger recorded were 9 to 17.
