### PR TITLE
fix(cli): report a held port as a startup error before the listening line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ Maintainer notes:
 
 ### Fixed
 
+- **`helio start` now reports a port that is already in use as a
+  startup error, before its listening line.** The three servers were
+  started without waiting for their binds and nothing listened for a
+  bind error, so a held `listen.port`, `dashboard.port`, or `sdk.port`
+  printed `Helio proxy listening` and then crashed through the
+  uncaught-exception path 4 to 8 ms later. The start command now waits
+  for each server to be listening, prints one line naming the setting,
+  the host, and the port when a bind fails, closes what it had started
+  (a stdio upstream's child included), and exits 1; the listening lines
+  print only once the servers are bound. The exported `startServer` and
+  `startSidebandServer` return a promise that resolves once the server
+  is listening and rejects with the bind error.
 - **The test suite no longer fails on ports other processes hold.**
   Every in-process test fixture bound the IPv6 wildcard on port 0, and
   macOS hands such a bind a port another process already holds on

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,6 +126,8 @@ The final `Watching` line prints once the config watcher is armed — an edit to
 > On startup, Helio also sends a synthetic upstream `tools/list` to warm the tool-annotation cache before first traffic. If the prime attempt cannot complete quickly, Helio continues startup and retries in the background. During that window, annotation matching remains fail-closed using MCP defaults.
 >
 > If `dashboard.enabled: true`, startup requires bundled dashboard assets to be present. If assets are missing, Helio exits with an actionable error instead of silently serving API-only mode.
+>
+> If `listen.port`, `dashboard.port`, or `sdk.port` is already in use, Helio exits with one line naming the setting, the host, and the port instead of printing its listening line, for example `listen.port 3000 is already in use on 127.0.0.1 (EADDRINUSE). Stop the process holding it, or set listen.port in helio.yaml to a free port.` With `-c`, the line names the config file you passed.
 
 ## Step 4: Point Your MCP Client at Helio
 

--- a/packages/proxy/src/cli.test.ts
+++ b/packages/proxy/src/cli.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, vi } from 'vitest'
 import { execFile, spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { existsSync, writeFileSync, rmSync, mkdtempSync, readFileSync } from 'node:fs'
-import { createServer } from 'node:http'
+import { createServer, request as httpRequest } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -2798,6 +2798,250 @@ audit:
             })
           })
         }
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    // --- held ports (issue #375) ---
+
+    /** Hold a 127.0.0.1 port in a raw server the test keeps open. */
+    async function holdPort(): Promise<{ port: number; release: () => Promise<void> }> {
+      const holder = createServer()
+      await new Promise<void>((resolve, reject) => {
+        holder.once('error', reject)
+        holder.listen(0, '127.0.0.1', () => {
+          resolve()
+        })
+      })
+      const port = (holder.address() as AddressInfo).port
+      return {
+        port,
+        release: () =>
+          new Promise<void>((resolve) => {
+            holder.close(() => {
+              resolve()
+            })
+          }),
+      }
+    }
+
+    type PortSetting = 'listen.port' | 'sdk.port' | 'dashboard.port'
+
+    /**
+     * Write a start config with `heldPort` on the named setting and free
+     * ports on the other two. The SDK sideband and the dashboard are
+     * enabled only when they carry the held port.
+     */
+    function writeHeldPortConfig(dir: string, setting: PortSetting, heldPort: number): string {
+      const configPath = join(dir, 'helio.yaml')
+      const base = randomChildPort()
+      const listenPort = setting === 'listen.port' ? heldPort : base
+      const sdkPort = setting === 'sdk.port' ? heldPort : base + 1
+      const dashboardPort = setting === 'dashboard.port' ? heldPort : base + 2
+      writeFileSync(
+        configPath,
+        `
+version: "1"
+upstream:
+  url: "http://127.0.0.1:1/mcp"
+  transport: streamable-http
+listen:
+  port: ${String(listenPort)}
+  host: 127.0.0.1
+dashboard:
+  enabled: ${setting === 'dashboard.port' ? 'true' : 'false'}
+  port: ${String(dashboardPort)}
+  host: 127.0.0.1
+  api_secret: "test-secret-375"
+sdk:
+  enabled: ${setting === 'sdk.port' ? 'true' : 'false'}
+  port: ${String(sdkPort)}
+  host: 127.0.0.1
+audit:
+  path: "${join(dir, 'audit.db')}"
+`,
+      )
+      return configPath
+    }
+
+    it.each(['listen.port', 'sdk.port', 'dashboard.port'] as const)(
+      'start with %s already in use exits 1 with one line naming the setting and no listening line (issue #375)',
+      async (setting) => {
+        const held = await holdPort()
+        const dir = mkdtempSync(join(tmpdir(), 'helio-cli-held-port-'))
+        const configPath = writeHeldPortConfig(dir, setting, held.port)
+        try {
+          const result = await runCli(['start', '-c', configPath])
+          expect(result.code).toBe(1)
+          expect(result.stderr).toContain(
+            `${setting} ${String(held.port)} is already in use on 127.0.0.1 (EADDRINUSE). ` +
+              `Stop the process holding it, or set ${setting} in ${configPath} to a free port.`,
+          )
+          // A diagnosis, not a crash: no listening line for a server that is
+          // not bound, no crash-path wrapper, no stack.
+          expect(result.stderr).not.toContain('Helio proxy listening')
+          expect(result.stderr).not.toContain('SDK sideband listening')
+          expect(result.stderr).not.toContain('Dashboard API listening')
+          expect(result.stderr).not.toContain('Uncaught exception')
+          expect(result.stderr).not.toContain('Unhandled promise rejection')
+          expect(result.stderr).not.toMatch(/\n\s+at /)
+        } finally {
+          await held.release()
+          rmSync(dir, { recursive: true, force: true })
+        }
+      },
+      15_000,
+    )
+
+    it('start with a listen.host this machine cannot bind exits 1 with the bind error and the config path (issue #375)', async () => {
+      // 192.0.2.1 is TEST-NET-1 (RFC 5737): never a local address, so the
+      // bind fails with EADDRNOTAVAIL rather than EADDRINUSE.
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-bad-host-'))
+      const configPath = join(dir, 'helio.yaml')
+      const listenPort = randomChildPort()
+      writeFileSync(
+        configPath,
+        `
+version: "1"
+upstream:
+  url: "http://127.0.0.1:1/mcp"
+  transport: streamable-http
+listen:
+  port: ${String(listenPort)}
+  host: 192.0.2.1
+dashboard:
+  enabled: false
+audit:
+  path: "${join(dir, 'audit.db')}"
+`,
+      )
+      try {
+        const result = await runCli(['start', '-c', configPath])
+        expect(result.code).toBe(1)
+        expect(result.stderr).toContain(
+          `listen.port ${String(listenPort)} on 192.0.2.1 cannot be bound: listen EADDRNOTAVAIL`,
+        )
+        expect(result.stderr).toContain(`Check listen.host and listen.port in ${configPath}.`)
+        expect(result.stderr).not.toContain('Helio proxy listening')
+        expect(result.stderr).not.toContain('Uncaught exception')
+        expect(result.stderr).not.toMatch(/\n\s+at /)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    it('prints the listening line only once the listen server is bound (issue #375)', async () => {
+      const { dir, configPath } = writeStartConfig()
+      const original = readFileSync(configPath, 'utf-8')
+      writeFileSync(configPath, original.replace('enabled: true', 'enabled: false'))
+      const listenPort = Number(/port: (\d+)/.exec(original)?.[1])
+      const child = spawn('node', [CLI_PATH, 'start', '-c', configPath], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+      })
+      let stderr = ''
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            reject(new Error(`Timed out waiting for the listening line. stderr:\n${stderr}`))
+          }, 8_000)
+          timer.unref()
+          child.stderr.on('data', (chunk: Buffer) => {
+            stderr += chunk.toString('utf-8')
+            if (stderr.includes('Helio proxy listening')) {
+              clearTimeout(timer)
+              resolve()
+            }
+          })
+          child.once('close', (code) => {
+            clearTimeout(timer)
+            reject(
+              new Error(
+                `helio start exited ${String(code)} before the listening line. stderr:\n${stderr}`,
+              ),
+            )
+          })
+        })
+        // ONE fresh connection the instant the marker lands: no retry and no
+        // keep-alive socket. The line must mean the server is bound.
+        const status = await new Promise<number>((resolve, reject) => {
+          const req = httpRequest(
+            { host: '127.0.0.1', port: listenPort, path: '/healthz', agent: false },
+            (res) => {
+              res.resume()
+              resolve(res.statusCode ?? 0)
+            },
+          )
+          req.on('error', reject)
+          req.end()
+        })
+        expect(status).toBe(200)
+      } finally {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGTERM')
+        }
+        await waitForChildExit(child, 8_000)
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }, 15_000)
+
+    it('start with listen.port already in use closes the stdio upstream child it had spawned (issue #375)', async () => {
+      const held = await holdPort()
+      const dir = mkdtempSync(join(tmpdir(), 'helio-cli-held-stdio-'))
+      const configPath = join(dir, 'helio.yaml')
+      const pidPath = join(dir, 'child.pid')
+      // A child that ignores stdin EOF silently: error handlers on every
+      // stream, stdin resumed, an interval keeping it alive. Its first
+      // statement records its pid for the test.
+      const childSource =
+        `require('fs').writeFileSync('${pidPath}', String(process.pid)); ` +
+        `for (const s of [process.stdin, process.stdout, process.stderr]) s.on('error', () => {}); ` +
+        `process.stdin.resume(); setInterval(() => {}, 1000)`
+      writeFileSync(
+        configPath,
+        `
+version: "1"
+upstream:
+  transport: stdio
+  command: "node"
+  args:
+    - "-e"
+    - "${childSource}"
+listen:
+  port: ${String(held.port)}
+  host: 127.0.0.1
+dashboard:
+  enabled: false
+audit:
+  path: "${join(dir, 'audit.db')}"
+`,
+      )
+      let childPid: number | undefined
+      try {
+        const result = await runCli(['start', '-c', configPath])
+        expect(result.code).toBe(1)
+        const pid = Number(readFileSync(pidPath, 'utf-8'))
+        expect(Number.isInteger(pid)).toBe(true)
+        childPid = pid
+        // The abort closes the forwarder, which signals the child. A child
+        // that outlives the CLI's exit is the leak this pins.
+        await vi.waitFor(
+          () => {
+            expect(() => process.kill(pid, 0)).toThrow(/ESRCH/)
+          },
+          { timeout: 4_000, interval: 20 },
+        )
+        expect(result.stderr).toContain(
+          `listen.port ${String(held.port)} is already in use on 127.0.0.1 (EADDRINUSE).`,
+        )
+      } finally {
+        if (childPid !== undefined) {
+          try {
+            process.kill(childPid, 'SIGKILL')
+          } catch {
+            // Already gone.
+          }
+        }
+        await held.release()
         rmSync(dir, { recursive: true, force: true })
       }
     }, 15_000)

--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -273,6 +273,66 @@ async function connectUpstream(
   }
 }
 
+/**
+ * Close every connected door while aborting startup. Best effort: a close
+ * failure is logged and never thrown, so the abort's own diagnosis stays
+ * the last word.
+ */
+async function closeDoorsBestEffort(
+  doors: ReadonlyArray<{ close?: () => Promise<void> }>,
+): Promise<void> {
+  for (const door of doors) {
+    try {
+      await door.close?.()
+    } catch (closeErr) {
+      console.error(
+        `[helio] Ignoring a forwarder close failure while aborting startup: ${String(closeErr)}`,
+      )
+    }
+  }
+}
+
+/** The config paths of the three ports `helio start` binds. */
+type PortSetting = 'listen.port' | 'sdk.port' | 'dashboard.port'
+
+/**
+ * The operator line for a port that could not be bound (#375). Names the
+ * setting the port came from, the configured host, the port, and the code,
+ * and says which file to change: `configPath` is the file this boot loaded,
+ * printed as given. A held port gets its own sentence; every other bind
+ * error quotes Node's message.
+ */
+function listenFailureMessage(
+  setting: PortSetting,
+  host: string,
+  port: number,
+  configPath: string,
+  err: unknown,
+): string {
+  const bindError =
+    err instanceof Error
+      ? (err as Error & { code?: string; address?: string; port?: number })
+      : undefined
+  if (bindError?.code === 'EADDRINUSE') {
+    // A named host resolves to an address Node reports; say so when it is
+    // not the configured host verbatim (`localhost` resolved to `::1`).
+    const resolved =
+      bindError.address !== undefined && bindError.address !== host
+        ? ` at ${bindError.address}:${String(bindError.port ?? port)}`
+        : ''
+    return (
+      `${setting} ${String(port)} is already in use on ${host} (EADDRINUSE${resolved}). ` +
+      `Stop the process holding it, or set ${setting} in ${configPath} to a free port.`
+    )
+  }
+  const hostSetting = setting.replace(/\.port$/, '.host')
+  const detail = bindError ? bindError.message : String(err)
+  return (
+    `${setting} ${String(port)} on ${host} cannot be bound: ${detail}. ` +
+    `Check ${hostSetting} and ${setting} in ${configPath}.`
+  )
+}
+
 /** One governed upstream stack: the forwarder wrapped in governance plus
  *  its running annotation prime loop. */
 interface UpstreamStack {
@@ -383,15 +443,7 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
       const built = await connectUpstream(upstream, name)
       doors.push({ name, forwarder: built.forwarder, close: built.close })
     } catch (err) {
-      for (const door of doors) {
-        try {
-          await door.close?.()
-        } catch (closeErr) {
-          console.error(
-            `[helio] Ignoring a forwarder close failure while aborting startup: ${String(closeErr)}`,
-          )
-        }
-      }
+      await closeDoorsBestEffort(doors)
       throw err
     }
   }
@@ -561,7 +613,41 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
       },
     })
   }
-  const handle = startServer(app, config)
+  // Bind the servers in config order, first failure aborts (the connect
+  // loop's shape). A bind failure is a diagnosed boot failure, not a crash
+  // (#375): stop what the boot started (the prime loops, the servers bound
+  // so far in reverse, then the doors, a stdio child included), then throw
+  // the operator line. Every close is best effort; the diagnosis is the
+  // last word. The `StartupError` catch prints it and exits 1.
+  const boundHandles: ServerHandle[] = []
+  const listenOrAbort = async (
+    setting: PortSetting,
+    host: string,
+    port: number,
+    start: () => Promise<ServerHandle>,
+  ): Promise<ServerHandle> => {
+    try {
+      const bound = await start()
+      boundHandles.push(bound)
+      return bound
+    } catch (err) {
+      for (const stack of stacks) stack.annotationPrime.stop()
+      for (const bound of [...boundHandles].reverse()) {
+        try {
+          await bound.close()
+        } catch (closeErr) {
+          console.error(
+            `[helio] Ignoring a server close failure while aborting startup: ${String(closeErr)}`,
+          )
+        }
+      }
+      await closeDoorsBestEffort(doors)
+      throw new StartupError(listenFailureMessage(setting, host, port, configPath, err))
+    }
+  }
+  const handle = await listenOrAbort('listen.port', config.listen.host, config.listen.port, () =>
+    startServer(app, config),
+  )
 
   // Conditionally start the sideband server for SDK communication.
   //
@@ -623,7 +709,9 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
       adapterToken,
       governance: governanceService,
     })
-    sidebandHandle = startSidebandServer(sidebandApp, config.sdk.port, config.sdk.host)
+    sidebandHandle = await listenOrAbort('sdk.port', config.sdk.host, config.sdk.port, () =>
+      startSidebandServer(sidebandApp, config.sdk.port, config.sdk.host),
+    )
   }
 
   // Conditionally start the dashboard API server
@@ -657,10 +745,11 @@ async function startCommand(configPath: string, options: StartOptions): Promise<
       },
     )
     closeDashboardApp = dashboardApp.close
-    dashboardHandle = startSidebandServer(
-      dashboardApp.app,
-      config.dashboard.port,
+    dashboardHandle = await listenOrAbort(
+      'dashboard.port',
       config.dashboard.host,
+      config.dashboard.port,
+      () => startSidebandServer(dashboardApp.app, config.dashboard.port, config.dashboard.host),
     )
   }
 

--- a/packages/proxy/src/server.test.ts
+++ b/packages/proxy/src/server.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from 'vitest'
 import { Hono } from 'hono'
-import { createApp, startSidebandServer } from './server.js'
+import { createApp, startServer, startSidebandServer } from './server.js'
 import type { HelioConfig } from './config/index.js'
+import { createServer as createNetServer } from 'node:net'
+import type { AddressInfo } from 'node:net'
 import type { McpForwarder, McpRequest, McpResponse } from './mcp/types.js'
 
 // ---------------------------------------------------------------------------
@@ -398,7 +400,7 @@ describe('startSidebandServer', () => {
     })
 
     const port = 20_000 + Math.floor(Math.random() * 10_000)
-    const handle = startSidebandServer(app, port, '127.0.0.1')
+    const handle = await startSidebandServer(app, port, '127.0.0.1')
     const holdRequest = fetch(`http://127.0.0.1:${String(port)}/hold`)
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 50)
@@ -412,5 +414,81 @@ describe('startSidebandServer', () => {
     await holdRequest.catch(() => {
       // Expected: shutdown may close the request stream abruptly.
     })
+  })
+})
+
+describe('listen failures', () => {
+  /** Hold a 127.0.0.1 port in a raw server the test keeps open. */
+  async function holdPort(): Promise<{ port: number; release: () => Promise<void> }> {
+    const holder = createNetServer()
+    await new Promise<void>((resolve, reject) => {
+      holder.once('error', reject)
+      holder.listen(0, '127.0.0.1', () => {
+        resolve()
+      })
+    })
+    const port = (holder.address() as AddressInfo).port
+    return {
+      port,
+      release: () =>
+        new Promise<void>((resolve) => {
+          holder.close(() => {
+            resolve()
+          })
+        }),
+    }
+  }
+
+  /** A 127.0.0.1 port that was free a moment ago. */
+  async function freePort(): Promise<number> {
+    const held = await holdPort()
+    await held.release()
+    return held.port
+  }
+
+  it('startSidebandServer rejects with the bind error when the port is held', async () => {
+    const held = await holdPort()
+    try {
+      await expect(startSidebandServer(new Hono(), held.port, '127.0.0.1')).rejects.toMatchObject({
+        code: 'EADDRINUSE',
+        syscall: 'listen',
+        port: held.port,
+      })
+    } finally {
+      await held.release()
+    }
+  })
+
+  it('startServer rejects with the bind error when listen.port is held', async () => {
+    const held = await holdPort()
+    const config = {
+      ...minimalConfig,
+      listen: { ...minimalConfig.listen, port: held.port, host: '127.0.0.1' },
+    } as HelioConfig
+    try {
+      await expect(startServer(new Hono(), config)).rejects.toMatchObject({
+        code: 'EADDRINUSE',
+        syscall: 'listen',
+        port: held.port,
+      })
+    } finally {
+      await held.release()
+    }
+  })
+
+  it('resolves once the server is listening and drops the bind error listener', async () => {
+    const port = await freePort()
+    const handle = await startSidebandServer(new Hono(), port, '127.0.0.1')
+    // Resolves ON listening, not before: the address is known.
+    const address = handle.server.address() as AddressInfo | null
+    expect(address).not.toBeNull()
+    expect(address?.port).toBe(port)
+    try {
+      // The bind error listener is removed once listening, so a runtime
+      // 'error' after that keeps the process's crash path.
+      expect(handle.server.listenerCount('error')).toBe(0)
+    } finally {
+      await handle.close()
+    }
   })
 })

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -324,37 +324,48 @@ export function createMultiApp(
 }
 
 /**
+ * Bind `app` on `hostname:port`. Resolves with the handle once the server
+ * is listening; rejects with the bind error (`EADDRINUSE`, `EADDRNOTAVAIL`,
+ * `EACCES`, ...). `serve()` returns before the bind completes (a named host
+ * resolves asynchronously), so the error listener is attached right after
+ * it returns and removed once listening: a settled promise ignores a later
+ * `reject`, and leaving the listener would silently swallow the first
+ * runtime `error` event instead of letting it reach the process's crash
+ * path as it does today.
+ */
+function listen(app: Hono, port: number, hostname: string): Promise<ServerHandle> {
+  return new Promise((resolve, reject) => {
+    const server = serve({ fetch: app.fetch, port, hostname }, () => {
+      server.off('error', reject)
+      resolve(createServerHandle(server))
+    })
+    server.once('error', reject)
+  })
+}
+
+/**
  * Start the HTTP server on the configured host and port.
  *
  * @param app - The Hono app to serve.
  * @param config - The validated Helio configuration (uses `listen.port` and `listen.host`).
- * @returns A handle with the underlying server and a `close()` method for graceful shutdown.
+ * @returns A handle with the underlying server and a `close()` method for
+ *   graceful shutdown. Resolves once the server is listening; rejects with
+ *   the bind error.
  */
-export function startServer(app: Hono, config: HelioConfig): ServerHandle {
-  const server = serve({
-    fetch: app.fetch,
-    port: config.listen.port,
-    hostname: config.listen.host,
-  })
-
-  return createServerHandle(server)
+export function startServer(app: Hono, config: HelioConfig): Promise<ServerHandle> {
+  return listen(app, config.listen.port, config.listen.host)
 }
 
 /**
  * Start the sideband HTTP server for the SDK API.
  *
  * Binds to 127.0.0.1 by default (local-only) on the configured SDK port.
+ * Resolves once the server is listening; rejects with the bind error.
  */
 export function startSidebandServer(
   app: Hono,
   port: number,
   host: string = '127.0.0.1',
-): ServerHandle {
-  const server = serve({
-    fetch: app.fetch,
-    port,
-    hostname: host,
-  })
-
-  return createServerHandle(server)
+): Promise<ServerHandle> {
+  return listen(app, port, host)
 }


### PR DESCRIPTION
## Description

`startServer` and `startSidebandServer` returned from `serve()` before the bind completed, and nothing attached an `error` listener, so the `start` command printed `Helio proxy listening` synchronously after three unbound servers. When `listen.port`, `sdk.port`, or `dashboard.port` was already held, the bind error surfaced one tick later as an unhandled `error` event, `uncaughtException` logged it with its stack, ran the crash drain, and exited 1, 4 to 8 ms after the line (the SDK and dashboard cases printed a second false listening line for the held port itself, and a stdio upstream child that ignored stdin EOF outlived the exit). Nothing was served in that window: the kernel completed a client's handshake into the backlog and the exit reset it.

The two start functions now return a promise through one private `listen()` in `server.ts` that resolves the handle from the listening callback and rejects on the server's `error` event, removing the reject listener once listening so a runtime `error` after the bind keeps today's crash path. The `start` command awaits each bind in config order (listen, SDK, dashboard) and aborts on the first rejection: it stops the annotation prime loops, closes the servers bound so far in reverse, closes the doors (a stdio child included), and throws a `StartupError` naming the setting, the configured host, the port, the code, and the config file the boot loaded. The existing catch prints that line and exits 1. The listening lines now print only once every configured server is bound.

Before and after, the reproduction harness with a `127.0.0.1` holder on the configured port (stderr line numbers; `L1` and `L2` are the fixture's annotation-prime lines):

| Setting held | Before: listening line | Before: false second line | Before: uncaught line | Gap | Before: exit | After: operator line | After: listening line | After: exit |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `listen.port` | L3 | none | L14 `[helio] Uncaught exception: Error: listen EADDRINUSE` | 4.0 ms | 1 | L3 `listen.port 18100 is already in use on 127.0.0.1 (EADDRINUSE). Stop the process holding it, or set listen.port in <config> to a free port.` | none | 1 |
| `dashboard.port` | L3 | L8 `Dashboard API listening on http://127.0.0.1:18100` | L16 | 5.7 ms | 1 | L3 `dashboard.port 18100 is already in use ...` | none | 1 |
| `sdk.port` | L3 | L8 `SDK sideband listening on http://127.0.0.1:18100` | L19 | 5.7 ms | 1 | L3 `sdk.port 18100 is already in use ...` | none | 1 |

A healthy start now prints the listening line after the bind: one fresh connection the instant the line lands is answered 200 (on main it was refused 10 of 10, the line preceding the bind by 11 to 16 ms). A bind error other than a held port quotes Node's message: `listen.port 3000 on 192.0.2.1 cannot be bound: listen EADDRNOTAVAIL: address not available 192.0.2.1:3000. Check listen.host and listen.port in <config>.` A wildcard `listen.host` beside a loopback holder still binds without error and is not diagnosable from the bind, so the fix does not fire there.

One commit. Production changes are `server.ts` (the `listen()` helper and the two signatures) and `cli.ts` (the three awaited starts, the abort closure, the message builder, and the connect loop's door-close loop extracted into `closeDoorsBestEffort`). The process handlers, the crash drain, `registerShutdown`, `closeResources`, `startup-error.ts`, the config schema, and the transports are untouched. The exported `startServer` and `startSidebandServer` change return type to `Promise<ServerHandle>`; no documented consumer, example, or README uses them, and the changelog records it.

The issue's "Additional Context" names `startProxyServer`; no such function exists. The two functions are `startServer` and `startSidebandServer` in `server.ts`.

Captures that stay out of this PR:

- The crash-drain path closes no stdio upstream child on ANY crash exit: the hook flushes the audit writer only, so a child that ignores stdin EOF is reparented to pid 1 and lives on. This PR's abort closes the child for a bind failure; the crash path is out of scope here and gets its own issue.
- A failed start still creates the audit database file (and its WAL) before the binds and leaves it, empty. Pre-existing and harmless; the store is constructed before the apps are wired, and a failed start must never delete an operator's database.
- A `listen.host` that resolves to an address a foreign process does not hold binds without error: `0.0.0.0` or `::` beside a `127.0.0.1` holder, and `localhost` (which resolves to `::1` first on macOS) beside a `127.0.0.1` holder. Loopback v4 traffic then reaches the holder. Not diagnosable from the bind; the shipped default is `127.0.0.1`.

Closes #375

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / build / tooling

## Packages Affected

- [x] `packages/proxy`
- [ ] `packages/dashboard`
- [ ] `packages/python-sdk`
- [x] Root config / monorepo tooling
- [x] `docs/`
- [ ] `examples/`

Root means `CHANGELOG.md`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing style (ESLint + Prettier pass)
- [x] TypeScript strict mode: no `any` types or `@ts-ignore` without justification
- [x] I have added or updated tests for my changes
- [x] All CI checks pass (`pnpm secrets:scan`, `pnpm docs:check:ci`, `pnpm audit --audit-level=high`, `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @gethelio/proxy benchmark`)
- [x] I have updated documentation if this changes user-facing behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`)

## How to Test

1. Hold a port: `node -e "require('http').createServer().listen(18100, '127.0.0.1', () => setTimeout(() => {}, 60000))" &`. Write a config with `listen.port: 18100` and `listen.host: 127.0.0.1`, run `node packages/proxy/dist/cli.js start -c helio.yaml`: one line, `listen.port 18100 is already in use on 127.0.0.1 (EADDRINUSE). Stop the process holding it, or set listen.port in helio.yaml to a free port.`, exit 1, no `Helio proxy listening`, no `Uncaught exception`. Set `dashboard.port` or `sdk.port` to 18100 instead (with that feature enabled): the same shape naming that setting. On `main` every one of the three prints the listening line and then the uncaught exception.
2. Set `listen.host: 192.0.2.1`: `listen.port <port> on 192.0.2.1 cannot be bound: listen EADDRNOTAVAIL: ...` and the `Check listen.host and listen.port in helio.yaml.` clause, exit 1.
3. The listener lifecycle: remove `server.once('error', reject)` from `listen()` in `server.ts`; the two rejection tests in `server.test.ts` time out and, after `pnpm build`, the three held-port CLI tests see `Uncaught exception` again. Remove `server.off('error', reject)` instead: the `listenerCount('error')` test fails with `expected 1 to be +0`. Restore both.
4. The order pin: remove the `await` from the three `listenOrAbort` calls in `cli.ts`, `pnpm build`, and `prints the listening line only once the listen server is bound` fails with `connect ECONNREFUSED`. Restore.
5. The abort: remove `await closeDoorsBestEffort(doors)` from the abort closure, `pnpm build`, and `closes the stdio upstream child it had spawned` times out with the child alive. Remove the `StartupError` conversion (`throw err`) instead: the three held-port tests see `Unhandled promise rejection` and a stack. Restore both.
6. `pnpm test` from the root, and `pnpm --filter @gethelio/proxy benchmark` exits 0 with its `Gate:` line.

## Additional Context

The fix follows the shape #233 introduced for diagnosed startup failures (a `StartupError` the `start` action prints verbatim and exits 1 on) and the async listen helper the test suite adopted in #374. The first collision aborts the boot, the connect loop's shape; a second collision is reported by the second run. The operator line names the config file the boot loaded as given, so `helio start -c /etc/helio/prod.yaml` points at the right file. The `localhost` case prints the resolved address in the parenthetical, `(EADDRINUSE at ::1:3000)`, when it differs from the configured host.
